### PR TITLE
Configurations decoupling and optimization

### DIFF
--- a/.github/workflows/esp-idf.yml
+++ b/.github/workflows/esp-idf.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: matth-x/MicroOcppMongoose
+        ref: 642006f0629b715dce44a913a5c4b77f3f8953bb
         path: examples/ESP-IDF/components/MicroOcppMongoose
     - name: Checkout ArduinoJson
       uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(MOCPP_SRC_UNIT
     tests/SmartCharging.cpp
     tests/Api.cpp
     tests/Metering.cpp
+    tests/Configuration.cpp
 )
 
 add_executable(mo_unit_tests

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -136,6 +136,8 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
         return;
     }
 
+    MOCPP_DBG_DEBUG("initialize OCPP");
+
     filesystem = fs;
     MOCPP_DBG_DEBUG("filesystem %s", filesystem ? "loaded" : "deactivated");
 
@@ -172,9 +174,9 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
         new BootService(*context, filesystem)));
     model.setConnectorsCommon(std::unique_ptr<ConnectorsCommon>(
         new ConnectorsCommon(*context, MOCPP_NUMCONNECTORS, filesystem)));
-    std::vector<Connector> connectors;
+    std::vector<std::unique_ptr<Connector>> connectors;
     for (unsigned int connectorId = 0; connectorId < MOCPP_NUMCONNECTORS; connectorId++) {
-        connectors.push_back(Connector(*context, connectorId));
+        connectors.emplace_back(new Connector(*context, connectorId));
     }
     model.setConnectors(std::move(connectors));
     model.setHeartbeatService(std::unique_ptr<HeartbeatService>(
@@ -214,6 +216,8 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
         model.getFirmwareService()->setBuildNumber((*credsJson)["firmwareVersion"]);
     }
     credsJson.reset();
+
+    configuration_load();
 }
 
 void mocpp_deinitialize() {
@@ -242,6 +246,8 @@ void mocpp_deinitialize() {
     filesystem.reset();
 
     configuration_deinit();
+
+    MOCPP_DBG_DEBUG("deinitialized OCPP\n");
 }
 
 void mocpp_loop() {

--- a/src/MicroOcpp/Core/Configuration.cpp
+++ b/src/MicroOcpp/Core/Configuration.cpp
@@ -3,6 +3,7 @@
 // MIT License
 
 #include <MicroOcpp/Core/Configuration.h>
+#include <MicroOcpp/Core/ConfigurationContainerFlash.h>
 #include <MicroOcpp/Debug.h>
 
 #include <string.h>

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -6,7 +6,6 @@
 #define CONFIGURATION_H
 
 #include <MicroOcpp/Core/ConfigurationKeyValue.h>
-#include <MicroOcpp/Core/ConfigurationOptions.h>
 #include <MicroOcpp/Core/ConfigurationContainerFlash.h>
 #include <MicroOcpp/Core/FilesystemAdapter.h>
 
@@ -23,19 +22,16 @@
 
 namespace MicroOcpp {
 
+/*
+ * 
+ */
 template <class T>
-std::shared_ptr<Configuration<T>> declareConfiguration(const char *key, T defaultValue, const char *filename = CONFIGURATION_FN, bool remotePeerCanWrite = true, bool remotePeerCanRead = true, bool localClientCanWrite = true, bool rebootRequiredWhenChanged = false);
+std::shared_ptr<Configuration> declareConfiguration(const char *key, T defaultValue, const char *filename = CONFIGURATION_FN, bool readonly = false, bool rebootRequired = false, bool accessible = true);
 
 void addConfigurationContainer(std::shared_ptr<ConfigurationContainer> container);
-std::vector<std::shared_ptr<ConfigurationContainer>>::iterator getConfigurationContainersBegin();
-std::vector<std::shared_ptr<ConfigurationContainer>>::iterator getConfigurationContainersEnd();
 
-
-namespace Ocpp16 {
-
-    std::shared_ptr<AbstractConfiguration> getConfiguration(const char *key);
-    std::unique_ptr<std::vector<std::shared_ptr<AbstractConfiguration>>> getAllConfigurations();
-}
+Configuration *getConfigurationPublic(const char *key);
+std::vector<ConfigurationContainer*> getConfigurationContainersPublic();
 
 bool configuration_init(std::shared_ptr<FilesystemAdapter> filesytem);
 void configuration_deinit();

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -16,10 +16,6 @@
 #define CONFIGURATION_VOLATILE "/volatile"
 #define MOCPP_KEYVALUE_FN (MOCPP_FILENAME_PREFIX "client-state.jsn")
 
-#ifndef MOCPP_CONFIG_EXT_PREFIX
-#define MOCPP_CONFIG_EXT_PREFIX "Cst_"
-#endif
-
 namespace MicroOcpp {
 
 /*
@@ -38,6 +34,9 @@ std::vector<ConfigurationContainer*> getConfigurationContainersPublic();
 
 bool configuration_init(std::shared_ptr<FilesystemAdapter> filesytem);
 void configuration_deinit();
+
+bool configuration_load();
+bool configuration_load(const char *filename);
 
 bool configuration_save();
 

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -28,6 +28,9 @@ namespace MicroOcpp {
 template <class T>
 std::shared_ptr<Configuration> declareConfiguration(const char *key, T defaultValue, const char *filename = CONFIGURATION_FN, bool readonly = false, bool rebootRequired = false, bool accessible = true);
 
+std::function<bool(const char*)> *getConfigurationValidator(const char *key);
+void registerConfigurationValidator(const char *key, std::function<bool(const char*)> validator);
+
 void addConfigurationContainer(std::shared_ptr<ConfigurationContainer> container);
 
 Configuration *getConfigurationPublic(const char *key);

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -6,7 +6,7 @@
 #define CONFIGURATION_H
 
 #include <MicroOcpp/Core/ConfigurationKeyValue.h>
-#include <MicroOcpp/Core/ConfigurationContainerFlash.h>
+#include <MicroOcpp/Core/ConfigurationContainer.h>
 #include <MicroOcpp/Core/FilesystemAdapter.h>
 
 #include <memory>

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -35,8 +35,7 @@ std::vector<ConfigurationContainer*> getConfigurationContainersPublic();
 bool configuration_init(std::shared_ptr<FilesystemAdapter> filesytem);
 void configuration_deinit();
 
-bool configuration_load();
-bool configuration_load(const char *filename);
+bool configuration_load(const char *filename = nullptr);
 
 bool configuration_save();
 

--- a/src/MicroOcpp/Core/ConfigurationContainer.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainer.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<Configuration> ConfigurationPool::declareConfiguration(const cha
     }
 
     if (rebootRequired) {
-        res->setRequiresReboot();
+        res->setRebootRequired();
     }
 
     return res;

--- a/src/MicroOcpp/Core/ConfigurationContainer.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainer.cpp
@@ -35,7 +35,7 @@ public:
 
     void removeConfiguration(Configuration *config) override {
         for (auto entry = configurations.begin(); entry != configurations.end();) {
-            if (entry.get() == config) {
+            if (entry->get() == config) {
                 entry = configurations.erase(entry);
             } else {
                 entry++;

--- a/src/MicroOcpp/Core/ConfigurationContainer.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainer.cpp
@@ -4,71 +4,106 @@
 
 #include <MicroOcpp/Core/ConfigurationContainer.h>
 
+#include <MicroOcpp/Debug.h>
+
 namespace MicroOcpp {
 
-std::shared_ptr<AbstractConfiguration> ConfigurationContainer::getConfiguration(const char *key) {
-    for (std::vector<std::shared_ptr<AbstractConfiguration>>::iterator configuration = configurations.begin(); configuration != configurations.end(); configuration++) {
-        if (!strcmp(key, (*configuration)->getKey())) {
-            return *configuration;
+std::shared_ptr<Configuration> ConfigurationPool::getConfiguration_typesafe(const char *key, TConfig type) {
+    for (auto entry = configurations.begin(); entry != configurations.end();entry++) {
+        if ((*entry)->getKey() && !strcmp((*entry)->getKey(), key)) {
+            //found entry
+            if ((*entry)->getType() == type) {
+                return *entry;
+            } else {
+                MOCPP_DBG_ERR("conflicting types for %s - discard old config", key);
+                configurations.erase(entry);
+                break;
+            }
         }
     }
     return nullptr;
 }
 
-bool ConfigurationContainer::removeConfiguration(std::shared_ptr<AbstractConfiguration> configuration) {
+template<class T>
+std::shared_ptr<Configuration> ConfigurationPool::declareConfiguration(const char *key, T factoryDef, bool readonly = false, bool rebootRequired = false) {
     
-    auto config = configurations.begin();
-    auto config_rev = configurations_revision.begin();
-    while (config != configurations.end()) {
-        if ((*config) == configuration) {
-            configurations.erase(config);
-            if (config_rev != configurations_revision.end())
-                configurations_revision.erase(config_rev);
-            return true;
+    std::shared_ptr<Configuration> res = getConfiguration_typesafe(key, convertType<T>());
+
+    if (!res) {
+        //config doesn't exist yet
+        res = makeConfigInt(key, factoryDef);
+        if (!res) {
+            //allocation failure - OOM
+            MOCPP_DBG_ERR("OOM");
+            return nullptr;
         }
-        config++;
-        if (config_rev != configurations_revision.end())
-            config_rev++;
+        configurations.push_back(res);
     }
 
-    return false;
+    if (readonly) {
+        res->setReadOnly();
+    }
+
+    if (rebootRequired) {
+        res->setRequiresReboot();
+    }
+
+    return res;
 }
 
-void ConfigurationContainer::addConfiguration(std::shared_ptr<AbstractConfiguration> configuration) {
-    configurations.push_back(configuration);
+size_t ConfigurationPool::getConfigurationCount() const {
+        return configurations.size();
+    }
+
+Configuration *ConfigurationPool::getConfiguration(size_t i) const {
+    return configurations[i].get();
 }
 
-bool ConfigurationContainer::configurationsUpdated() {
-    bool updated = false;
-
-    auto config = configurations.begin();
-    auto config_rev = configurations_revision.begin();
-    while (config != configurations.end()) {
-        if (config_rev == configurations_revision.end()) {
-            //vectors are not the same length -> added configurations
-            updated = true;
-            break;
-        }
-
-        if ((*config)->getValueRevision() != *config_rev) {
-            updated = true;
-            break;
-        }
-
-        config++;
-        config_rev++;
-    }
-
-    if (updated) {
-        configurations_revision.erase(config_rev, configurations_revision.end());
-
-        while (config != configurations.end()) {
-            configurations_revision.push_back((*config)->getValueRevision());
-            config++;
+Configuration *ConfigurationPool::getConfiguration(const char *key) const {
+    for (auto& entry : configurations) {
+        if (!strcmp(entry->getKey(), key)) {
+            return entry.get();
         }
     }
+}
 
-    return updated;
+class ConfigurationContainerVolatile : public ConfigurationContainer {
+private:
+    ConfigurationPool container;
+public:
+    ConfigurationContainerVolatile(const char *filename, bool accessible) : ConfigurationContainer(filename, accessible) { }
+
+    bool load() override {return true;}
+
+    bool save() override {return true;}
+
+    std::shared_ptr<Configuration> declareConfigurationInt(const char *key, int factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        return container.declareConfiguration<int>(key, factoryDef, readonly, rebootRequired);
+    }
+
+    std::shared_ptr<Configuration> declareConfigurationBool(const char *key, bool factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        return container.declareConfiguration<bool>(key, factoryDef, readonly, rebootRequired);
+    }
+
+    std::shared_ptr<Configuration> declareConfigurationString(const char *key, const char*factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        return container.declareConfiguration<const char*>(key, factoryDef, readonly, rebootRequired);
+    }
+
+    size_t getConfigurationCount() override {
+        return container.getConfigurationCount();
+    }
+
+    Configuration *getConfiguration(size_t i) override {
+        return container.getConfiguration(i);
+    }
+
+    Configuration *getConfiguration(const char *key) override {
+        return container.getConfiguration(key);
+    }
+};
+
+std::unique_ptr<ConfigurationContainer> makeConfigurationContainerVolatile(const char *filename, bool accessible) {
+    return std::unique_ptr<ConfigurationContainer>(new ConfigurationContainerVolatile(filename, accessible));
 }
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/ConfigurationContainer.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainer.cpp
@@ -34,10 +34,13 @@ public:
     }
 
     void removeConfiguration(Configuration *config) override {
-        configurations.erase(std::remove_if(configurations.begin(), configurations.end(),
-            [config] (std::shared_ptr<Configuration>& entry) {
-                return entry.get() == config;
-            }), configurations.end());
+        for (auto entry = configurations.begin(); entry != configurations.end();) {
+            if (entry.get() == config) {
+                entry = configurations.erase(entry);
+            } else {
+                entry++;
+            }
+        }
     }
 
     size_t getConfigurationCount() override {

--- a/src/MicroOcpp/Core/ConfigurationContainer.h
+++ b/src/MicroOcpp/Core/ConfigurationContainer.h
@@ -34,7 +34,7 @@ public:
     virtual Configuration *getConfiguration(size_t i) = 0;
     virtual std::shared_ptr<Configuration> getConfiguration(const char *key) = 0;
 
-    virtual void loadStaticKey(Configuration& config, const char *key) { } //possible optimization: can replace internal key with passed key
+    virtual void loadStaticKey(Configuration& config, const char *key) { } //possible optimization: can replace internal key with passed static key
 };
 
 std::unique_ptr<ConfigurationContainer> makeConfigurationContainerVolatile(const char *filename, bool accessible);

--- a/src/MicroOcpp/Core/ConfigurationContainer.h
+++ b/src/MicroOcpp/Core/ConfigurationContainer.h
@@ -27,33 +27,14 @@ public:
     virtual bool load() = 0; //called at the end of mocpp_intialize, to load the configurations with the stored value
     virtual bool save() = 0;
 
-    virtual std::shared_ptr<Configuration> declareConfigurationInt(const char *key, int factoryDef, bool readonly = false, bool rebootRequired = false) = 0;
-    virtual std::shared_ptr<Configuration> declareConfigurationBool(const char *key, bool factoryDef, bool readonly = false, bool rebootRequired = false) = 0;
-    virtual std::shared_ptr<Configuration> declareConfigurationString(const char *key, const char *factoryDef, bool readonly = false, bool rebootRequired = false) = 0;
-    
+    virtual std::shared_ptr<Configuration> createConfiguration(TConfig type, const char *key) = 0;
+    virtual void removeConfiguration(Configuration *config) = 0;
+
     virtual size_t getConfigurationCount() = 0;
     virtual Configuration *getConfiguration(size_t i) = 0;
-    virtual Configuration *getConfiguration(const char *key) = 0;
-};
+    virtual std::shared_ptr<Configuration> getConfiguration(const char *key) = 0;
 
-//Utils class only used for internal ConfigurationContainer implementations
-class ConfigurationPool {
-private:
-    std::vector<std::shared_ptr<Configuration>> configurations;
-
-    std::shared_ptr<Configuration> getConfiguration_typesafe(const char *key, TConfig type);
-
-public:
-    template<class T>
-    std::shared_ptr<Configuration> declareConfiguration(const char *key, T factoryDef, bool readonly = false, bool rebootRequired = false);
-    
-    std::vector<std::shared_ptr<Configuration>>& getConfigurations();
-    
-    size_t getConfigurationCount() const;
-
-    Configuration *getConfiguration(size_t i) const;
-
-    Configuration *getConfiguration(const char *key) const;
+    virtual void loadStaticKey(Configuration& config, const char *key) { } //possible optimization: can replace internal key with passed key
 };
 
 std::unique_ptr<ConfigurationContainer> makeConfigurationContainerVolatile(const char *filename, bool accessible);

--- a/src/MicroOcpp/Core/ConfigurationContainer.h
+++ b/src/MicroOcpp/Core/ConfigurationContainer.h
@@ -19,6 +19,8 @@ private:
 public:
     ConfigurationContainer(const char *filename, bool accessible) : filename(filename), accessible(accessible) { }
 
+    virtual ~ConfigurationContainer();
+
     const char *getFilename() {return filename;}
     bool isAccessible() {return accessible;}
 
@@ -53,10 +55,6 @@ public:
 
     Configuration *getConfiguration(const char *key) const;
 };
-
-template<> std::shared_ptr<Configuration> ConfigurationPool::declareConfiguration<int>(const char *key, int factoryDef, bool readonly, bool rebootRequired);
-template<> std::shared_ptr<Configuration> ConfigurationPool::declareConfiguration<bool>(const char *key, bool factoryDef, bool readonly, bool rebootRequired);
-template<> std::shared_ptr<Configuration> ConfigurationPool::declareConfiguration<const char*>(const char *key, const char *factoryDef, bool readonly, bool rebootRequired);
 
 std::unique_ptr<ConfigurationContainer> makeConfigurationContainerVolatile(const char *filename, bool accessible);
 

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
@@ -279,14 +279,10 @@ public:
     }
 
     void removeConfiguration(Configuration *config) override {
+        clearKeyPool(config->getKey());
         configurations.erase(std::remove_if(configurations.begin(), configurations.end(),
-            [this, config] (std::shared_ptr<Configuration>& entry) {
-                bool match = entry.get() == config;
-                if (match && config->getKey()) {
-                    std::string key_cpy = config->getKey();
-                    this->clearKeyPool(key_cpy.c_str());
-                }
-                return match;
+            [config] (std::shared_ptr<Configuration>& entry) {
+                return entry.get() == config;
             }), configurations.end());
     }
 

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
@@ -6,146 +6,291 @@
 #include <MicroOcpp/Core/FilesystemUtils.h>
 #include <MicroOcpp/Debug.h>
 
-#include <algorithm>
-
 #define MAX_CONFIGURATIONS 50
 
 namespace MicroOcpp {
 
-bool ConfigurationContainerFlash::load() {
+class ConfigurationContainerFlash : public ConfigurationContainer {
+private:
+    ConfigurationPool container;
+    std::shared_ptr<FilesystemAdapter> filesystem;
+    uint16_t revisionSum = 0;
 
-    if (!filesystem) {
-        return false;
-    }
-
-    if (configurations.size() > 0) {
-        MOCPP_DBG_ERR("Error: declared configurations before calling container->load(). " \
-                    "All previously declared values won't be written back");
-        (void)0;
-    }
-
-    size_t file_size = 0;
-    if (filesystem->stat(getFilename(), &file_size) != 0 // file does not exist
-            || file_size == 0) {                         // file exists, but empty
-        MOCPP_DBG_DEBUG("Populate FS: create configuration file");
-        return save();
-    }
-
-    auto doc = FilesystemUtils::loadJson(filesystem, getFilename());
-    if (!doc) {
-        MOCPP_DBG_ERR("failed to load %s", getFilename());
-        return false;
-    }
-
-    JsonObject root = doc->as<JsonObject>();
-
-    JsonObject configHeader = root["head"];
-
-    if (strcmp(configHeader["content-type"] | "Invalid", "ocpp_config_file") &&
-            strcmp(configHeader["content-type"] | "Invalid", "ao_configuration_file")) { //backwards-compatibility
-        MOCPP_DBG_ERR("Unable to initialize: unrecognized configuration file format");
-        return false;
-    }
-
-    if (strcmp(configHeader["version"] | "Invalid", "2.0") &&
-            strcmp(configHeader["version"] | "Invalid", "1.1")) { //backwards-compatibility
-        MOCPP_DBG_ERR("Unable to initialize: unsupported version");
-        return false;
-    }
+    std::vector<std::string> keyPool;
     
-    JsonArray configurationsArray = root["configurations"];
-    if (configurationsArray.size() > MAX_CONFIGURATIONS) {
-        MOCPP_DBG_ERR("Unable to initialize: configurations_len is too big (=%zu)", configurationsArray.size());
-        return false;
+    void clearKeyPool(const char *key) {
+        keyPool.erase(std::remove_if(keyPool.begin(), keyPool.end(), 
+            [key] (std::string& k) {
+                return !k.compare(key);
+            }));
     }
 
-    for (JsonObject config : configurationsArray) {
-        const char *key = config["key"] | "";
-        if (!*key || !config.containsKey("value")) {
-            MOCPP_DBG_ERR("corrupt config");
-            continue;
+    bool configurationsUpdated() {
+        auto revisionSum_old = revisionSum;
+
+        revisionSum = 0;
+        auto& configurations = container.getConfigurations();
+        for (size_t i = 0; i < configurations.size(); i++) {
+            revisionSum += configurations[i]->getValueRevision();
         }
 
-        const char *type = config["type"] | "Undefined";
+        return revisionSum == revisionSum_old;
+    }
+public:
+    ConfigurationContainerFlash(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename, bool accessible) :
+            ConfigurationContainer(filename, accessible), filesystem(filesystem) { }
 
-        std::shared_ptr<AbstractConfiguration> configuration = nullptr;
+    ~ConfigurationContainerFlash() = default;
 
-        if (!strcmp(type, SerializedType<int>::get()) && config["value"].is<int>()){
-            configuration = std::make_shared<Configuration<int>>(key, config["value"].as<int>());
-        } else if (!strcmp(type, SerializedType<float>::get()) && config["value"].is<float>()){
-            configuration = std::make_shared<Configuration<float>>(key, config["value"].as<float>());
-        } else if (!strcmp(type, SerializedType<bool>::get()) && config["value"].is<bool>()){
-            configuration = std::make_shared<Configuration<bool>>(key, config["value"].as<bool>());
-        } else if (!strcmp(type, SerializedType<const char *>::get()) && config["value"].is<const char*>()){
-            configuration = std::make_shared<Configuration<const char *>>(key, config["value"].as<const char*>());
-        } else {
-            MOCPP_DBG_ERR("corrupt config");
-            continue;
+    bool load() override {
+
+        if (!filesystem) {
+            return false;
         }
 
-        if (configuration) {
-            configurations.push_back(configuration);
-        } else {
-            MOCPP_DBG_ERR("Initialization fault: could not read key-value pair %s of type %s", config["key"].as<const char *>(), config["type"].as<const char *>());
+        auto& configurations = container.getConfigurations();
+
+        size_t file_size = 0;
+        if (filesystem->stat(getFilename(), &file_size) != 0 // file does not exist
+                || file_size == 0) {                         // file exists, but empty
+            MOCPP_DBG_DEBUG("Populate FS: create configuration file");
+            return save();
         }
+
+        auto doc = FilesystemUtils::loadJson(filesystem, getFilename());
+        if (!doc) {
+            MOCPP_DBG_ERR("failed to load %s", getFilename());
+            return false;
+        }
+
+        JsonObject root = doc->as<JsonObject>();
+
+        JsonObject configHeader = root["head"];
+
+        if (strcmp(configHeader["content-type"] | "Invalid", "ocpp_config_file") &&
+                strcmp(configHeader["content-type"] | "Invalid", "ao_configuration_file")) { //backwards-compatibility
+            MOCPP_DBG_ERR("Unable to initialize: unrecognized configuration file format");
+            return false;
+        }
+
+        if (strcmp(configHeader["version"] | "Invalid", "2.0") &&
+                strcmp(configHeader["version"] | "Invalid", "1.1")) { //backwards-compatibility
+            MOCPP_DBG_ERR("Unable to initialize: unsupported version");
+            return false;
+        }
+        
+        JsonArray configurationsArray = root["configurations"];
+        if (configurationsArray.size() > MAX_CONFIGURATIONS) {
+            MOCPP_DBG_ERR("Unable to initialize: configurations_len is too big (=%zu)", configurationsArray.size());
+            return false;
+        }
+
+        for (JsonObject stored : configurationsArray) {
+            TConfig type;
+            if (!deserializeTConfig(stored["type"] | "_Undefined", type)) {
+                MOCPP_DBG_ERR("corrupt config");
+                continue;
+            }
+
+            const char *key = stored["key"] | "";
+            if (!*key) {
+                MOCPP_DBG_ERR("corrupt config");
+                continue;
+            }
+
+            if (!stored.containsKey("value")) {
+                MOCPP_DBG_ERR("corrupt config");
+                continue;
+            }
+            
+            std::string key_pooled;
+
+            Configuration *config = container.getConfiguration(key);
+            if (!config || config->getType() != type) {
+                key_pooled = key;
+                config = nullptr;
+            }
+
+            switch (type) {
+                case TConfig::Int: {
+                    if (!stored["value"].is<int>()) {
+                        MOCPP_DBG_ERR("corrupt config");
+                        continue;
+                    }
+                    int value = stored["value"] | 0;
+                    if (config) {
+                        //config already exists
+                        config->setInt(value);
+                    } else {
+                        //create new config
+                        config = container.declareConfiguration<int>(key_pooled.c_str(), value).get();
+                    }
+                    break;
+                }
+                case (TConfig::Bool):
+                    if (!stored["value"].is<bool>()) {
+                        MOCPP_DBG_ERR("corrupt config");
+                        continue;
+                    }
+                    bool value = stored["value"] | false;
+                    if (config) {
+                        //config already exists
+                        config->setBool(value);
+                    } else {
+                        //create new config
+                        config = container.declareConfiguration<bool>(key_pooled.c_str(), value).get();
+                    }
+                    break;
+                case (TConfig::String):
+                    if (!stored["value"].is<const char*>()) {
+                        MOCPP_DBG_ERR("corrupt config");
+                        continue;
+                    }
+                    const char *value = stored["value"] | "";
+                    if (config) {
+                        //config already exists
+                        config->setBool(value);
+                    } else {
+                        //create new config
+                        config = container.declareConfiguration<bool>(key_pooled.c_str(), value).get();
+                    }
+                    break;
+            }
+
+            if (config) {
+                //success
+
+                if (!key_pooled.empty()) {
+                    //allocated key, need to store
+                    keyPool.push_back(std::string(key));
+                }
+            } else {
+                MOCPP_DBG_ERR("OOM: %s", key);
+                (void)0;
+            }
+        }
+
+        configurationsUpdated();
+
+        MOCPP_DBG_DEBUG("Initialization finished");
+        return true;
     }
 
-    configurationsUpdated();
+    bool save() override {
 
-    MOCPP_DBG_DEBUG("Initialization finished");
-    return true;
-}
+        if (!filesystem) {
+            return false;
+        }
 
-bool ConfigurationContainerFlash::save() {
+        if (!configurationsUpdated()) {
+            return true; //nothing to be done
+        }
 
-    if (!filesystem) {
-        return false;
-    }
+        auto& configurations = container.getConfigurations();
 
-    if (!configurationsUpdated()) {
-        return true; //nothing to be done
-    }
+        size_t jsonCapacity = 2 * JSON_OBJECT_SIZE(2); //head + configurations + head payload
+        jsonCapacity += JSON_ARRAY_SIZE(configurations.size()); //configurations array
+        jsonCapacity += configurations.size() * JSON_OBJECT_SIZE(3); //config entries in array
 
-    size_t jsonCapacity = 2 * JSON_OBJECT_SIZE(2); //head + configurations + head payload
+        if (jsonCapacity > MOCPP_MAX_JSON_CAPACITY) {
+            MOCPP_DBG_ERR("configs JSON exceeds maximum capacity (%s, %zu entries). Crop configs file (by FCFS)", getFilename(), configurations.size());
+            jsonCapacity = MOCPP_MAX_JSON_CAPACITY;
+        }
 
-    std::vector<std::unique_ptr<DynamicJsonDocument>> entries;
+        DynamicJsonDocument doc {jsonCapacity};
+        JsonObject head = doc.createNestedObject("head");
+        head["content-type"] = "ocpp_config_file";
+        head["version"] = "2.0";
 
-    for (auto config = configurations.begin(); config != configurations.end(); config++) {
-        auto entry = (*config)->toJsonStorageEntry();
-        if (entry) {
-            size_t capacity = entry->memoryUsage(); //entry payload size
+        JsonArray configurationsArray = doc.createNestedArray("configurations");
 
-            if (jsonCapacity + capacity + JSON_ARRAY_SIZE(entries.size() + 1)  > MOCPP_MAX_JSON_CAPACITY) {
-                MOCPP_DBG_ERR("configs JSON exceeds maximum capacity (%s, %zu entries). Crop configs file (by FCFS)", getFilename(), entries.size());
+        size_t trackCapacity = 0;
+
+        for (size_t i = 0; i < configurations.size(); i++) {
+            auto& config = *configurations[i];
+            if (!config.getKey()) {
+                MOCPP_DBG_ERR("corrupt config");
+                continue;
+            }
+
+            size_t entryCapacity = JSON_OBJECT_SIZE(3) + (JSON_ARRAY_SIZE(2) - JSON_ARRAY_SIZE(1));
+            if (trackCapacity + entryCapacity > MOCPP_MAX_JSON_CAPACITY) {
                 break;
             }
 
-            entries.push_back(std::move(entry));
-            jsonCapacity += capacity;
+            trackCapacity += entryCapacity;
+
+            auto stored = configurationsArray.createNestedObject();
+
+            stored["type"] = serializeTConfig(config.getType());
+            stored["key"] = config.getKey();
+            
+            switch (config.getType()) {
+                case TConfig::Int:
+                    stored["value"] = config.getInt();
+                    break;
+                case TConfig::Bool:
+                    stored["value"] = config.getBool();
+                    break;
+                case TConfig::String:
+                    if (!config.getString()) {
+                        MOCPP_DBG_ERR("corrupt config");
+                        configurationsArray.remove(configurationsArray.size());
+                        break;
+                    }
+                    stored["value"] = config.getString();
+                    break;
+            }
         }
+
+        bool success = FilesystemUtils::storeJson(filesystem, getFilename(), doc);
+
+        if (success) {
+            MOCPP_DBG_DEBUG("Saving configurations finished");
+        } else {
+            MOCPP_DBG_ERR("could not save configs file: %s", getFilename());
+        }
+
+        return success;
     }
 
-    jsonCapacity += JSON_ARRAY_SIZE(entries.size());
-
-    DynamicJsonDocument doc {jsonCapacity};
-    JsonObject head = doc.createNestedObject("head");
-    head["content-type"] = "ocpp_config_file";
-    head["version"] = "2.0";
-
-    JsonArray configurationsArray = doc.createNestedArray("configurations");
-    for (auto entry = entries.begin(); entry != entries.end(); entry++) {
-        configurationsArray.add((*entry)->as<JsonObject>());
+    std::shared_ptr<Configuration> declareConfigurationInt(const char *key, int factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        auto res = container.declareConfiguration<int>(key, factoryDef, readonly, rebootRequired);
+        if (res) res->setKey(key);
+        clearKeyPool(key);
+        return res;
     }
 
-    bool success = FilesystemUtils::storeJson(filesystem, getFilename(), doc);
-
-    if (success) {
-        MOCPP_DBG_DEBUG("Saving configurations finished");
-    } else {
-        MOCPP_DBG_ERR("could not save configs file: %s", getFilename());
+    std::shared_ptr<Configuration> declareConfigurationBool(const char *key, bool factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        auto res = container.declareConfiguration<bool>(key, factoryDef, readonly, rebootRequired);
+        if (res) res->setKey(key);
+        clearKeyPool(key);
+        return res;
     }
 
-    return success;
+    std::shared_ptr<Configuration> declareConfigurationString(const char *key, const char*factoryDef, bool readonly = false, bool rebootRequired = false) override {
+        auto res = container.declareConfiguration<const char*>(key, factoryDef, readonly, rebootRequired);
+        if (res) res->setKey(key);
+        clearKeyPool(key);
+        return res;
+    }
+
+    size_t getConfigurationCount() override {
+        return container.getConfigurationCount();
+    }
+
+    Configuration *getConfiguration(size_t i) override {
+        return container.getConfiguration(i);
+    }
+
+    Configuration *getConfiguration(const char *key) override {
+        return container.getConfiguration(key);
+    }
+
+};
+
+std::unique_ptr<ConfigurationContainer> makeConfigurationContainerFlash(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename, bool accessible) {
+    return std::unique_ptr<ConfigurationContainer>(new ConfigurationContainerFlash(filesystem, filename, accessible));
 }
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
@@ -279,11 +279,14 @@ public:
     }
 
     void removeConfiguration(Configuration *config) override {
-        clearKeyPool(config->getKey());
+        const char *key = config->getKey();
         configurations.erase(std::remove_if(configurations.begin(), configurations.end(),
             [config] (std::shared_ptr<Configuration>& entry) {
                 return entry.get() == config;
             }), configurations.end());
+        if (key) {
+            clearKeyPool(key);
+        }
     }
 
     size_t getConfigurationCount() override {

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.h
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.h
@@ -10,19 +10,7 @@
 
 namespace MicroOcpp {
 
-class ConfigurationContainerFlash : public ConfigurationContainer {
-    std::shared_ptr<FilesystemAdapter> filesystem;
-public:
-    ConfigurationContainerFlash(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename) :
-            ConfigurationContainer(filename), filesystem(filesystem) { }
-
-    ~ConfigurationContainerFlash() = default;
-
-    bool load();
-
-    bool save();
-
-};
+std::unique_ptr<ConfigurationContainer> makeConfigurationContainerFlash(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename, bool accessible);
 
 } //end namespace MicroOcpp
 

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
@@ -78,11 +78,11 @@ revision_t Configuration::getValueRevision() {
     return value_revision;
 }
 
-void Configuration::setRequiresReboot() {
+void Configuration::setRebootRequired() {
     rebootRequired = true;
 }
 
-bool Configuration::getRequiresReboot() {
+bool Configuration::isRebootRequired() {
     return rebootRequired;
 }
 
@@ -90,7 +90,7 @@ void Configuration::setReadOnly() {
     readOnly = true;
 }
 
-bool Configuration::getReadOnly() {
+bool Configuration::isReadOnly() {
     return readOnly;
 }
 
@@ -320,7 +320,7 @@ bool serializeConfigOcpp(Configuration& config, DynamicJsonDocument& out) {
     out = DynamicJsonDocument(JSON_OBJECT_SIZE(3) + vcapacity);
 
     out["key"] = config.getKey();
-    out["readonly"] = config.getReadOnly();
+    out["readonly"] = config.isReadOnly();
     if (vcapacity > 0) {
         //value has capacity, copy string
         out["value"] = (char*) v;

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
@@ -228,33 +228,24 @@ public:
     }
 };
 
-template<>
-std::unique_ptr<Configuration> makeConfig<int>(const char *key, int val) {
-    auto res = std::unique_ptr<Configuration>(new ConfigInt());
-    if (res) {
-        res->setKey(key);
-        res->setInt(val);
+std::unique_ptr<Configuration> makeConfiguration(TConfig type, const char *key) {
+    std::unique_ptr<Configuration> res;
+    switch (type) {
+        case TConfig::Int:
+            res.reset(new ConfigInt());
+            break;
+        case TConfig::Bool:
+            res.reset(new ConfigBool());
+            break;
+        case TConfig::String:
+            res.reset(new ConfigString());
+            break;
     }
-    return res;
-};
-
-template<>
-std::unique_ptr<Configuration> makeConfig<bool>(const char *key, bool val) {
-    auto res = std::unique_ptr<Configuration>(new ConfigBool());
-    if (res) {
-        res->setKey(key);
-        res->setBool(val);
+    if (!res) {
+        MOCPP_DBG_ERR("OOM");
+        return nullptr;
     }
-    return res;
-};
-
-template<>
-std::unique_ptr<Configuration> makeConfig<const char*>(const char *key, const char *val) {
-    auto res = std::unique_ptr<Configuration>(new ConfigString());
-    if (res) {
-        res->setKey(key);
-        res->setString(val);
-    }
+    res->setKey(key);
     return res;
 };
 

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
@@ -10,7 +10,11 @@
 #include <ArduinoJson.h>
 
 #define KEY_MAXLEN 60
-#define STRING_VAL_MAXLEN 2000 //allow TLS certificates in ...
+#define STRING_VAL_MAXLEN 512
+
+#ifndef MOCPP_CONFIG_TYPECHECK
+#define MOCPP_CONFIG_TYPECHECK 1 //enable this for debugging
+#endif
 
 namespace MicroOcpp {
 
@@ -27,233 +31,416 @@ int toCStringValue(char *buf, size_t length, bool value) {
     return snprintf(buf, length, "%s", value ? "true" : "false");
 }
 
-AbstractConfiguration::AbstractConfiguration(const char *key) {
-    if (!key || !*key) {
-        MOCPP_DBG_ERR("invalid argument");
-        return;
-    }
 
-    this->key = key;
-}
 
-AbstractConfiguration::~AbstractConfiguration() {
-
-}
-
-const char *AbstractConfiguration::getKey() {
-    return key.c_str();
-}
-
-size_t AbstractConfiguration::getStorageHeaderJsonCapacity() {
-    return key.length() + 1;
-}
-
-void AbstractConfiguration::storeStorageHeader(JsonObject &keyValuePair) {
-    keyValuePair["key"] = key;
-}
-
-size_t AbstractConfiguration::getOcppMsgHeaderJsonCapacity() {
-    return key.size() + 1;
-}
-
-void AbstractConfiguration::storeOcppMsgHeader(JsonObject &keyValuePair) {
-    keyValuePair["key"] = key;
-    if (remotePeerCanWrite) {
-        keyValuePair["readonly"] = false;
-    } else {
-        keyValuePair["readonly"] = true;
-    }
-}
-
-bool AbstractConfiguration::isValid() {
-    return initializedValue && !key.empty();
-}
-
-void AbstractConfiguration::requireRebootWhenChanged() {
-    rebootRequiredWhenChanged = true;
-}
-
-bool AbstractConfiguration::requiresRebootWhenChanged() {
-    return rebootRequiredWhenChanged;
-}
-
-uint16_t AbstractConfiguration::getValueRevision() {
+uint16_t Configuration::getValueRevision() {
     return value_revision;
 }
 
-template<class T>
-Configuration<T>::Configuration(const char *key, T value) : AbstractConfiguration(key) {
-    this->operator=(value);
+void Configuration::setRequiresReboot() {
+    rebootRequired = true;
 }
 
-template <class T>
-const T &Configuration<T>::operator=(const T & newVal) {
-
-    if (permissionLocalClientCanWrite() || !initializedValue) {
-        if (!initializedValue) {
-            const size_t VALUE_MAXSIZE = 50;
-            char value_str [VALUE_MAXSIZE] = {'\0'};
-            toCStringValue(value_str, VALUE_MAXSIZE, newVal);
-            MOCPP_DBG_DEBUG("add config: key = %s, value = %s", getKey(), value_str);
-        }
-        if (initializedValue == true && value != newVal) {
-            value_revision++;
-        }
-        value = newVal;
-        initializedValue = true;
-    } else {
-        MOCPP_DBG_ERR("Tried to override read-only configuration: %s", getKey());
-    }
-    return newVal;
+bool Configuration::getRequiresReboot() {
+    return rebootRequired;
 }
 
-template <class T>
-Configuration<T>::operator T() {
-    return value;
+void Configuration::revokeWritePermission() {
+    writePermission = false;
 }
 
-template<class T>
-bool Configuration<T>::isValid() {
-    return AbstractConfiguration::isValid();
+bool Configuration::getWritePermission() {
+    return writePermission;
 }
 
-template<class T>
-size_t Configuration<T>::getValueJsonCapacity() {
-    return 0;
+void Configuration::revokeReadPermission() {
+    readPermission = false;
 }
 
-size_t Configuration<const char *>::getValueJsonCapacity() {
-    return value.size() + 1;
+bool Configuration::getReadPermission() {
+    return readPermission;
 }
 
-template<class T>
-std::unique_ptr<DynamicJsonDocument> Configuration<T>::toJsonStorageEntry() {
-    if (!isValid()) {
-        return nullptr;
-    }
-    size_t capacity = getStorageHeaderJsonCapacity()
-                + getValueJsonCapacity()
-                + JSON_OBJECT_SIZE(3); //type, header, value
-    
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(capacity));
-    JsonObject keyValuePair = doc->to<JsonObject>();
-    keyValuePair["type"] = SerializedType<T>::get();
-    storeStorageHeader(keyValuePair);
-    keyValuePair["value"] = value;
-    return doc;
-}
-
-template<class T>
-std::unique_ptr<DynamicJsonDocument> Configuration<T>::toJsonOcppMsgEntry() {
-    if (!isValid()) {
-        return nullptr;
-    }
-    size_t capacity = getOcppMsgHeaderJsonCapacity()
-                + JSON_OBJECT_SIZE(3); //header (key + readonly), value
-
-    const size_t VALUE_MAXSIZE = 50;
-    char value_str [VALUE_MAXSIZE] = {'\0'};
-    toCStringValue(value_str, VALUE_MAXSIZE, value);
-    capacity += strlen(value_str) + 1;
-    
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(capacity));
-    JsonObject keyValuePair = doc->to<JsonObject>();
-    storeOcppMsgHeader(keyValuePair);
-    keyValuePair["value"] = value_str;
-    return doc;
-}
-
-std::unique_ptr<DynamicJsonDocument> Configuration<const char *>::toJsonStorageEntry() {
-    if (!isValid()) {
-        return nullptr;
-    }
-    size_t capacity = getStorageHeaderJsonCapacity()
-                + getValueJsonCapacity()
-                + JSON_OBJECT_SIZE(3); //type, header, value
-    
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(capacity));
-    JsonObject keyValuePair = doc->to<JsonObject>();
-    keyValuePair["type"] = SerializedType<const char *>::get();
-    storeStorageHeader(keyValuePair);
-    keyValuePair["value"] = value;
-    return doc;
-}
-
-std::unique_ptr<DynamicJsonDocument> Configuration<const char *>::toJsonOcppMsgEntry() {
-    if (!isValid()) {
-        return nullptr;
-    }
-    size_t capacity = getOcppMsgHeaderJsonCapacity()
-                + getValueJsonCapacity()
-                + JSON_OBJECT_SIZE(3); //header (key + readonly), value
-    
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(capacity));
-    JsonObject keyValuePair = doc->to<JsonObject>();
-    storeOcppMsgHeader(keyValuePair);
-    keyValuePair["value"] = value;
-    return doc;
-}
-
-Configuration<const char *>::Configuration(const char *key, const char *value) : AbstractConfiguration(key) {
-    if (!value) {
-        MOCPP_DBG_ERR("invalid args");
-        return;
-    }
-
-    this->operator=(value);
-}
-
-Configuration<const char *>::~Configuration() {
-
-}
-
-const char *Configuration<const char *>::operator=(const char *new_value) {
-    if (!new_value) {
-        MOCPP_DBG_ERR("invalid args");
-        return new_value;
-    }
-
-    if (!permissionLocalClientCanWrite() && initializedValue) {
-        MOCPP_DBG_ERR("Tried to override read-only configuration: %s", getKey());
-        return new_value;
-    }
-
-    if (value.compare(new_value) || !initializedValue) {
-        value = new_value;
-        value_revision++;
-    }
-    
-    if (!initializedValue) {
-        MOCPP_DBG_DEBUG("add config: key = %s, value = %s", getKey(), value.c_str());
-        (void)0;
-    }
-    initializedValue = true;
-    return new_value;
-}
-
-Configuration<const char *>::operator const char*() {
-    return value.c_str();
-}
-
-bool Configuration<const char *>::isValid() {
-    return AbstractConfiguration::isValid();
-}
-
-size_t Configuration<const char *>::getBuffsize() {
-    return value.size() + 1;
-}
-
-void Configuration<const char *>::setValidator(std::function<bool(const char*)> validator) {
+void Configuration::setValidator(std::function<bool(const char*)> validator) {
     this->validator = validator;
 }
 
-std::function<bool(const char*)> Configuration<const char *>::getValidator() {
-    return this->validator;
+std::function<bool(const char*)> Configuration::getValidator() {
+    return validator;
 }
 
-template class Configuration<int>;
-template class Configuration<float>;
-template class Configuration<bool>;
+namespace ConfigHelpers {
+
+bool initKey(const char *dest, const char *src) {
+    dest = src;
+    return true;
+}
+
+bool initKey(char *dest, const char *src) {
+    size_t len = strlen(src);
+    dest = (char*) malloc(len + 1);
+    if (!dest) {
+        return false;
+    }
+    strcpy(dest, src);
+    return true;
+}
+
+void deinitKey(const char *key) {
+    (void)key;
+}
+
+void deinitKey(char *key) {
+    free(key);
+}
+
+template<class T>
+void deinitValue(T) { }
+
+template<>
+void deinitValue(char *val) {
+    free(val);
+}
+
+template<class T>
+T getNull();
+
+template<>
+int getNull() {return 0;}
+
+template<>
+float getNull() {return 0.f;}
+
+template<>
+char *getNull() {return nullptr;}
+
+template<>
+const char *getNull() {return nullptr;}
+
+template<class T, class U>
+T as(U) {return getNull<T>();}
+
+template<>
+int as(int v) {return v;}
+
+template<>
+float as(float v) {return v;}
+
+template<>
+const char *as(char *v) {return v;}
+
+template<>
+const char *as(const char *v) {return v;}
+
+
+template<class T>
+struct TConfigType {
+    static TConfig get() {return TConfig::None;}
+};
+
+template<> struct TConfigType<int> {static TConfig get() {return TConfig::Int;}};
+template<> struct TConfigType<float> {static TConfig get() {return TConfig::Float;}};
+template<> struct TConfigType<const char*> {static TConfig get() {return TConfig::String;}};
+template<> struct TConfigType<bool> {static TConfig get() {return TConfig::Bool;}};
+
+} //end namespace ConfigHelpers
+
+
+template<class K, class T>
+ConfigConcrete<K,T>::ConfigConcrete() {
+    key = nullptr;
+    val = ConfigHelpers::getNull<T>();
+}
+
+template<class K, class T>
+ConfigConcrete<K,T>::~ConfigConcrete() {
+    ConfigHelpers::deinitKey(key);
+}
+
+template<class K, class T>
+ConfigConcrete<K,T>::ConfigConcrete() {
+
+}
+
+template<class K, class T>
+ConfigConcrete<K,T>::ConfigConcrete() {
+
+}
+
+template<class K, class T>
+ConfigConcrete<K,T>::ConfigConcrete() {
+
+}
+
+template<class K, class T>
+ConfigConcrete<K,T>::~ConfigConcrete() {
+    ConfigHelpers::deinitKey(key);
+}
+
+template<class K, class T>
+bool ConfigConcrete<K,T>::setKey(const char *key) {
+    return ConfigHelpers::initKey(this->key, key);
+}
+
+template<class K, class T>
+const char *ConfigConcrete<K,T>::getKey() {
+    return key;
+}
+
+template<class K, class T>
+int ConfigConcrete<K,T>::getInt() {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::Int) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    return ConfigHelpers::as<int>(val);
+}
+
+template<class K, class T>
+bool ConfigConcrete<K,T>::getBool() {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::Bool) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    return ConfigHelpers::as<bool>(val);
+}
+
+template<class K, class T>
+const char *ConfigConcrete<K,T>::getString() {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::String) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    return ConfigHelpers::as<const char*>(val);
+}
+
+template<class K, class T>
+void ConfigConcrete<K,T>::setInt(int v) {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::Int) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    value_revision++;
+    val = ConfigHelpers::as<T>(v);
+}
+
+template<class K, class T>
+void ConfigConcrete<K,T>::setBool(bool v) {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::Bool) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    value_revision++;
+    val = ConfigHelpers::as<T>(v);
+}
+
+template<class K, class T>
+bool ConfigConcrete<K,T>::setString(const char *src) {
+#if MOCPP_CONFIG_TYPECHECK
+    if (getType() != TConfig::String) {
+        MOCPP_DBG_ERR("type err");
+    }
+#endif
+    value_revision++;
+    auto dest = ConfigHelpers::as<char*>(val);
+    if (dest) {
+        free(dest);
+        dest = nullptr;
+    }
+    if (src && dest) {
+        size_t len = strlen(src);
+        dest = (char*) malloc(len + 1);
+        if (!dest) {
+            return false;
+        }
+        strcpy(dest, src);
+    }
+    return true;
+}
+
+template<class K, class T>
+TConfig ConfigConcrete<K,T>::getType() {
+    return ConfigHelpers::TConfigType<T>::get();
+}
+
+
+bool deserializeTConfig(TConfig& out, const char *serialized) {
+    if (!strcmp(serialized, "int")) {
+        out = TConfig::Int;
+    } else if (!strcmp(serialized, "bool")) {
+        out = TConfig::Bool;
+    } else if (!strcmp(serialized, "string")) {
+        out = TConfig::String;
+    } else {
+        out = TConfig::None;
+        MOCPP_DBG_WARN("config type error");
+    }
+    return out;
+}
+
+const char *serializeTConfig(TConfig type) {
+    switch (type) {
+        case (TConfig::Int):
+            return "int";
+        case (TConfig::Bool):
+            return "bool";
+        case (TConfig::String):
+            return "string";
+        case (TConfig::None):
+            MOCPP_DBG_WARN("config type error");
+            return "undefined";
+    }
+}
+
+std::unique_ptr<Configuration> deserializeConfigInternal(JsonObject stored) {
+    
+    TConfig ctype = TConfig::None;
+    if (!deserializeTConfig(ctype, stored["type"] | "_Undefined") || ctype == TConfig::None) {
+        return nullptr;
+    }
+
+    if (!stored.containsKey("value")) {
+        return nullptr;
+    }
+
+    std::unique_ptr<Configuration> res;
+
+    switch (ctype) {
+        case (TConfig::Int):
+            if (!stored["value"].is<int>()) {
+                return nullptr;
+            }
+            res = std::unique_ptr<ConfigConcrete<char*,int>>(new ConfigConcrete<char*,int>());
+            if (!res) {
+                return nullptr;
+            }
+            res->setInt(stored["value"] | 0);
+            break;
+        case (TConfig::Bool):
+            if (!stored["value"].is<bool>()) {
+                return nullptr;
+            }
+            res = std::unique_ptr<ConfigConcrete<char*,bool>>(new ConfigConcrete<char*,bool>());
+            if (!res) {
+                return nullptr;
+            }
+            res->setBool(stored["value"] | false);
+            break;
+        case (TConfig::String):
+            if (!stored["value"].is<const char*>()) {
+                return nullptr;
+            }
+            res = std::unique_ptr<ConfigConcrete<char*,const char*>>(new ConfigConcrete<char*,const char*>());
+            if (!res) {
+                return nullptr;
+            }
+            res->setString(stored["value"] | "");
+            break;
+        case (TConfig::None):
+            return nullptr;
+    }
+    
+    const char *key = stored["key"] | "";
+    if (!*key) {
+        return nullptr;
+    }
+
+    if (!res->setKey(key)) {
+        return nullptr;
+    }
+
+    return res;
+}
+
+bool serializeConfigInternal(Configuration& config, JsonObject out) {
+
+    out["key"] = config.getKey();
+    
+    switch (config.getType()) {
+        case TConfig::Int:
+            out["type"] = "int";
+            out["value"] = config.getInt();
+            break;
+        case TConfig::Bool:
+            out["type"] = "bool";
+            out["value"] = config.getBool();
+            break;
+        case TConfig::String:
+            out["type"] = "string";
+            out["value"] = config.getString();
+            break;
+        case TConfig::None:
+            MOCPP_DBG_ERR("invalid config");
+            out.clear();
+            return false;
+            break;
+    }
+
+    return true;
+}
+
+bool serializeConfigOcpp(Configuration& config, DynamicJsonDocument& out) {
+
+    const size_t PRIMITIVE_VALUESIZE = 30;
+    char vbuf [PRIMITIVE_VALUESIZE];
+    const char *v = vbuf;
+    size_t vcapacity = 0;
+    switch(config.getType()) {
+        case TConfig::Int: {
+            auto ret = snprintf(valuebuf, PRIMITIVE_VALUESIZE, "%i", config.getInt());
+            if (ret < 0 || ret >= PRIMITIVE_VALUESIZE) {
+                return false;
+            }
+            v = vbuf;
+            vcapacity = ret;
+            break;
+        }
+        case TConfig::Bool: {
+            v = config.getBool() ? "true" : "false";
+            vcapacity = 0;
+            break;
+        }
+        case TConfig::String: {
+            v = config.getString();
+            if (!v) {
+                MOCPP_DBG_ERR("invalid config");
+                return nullptr;
+            }
+            vcapacity = 0;
+            break;
+        }
+        case TConfig::None: {
+            MOCPP_DBG_ERR("invalid config");
+            return false;
+        }
+    }
+
+    out.reset(JSON_OBJECT_SIZE(3) + vcapacity);
+
+    out["key"] = config.getKey();
+    out["readonly"] = !config.getWritePermission();
+    if (vcapacity > 0) {
+        //value has capacity, copy string
+        out["value"] = (char*) v;
+    } else {
+        //value is static, no-copy mode
+        out["value"] = v;
+    }
+
+    return true;
+}
+
+template class ConfigConcrete<char*,int>;
+template class ConfigConcrete<char*,bool>;
+template class ConfigConcrete<char*,const char*>;
+template class ConfigConcrete<const char*,int>;
+template class ConfigConcrete<const char*,bool>;
+template class ConfigConcrete<const char*,const char*>;
 //template class Configuration<const char *>; //no effect after explicit specialization
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.h
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.h
@@ -47,11 +47,11 @@ public:
 
     revision_t getValueRevision(); 
 
-    void setRequiresReboot();
-    bool getRequiresReboot();
+    void setRebootRequired();
+    bool isRebootRequired();
 
     void setReadOnly();
-    bool getReadOnly();
+    bool isReadOnly();
 };
 
 /*

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.h
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.h
@@ -18,7 +18,7 @@ namespace MicroOcpp {
 
 using revision_t = uint16_t;
 
-enum TConfig : uint8_t {
+enum class TConfig : uint8_t {
     Int,
     Bool,
     String

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.h
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.h
@@ -64,9 +64,7 @@ public:
  * How to use custom implementations: for each OCPP config, pass a config instance to the OCPP lib
  * before its initialization stage. Then the library won't create new config objects but 
  */
-
-template<class T>
-std::unique_ptr<Configuration> makeConfig(const char *key, T val);
+std::unique_ptr<Configuration> makeConfiguration(TConfig type, const char *key);
 
 const char *serializeTConfig(TConfig type);
 bool deserializeTConfig(const char *serialized, TConfig& out);

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.h
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.h
@@ -10,6 +10,10 @@
 
 #define MOCPP_CONFIG_MAX_VALSTRSIZE 128
 
+#ifndef MOCPP_CONFIG_EXT_PREFIX
+#define MOCPP_CONFIG_EXT_PREFIX "Cst_"
+#endif
+
 namespace MicroOcpp {
 
 using revision_t = uint16_t;
@@ -41,7 +45,7 @@ public:
 
     virtual int getInt();
     virtual bool getBool();
-    virtual const char *getString();
+    virtual const char *getString(); //always returns c-string (empty if undefined)
 
     virtual TConfig getType() = 0;
 

--- a/src/MicroOcpp/Core/Connection.cpp
+++ b/src/MicroOcpp/Core/Connection.cpp
@@ -9,13 +9,13 @@ using namespace MicroOcpp;
 
 void LoopbackConnection::loop() { }
 
-bool LoopbackConnection::sendTXT(std::string &out) {
+bool LoopbackConnection::sendTXT(const char *msg, size_t length) {
     if (!connected) {
         return false;
     }
     if (receiveTXT) {
         lastRecv = mocpp_tick_ms();
-        return receiveTXT(out.c_str(), out.length());
+        return receiveTXT(msg, length);
     } else {
         return false;
     }
@@ -52,7 +52,7 @@ void WSClient::loop() {
     wsock->loop();
 }
 
-bool WSClient::sendTXT(std::string &out) {
+bool WSClient::sendTXT(const char *msg, size_t length) {
     return wsock->sendTXT(out.c_str(), out.length());
 }
 

--- a/src/MicroOcpp/Core/Connection.cpp
+++ b/src/MicroOcpp/Core/Connection.cpp
@@ -53,7 +53,7 @@ void WSClient::loop() {
 }
 
 bool WSClient::sendTXT(const char *msg, size_t length) {
-    return wsock->sendTXT(out.c_str(), out.length());
+    return wsock->sendTXT(msg, length);
 }
 
 void WSClient::setReceiveTXTcallback(ReceiveTXTcallback &callback) {

--- a/src/MicroOcpp/Core/Connection.h
+++ b/src/MicroOcpp/Core/Connection.h
@@ -7,7 +7,6 @@
 
 #include <functional>
 #include <memory>
-#include <string>
 
 #include <MicroOcpp/Platform.h>
 
@@ -37,7 +36,7 @@ public:
     /*
      * The OCPP library calls this function for sending out OCPP messages to the server
      */
-    virtual bool sendTXT(std::string &out) = 0;
+    virtual bool sendTXT(const char *msg, size_t length) = 0;
 
     /*
      * The OCPP library calls this function once during initialization. It passes a callback function to
@@ -65,7 +64,7 @@ private:
     unsigned long lastConn = 0;
 public:
     void loop() override;
-    bool sendTXT(std::string &out) override;
+    bool sendTXT(const char *msg, size_t length) override;
     void setReceiveTXTcallback(ReceiveTXTcallback &receiveTXT) override;
     unsigned long getLastRecv() override;
     unsigned long getLastConnected() override;
@@ -92,7 +91,7 @@ public:
 
     void loop();
 
-    bool sendTXT(std::string &out);
+    bool sendTXT(const char *msg, size_t length);
 
     void setReceiveTXTcallback(ReceiveTXTcallback &receiveTXT);
 

--- a/src/MicroOcpp/Core/RequestQueue.cpp
+++ b/src/MicroOcpp/Core/RequestQueue.cpp
@@ -62,7 +62,7 @@ void RequestQueue::loop(Connection& ocppSock) {
             std::string out;
             serializeJson(*response, out);
     
-            bool success = ocppSock.sendTXT(out);
+            bool success = ocppSock.sendTXT(out.c_str(), out.length());
 
             if (success) {
                 MOCPP_DBG_TRAFFIC_OUT(out.c_str());
@@ -113,7 +113,7 @@ void RequestQueue::loop(Connection& ocppSock) {
     std::string out;
     serializeJson(*request, out);
 
-    bool success = ocppSock.sendTXT(out);
+    bool success = ocppSock.sendTXT(out.c_str(), out.length());
 
     if (success) {
         MOCPP_DBG_TRAFFIC_OUT(out.c_str());

--- a/src/MicroOcpp/Core/RequestStore.h
+++ b/src/MicroOcpp/Core/RequestStore.h
@@ -15,7 +15,7 @@ namespace MicroOcpp {
 
 class RequestStore;
 class FilesystemAdapter;
-template<class T> class Configuration;
+class Configuration;
 
 class StoredOperationHandler {
 private:
@@ -48,7 +48,7 @@ public:
 class RequestStore {
 private:
     std::shared_ptr<FilesystemAdapter> filesystem;
-    std::shared_ptr<Configuration<int>> opBegin; //Tx-related operations are stored; index of the first pending operation
+    std::shared_ptr<Configuration> opBeginInt; //Tx-related operations are stored; index of the first pending operation
     unsigned int opEnd = 0; //one place after last number
 
 public:

--- a/src/MicroOcpp/Model/Authorization/AuthorizationService.h
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationService.h
@@ -19,8 +19,8 @@ private:
     std::shared_ptr<FilesystemAdapter> filesystem;
     AuthorizationList localAuthorizationList;
 
-    std::shared_ptr<Configuration<bool>> localAuthorizeOffline;
-    std::shared_ptr<Configuration<bool>> localAuthListEnabled;
+    std::shared_ptr<Configuration> localAuthorizeOfflineBool;
+    std::shared_ptr<Configuration> localAuthListEnabledBool;
 
 public:
     AuthorizationService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem);

--- a/src/MicroOcpp/Model/Boot/BootService.cpp
+++ b/src/MicroOcpp/Model/Boot/BootService.cpp
@@ -36,9 +36,9 @@ RegistrationStatus MicroOcpp::deserializeRegistrationStatus(const char *serializ
 BootService::BootService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem) : context(context), filesystem(filesystem) {
     
     //if transactions can start before the BootNotification succeeds
-    preBootTransactions = declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", false, CONFIGURATION_FN, true, true, true, false);
+    preBootTransactionsBool = declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", false);
     
-    if (!preBootTransactions) {
+    if (!preBootTransactionsBool) {
         MOCPP_DBG_ERR("initialization error");
         (void)0;
     }
@@ -69,7 +69,7 @@ void BootService::loop() {
         activatedPostBootCommunication = true;
     }
 
-    if (!activatedModel && (status == RegistrationStatus::Accepted || *preBootTransactions)) {
+    if (!activatedModel && (status == RegistrationStatus::Accepted || preBootTransactionsBool->getBool())) {
         context.getModel().activateTasks();
         activatedModel = true;
     }

--- a/src/MicroOcpp/Model/Boot/BootService.h
+++ b/src/MicroOcpp/Model/Boot/BootService.h
@@ -45,7 +45,7 @@ private:
     
     std::string cpCredentials;
 
-    std::shared_ptr<Configuration<bool>> preBootTransactions;
+    std::shared_ptr<Configuration> preBootTransactionsBool;
 
     bool activatedModel = false;
     bool activatedPostBootCommunication = false;

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -32,7 +32,8 @@ private:
 
     std::shared_ptr<Transaction> transaction;
 
-    std::shared_ptr<Configuration<bool>> availability;
+    std::shared_ptr<Configuration> availabilityBool;
+    char availabilityBoolKey [sizeof(MOCPP_CONFIG_EXT_PREFIX "AVAIL_CONN_xxxx") + 1];
     bool availabilityVolatile = true;
 
     std::function<bool()> connectorPluggedInput;
@@ -44,7 +45,7 @@ private:
     const char *getErrorCode();
 
     ChargePointStatus currentStatus = ChargePointStatus::NOT_SET;
-    std::shared_ptr<Configuration<int>> minimumStatusDuration; //in seconds
+    std::shared_ptr<Configuration> minimumStatusDurationInt; //in seconds
     ChargePointStatus reportedStatus = ChargePointStatus::NOT_SET;
     unsigned long t_statusTransition = 0;
 
@@ -56,23 +57,26 @@ private:
 
     std::function<void(Transaction*,TxNotification)> txNotificationOutput;
 
-    std::shared_ptr<Configuration<int>> connectionTimeOut; //in seconds
-    std::shared_ptr<Configuration<bool>> stopTransactionOnInvalidId;
-    std::shared_ptr<Configuration<bool>> stopTransactionOnEVSideDisconnect;
-    std::shared_ptr<Configuration<bool>> unlockConnectorOnEVSideDisconnect;
-    std::shared_ptr<Configuration<bool>> localPreAuthorize;
-    std::shared_ptr<Configuration<bool>> allowOfflineTxForUnknownId;
+    std::shared_ptr<Configuration> connectionTimeOutInt; //in seconds
+    std::shared_ptr<Configuration> stopTransactionOnInvalidIdBool;
+    std::shared_ptr<Configuration> stopTransactionOnEVSideDisconnectBool;
+    std::shared_ptr<Configuration> localPreAuthorizeBool;
+    std::shared_ptr<Configuration> allowOfflineTxForUnknownIdBool;
 
-    std::shared_ptr<Configuration<bool>> silentOfflineTransactions;
-    std::shared_ptr<Configuration<int>> authorizationTimeout; //in seconds
-    std::shared_ptr<Configuration<bool>> freeVendActive;
-    std::shared_ptr<Configuration<const char*>> freeVendIdTag;
+    std::shared_ptr<Configuration> silentOfflineTransactionsBool;
+    std::shared_ptr<Configuration> authorizationTimeoutInt; //in seconds
+    std::shared_ptr<Configuration> freeVendActiveBool;
+    std::shared_ptr<Configuration> freeVendIdTagString;
     bool freeVendTrackPlugged = false;
 
     bool trackLoopExecute = false; //if loop has been executed once
 public:
     Connector(Context& context, int connectorId);
-    Connector(Connector&& other) = default;
+    Connector(const Connector&) = delete;
+    Connector(Connector&&) = delete;
+    Connector& operator=(const Connector&) = delete;
+
+    ~Connector();
 
     /*
      * beginTransaction begins the transaction process which eventually leads to a StartTransaction

--- a/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
@@ -29,33 +29,13 @@ using namespace MicroOcpp;
 ConnectorsCommon::ConnectorsCommon(Context& context, unsigned int numConn, std::shared_ptr<FilesystemAdapter> filesystem) :
         context(context) {
     
-    std::shared_ptr<Configuration<int>> numberOfConnectors =
-            declareConfiguration<int>("NumberOfConnectors", numConn >= 1 ? numConn - 1 : 0, CONFIGURATION_VOLATILE, false, true, false, false);
-
-    const char *fpId = "Core,RemoteTrigger";
-    const char *fpIdCore = "Core";
-    const char *fpIdRTrigger = "RemoteTrigger";
-    auto fProfile = declareConfiguration<const char*>("SupportedFeatureProfiles",fpId, CONFIGURATION_VOLATILE, false, true, true, false);
-    if (!strstr(*fProfile, fpIdCore)) {
-        auto fProfilePlus = std::string(*fProfile);
-        if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
-            fProfilePlus += ",";
-        fProfilePlus += fpIdCore;
-        *fProfile = fProfilePlus.c_str();
-    }
-    if (!strstr(*fProfile, fpIdRTrigger)) {
-        auto fProfilePlus = std::string(*fProfile);
-        if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
-            fProfilePlus += ",";
-        fProfilePlus += fpIdRTrigger;
-        *fProfile = fProfilePlus.c_str();
-    }
+    declareConfiguration<int>("NumberOfConnectors", numConn >= 1 ? numConn - 1 : 0, CONFIGURATION_VOLATILE, true);
     
     /*
      * Further configuration keys which correspond to the Core profile
      */
-    declareConfiguration<bool>("AuthorizeRemoteTxRequests",false,CONFIGURATION_VOLATILE,false,true,false,false);
-    declareConfiguration<int>("GetConfigurationMaxKeys",30,CONFIGURATION_VOLATILE,false,true,false,false);
+    declareConfiguration<bool>("AuthorizeRemoteTxRequests", false, CONFIGURATION_VOLATILE, true);
+    declareConfiguration<int>("GetConfigurationMaxKeys", 30, CONFIGURATION_VOLATILE, true);
     
     context.getOperationRegistry().registerOperation("ChangeAvailability", [&context] () {
         return new Ocpp16::ChangeAvailability(context.getModel());});

--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.cpp
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.cpp
@@ -6,7 +6,6 @@
 #include <MicroOcpp/Core/Context.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Core/SimpleRequestFactory.h>
-#include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Debug.h>
 
 #include <MicroOcpp/Operations/GetDiagnostics.h>
@@ -16,15 +15,6 @@ using namespace MicroOcpp;
 using Ocpp16::DiagnosticsStatus;
 
 DiagnosticsService::DiagnosticsService(Context& context) : context(context) {
-    const char *fpId = "FirmwareManagement";
-    auto fProfile = declareConfiguration<const char*>("SupportedFeatureProfiles",fpId, CONFIGURATION_VOLATILE, false, true, true, false);
-    if (!strstr(*fProfile, fpId)) {
-        auto fProfilePlus = std::string(*fProfile);
-        if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
-            fProfilePlus += ",";
-        fProfilePlus += fpId;
-        *fProfile = fProfilePlus.c_str();
-    }
     
     context.getOperationRegistry().registerOperation("GetDiagnostics", [&context] () {
         return new Ocpp16::GetDiagnostics(context.getModel());});

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
@@ -33,7 +33,7 @@ class FirmwareService {
 private:
     Context& context;
     
-    std::shared_ptr<Configuration<const char *>> previousBuildNumber;
+    std::shared_ptr<Configuration> previousBuildNumberString;
     std::string buildNumber;
 
     std::function<DownloadStatus()> downloadStatusInput;

--- a/src/MicroOcpp/Model/Heartbeat/HeartbeatService.cpp
+++ b/src/MicroOcpp/Model/Heartbeat/HeartbeatService.cpp
@@ -12,7 +12,7 @@
 using namespace MicroOcpp;
 
 HeartbeatService::HeartbeatService(Context& context) : context(context) {
-    heartbeatInterval = declareConfiguration("HeartbeatInterval", 86400);
+    heartbeatIntervalInt = declareConfiguration<int>("HeartbeatInterval", 86400);
     lastHeartbeat = mocpp_tick_ms();
 
     //Register message handler for TriggerMessage operation
@@ -21,7 +21,7 @@ HeartbeatService::HeartbeatService(Context& context) : context(context) {
 }
 
 void HeartbeatService::loop() {
-    unsigned long hbInterval = *heartbeatInterval;
+    unsigned long hbInterval = heartbeatIntervalInt->getInt();
     hbInterval *= 1000UL; //conversion s -> ms
     unsigned long now = mocpp_tick_ms();
 

--- a/src/MicroOcpp/Model/Heartbeat/HeartbeatService.h
+++ b/src/MicroOcpp/Model/Heartbeat/HeartbeatService.h
@@ -17,7 +17,7 @@ private:
     Context& context;
 
     unsigned long lastHeartbeat;
-    std::shared_ptr<MicroOcpp::Configuration<int>> heartbeatInterval;
+    std::shared_ptr<Configuration> heartbeatIntervalInt;
 
 public:
     HeartbeatService(Context& context);

--- a/src/MicroOcpp/Model/Metering/MeterValue.h
+++ b/src/MicroOcpp/Model/Metering/MeterValue.h
@@ -35,15 +35,15 @@ public:
 class MeterValueBuilder {
 private:
     const std::vector<std::unique_ptr<SampledValueSampler>> &samplers;
-    std::shared_ptr<Configuration<const char*>> select;
+    std::shared_ptr<Configuration> selectString;
     std::vector<bool> select_mask;
     unsigned int select_n {0};
-    decltype(select->getValueRevision()) select_observe;
+    decltype(selectString->getValueRevision()) select_observe;
 
     void updateObservedSamplers();
 public:
     MeterValueBuilder(const std::vector<std::unique_ptr<SampledValueSampler>> &samplers,
-            std::shared_ptr<Configuration<const char*>> samplers_select);
+            std::shared_ptr<Configuration> samplersSelectStr);
     
     std::unique_ptr<MeterValue> takeSample(const Timestamp& timestamp, const ReadingContext& context);
 

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.h
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.h
@@ -35,10 +35,10 @@ private:
     std::unique_ptr<MeterValueBuilder> stopTxnSampledDataBuilder;
     std::unique_ptr<MeterValueBuilder> stopTxnAlignedDataBuilder;
 
-    std::shared_ptr<Configuration<const char *>> sampledDataSelect;
-    std::shared_ptr<Configuration<const char *>> alignedDataSelect;
-    std::shared_ptr<Configuration<const char *>> stopTxnSampledDataSelect;
-    std::shared_ptr<Configuration<const char *>> stopTxnAlignedDataSelect;
+    std::shared_ptr<Configuration> sampledDataSelectString;
+    std::shared_ptr<Configuration> alignedDataSelectString;
+    std::shared_ptr<Configuration> stopTxnSampledDataSelectString;
+    std::shared_ptr<Configuration> stopTxnAlignedDataSelectString;
 
     unsigned long lastSampleTime = 0; //0 means not charging right now
     Timestamp nextAlignedTime;
@@ -48,13 +48,13 @@ private:
     std::vector<std::unique_ptr<SampledValueSampler>> samplers;
     int energySamplerIndex {-1};
 
-    std::shared_ptr<Configuration<int>> MeterValueSampleInterval;
-    std::shared_ptr<Configuration<int>> MeterValueCacheSize;
+    std::shared_ptr<Configuration> meterValueSampleIntervalInt;
+    std::shared_ptr<Configuration> meterValueCacheSizeInt;
 
-    std::shared_ptr<Configuration<int>> ClockAlignedDataInterval;
+    std::shared_ptr<Configuration> clockAlignedDataIntervalInt;
 
-    std::shared_ptr<Configuration<bool>> MeterValuesInTxOnly;
-    std::shared_ptr<Configuration<bool>> StopTxnDataCapturePeriodic;
+    std::shared_ptr<Configuration> meterValuesInTxOnlyBool;
+    std::shared_ptr<Configuration> stopTxnDataCapturePeriodicBool;
 public:
     MeteringConnector(Model& model, int connectorId, MeterStore& meterStore);
 

--- a/src/MicroOcpp/Model/Metering/MeteringService.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringService.cpp
@@ -16,36 +16,14 @@ using namespace MicroOcpp;
 MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<FilesystemAdapter> filesystem)
       : context(context), meterStore(filesystem) {
 
-    auto MeterValuesSampledData = declareConfiguration<const char*>(
-        "MeterValuesSampledData",
-        "Energy.Active.Import.Register,Power.Active.Import",
-        CONFIGURATION_FN,
-        true,true,true,false
-    );
-    
-    auto StopTxnSampledData = declareConfiguration<const char*>(
-        "StopTxnSampledData",
-        "",
-        CONFIGURATION_FN,
-        true,true,true,false
-    );
-    
-    auto MeterValuesAlignedData = declareConfiguration<const char*>(
-        "MeterValuesAlignedData",
-        "Energy.Active.Import.Register,Power.Active.Import",
-        CONFIGURATION_FN,
-        true,true,true,false
-    );
-    
-    auto StopTxnAlignedData = declareConfiguration<const char*>(
-        "StopTxnAlignedData",
-        "",
-        CONFIGURATION_FN,
-        true,true,true,false
-    );
+    //set factory defaults for Metering-related config keys
+    declareConfiguration<const char*>("MeterValuesSampledData", "Energy.Active.Import.Register,Power.Active.Import");
+    declareConfiguration<const char*>("StopTxnSampledData", "");
+    declareConfiguration<const char*>("MeterValuesAlignedData", "Energy.Active.Import.Register,Power.Active.Import");
+    declareConfiguration<const char*>("StopTxnAlignedData", "");
     
     for (int i = 0; i < numConn; i++) {
-        connectors.push_back(std::unique_ptr<MeteringConnector>(new MeteringConnector(context.getModel(), i, meterStore)));
+        connectors.emplace_back(new MeteringConnector(context.getModel(), i, meterStore));
     }
 
     std::function<bool(const char*)> validateSelectString = [this] (const char *csl) {
@@ -77,10 +55,10 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
         }
         return isValid;
     };
-    MeterValuesSampledData->setValidator(validateSelectString);
-    StopTxnSampledData->setValidator(validateSelectString);
-    MeterValuesAlignedData->setValidator(validateSelectString);
-    StopTxnAlignedData->setValidator(validateSelectString);
+    registerConfigurationValidator("MeterValuesSampledData", validateSelectString);
+    registerConfigurationValidator("StopTxnSampledData", validateSelectString);
+    registerConfigurationValidator("MeterValuesAlignedData", validateSelectString);
+    registerConfigurationValidator("StopTxnAlignedData", validateSelectString);
 
     /*
      * Register further message handlers to support echo mode: when this library

--- a/src/MicroOcpp/Model/Model.h
+++ b/src/MicroOcpp/Model/Model.h
@@ -26,7 +26,7 @@ class ResetService;
 
 class Model {
 private:
-    std::vector<Connector> connectors;
+    std::vector<std::unique_ptr<Connector>> connectors;
     std::unique_ptr<TransactionStore> transactionStore;
     std::unique_ptr<SmartChargingService> smartChargingService;
     std::unique_ptr<ConnectorsCommon> chargeControlCommon;
@@ -39,6 +39,9 @@ private:
     std::unique_ptr<BootService> bootService;
     std::unique_ptr<ResetService> resetService;
     Clock clock;
+
+    bool capabilitiesUpdated = true;
+    void updateSupportedStandardProfiles();
 
     bool runTasks = false;
 
@@ -62,7 +65,7 @@ public:
     void setConnectorsCommon(std::unique_ptr<ConnectorsCommon> ccs);
     ConnectorsCommon *getConnectorsCommon();
 
-    void setConnectors(std::vector<Connector>&& connectors);
+    void setConnectors(std::vector<std::unique_ptr<Connector>>&& connectors);
     unsigned int getNumConnectors() const;
     Connector *getConnector(unsigned int connectorId);
 

--- a/src/MicroOcpp/Model/Reservation/Reservation.h
+++ b/src/MicroOcpp/Model/Reservation/Reservation.h
@@ -8,6 +8,12 @@
 #include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Core/Time.h>
 
+#define MOCPP_RESERVATION_CID_KEY "cid_"
+#define MOCPP_RESERVATION_EXPDATE_KEY "expdt_"
+#define MOCPP_RESERVATION_IDTAG_KEY "idt_"
+#define MOCPP_RESERVATION_RESID_KEY "rsvid_"
+#define MOCPP_RESERVATION_PARENTID_KEY "pidt_"
+
 namespace MicroOcpp {
 
 class Model;
@@ -17,15 +23,26 @@ private:
     Model& model;
     const unsigned int slot;
 
-    std::shared_ptr<Configuration<int>> connectorId;
-    std::shared_ptr<Configuration<const char *>> expiryDateRaw;
+    std::shared_ptr<Configuration> connectorIdInt;
+    char connectorIdKey [sizeof(MOCPP_RESERVATION_CID_KEY "xxx") + 1]; //"xxx" = placeholder for digits
+    std::shared_ptr<Configuration> expiryDateRawString;
+    char expiryDateRawKey [sizeof(MOCPP_RESERVATION_EXPDATE_KEY "xxx") + 1];
+
     Timestamp expiryDate;
-    std::shared_ptr<Configuration<const char *>> idTag;
-    std::shared_ptr<Configuration<int>> reservationId;
-    std::shared_ptr<Configuration<const char *>> parentIdTag;
+    std::shared_ptr<Configuration> idTagString;
+    char idTagKey [sizeof(MOCPP_RESERVATION_IDTAG_KEY "xxx") + 1];
+    std::shared_ptr<Configuration> reservationIdInt;
+    char reservationIdKey [sizeof(MOCPP_RESERVATION_RESID_KEY "xxx") + 1];
+    std::shared_ptr<Configuration> parentIdTagString;
+    char parentIdTagKey [sizeof(MOCPP_RESERVATION_PARENTID_KEY "xxx") + 1];
 
 public:
     Reservation(Model& model, unsigned int slot);
+    Reservation(const Reservation&) = delete;
+    Reservation(Reservation&&) = delete;
+    Reservation& operator=(const Reservation&) = delete;
+
+    ~Reservation();
 
     bool isActive(); //if this object contains a valid, unexpired reservation
 

--- a/src/MicroOcpp/Model/Reservation/ReservationService.h
+++ b/src/MicroOcpp/Model/Reservation/ReservationService.h
@@ -7,6 +7,8 @@
 
 #include <MicroOcpp/Model/Reservation/Reservation.h>
 
+#include <memory>
+
 namespace MicroOcpp {
 
 class Context;
@@ -16,9 +18,9 @@ private:
     Context& context;
 
     const int maxReservations; // = number of physical connectors
-    std::vector<Reservation> reservations;
+    std::vector<std::unique_ptr<Reservation>> reservations;
 
-    std::shared_ptr<Configuration<bool>> reserveConnectorZeroSupported;
+    std::shared_ptr<Configuration> reserveConnectorZeroSupportedBool;
 
 public:
     ReservationService(Context& context, unsigned int numConnectors);

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -26,7 +26,7 @@ using namespace MicroOcpp;
 ResetService::ResetService(Context& context)
       : context(context) {
 
-    resetRetries = declareConfiguration<int>("ResetRetries", 2, CONFIGURATION_FN, true, true, false, false);
+    resetRetriesInt = declareConfiguration<int>("ResetRetries", 2);
 
     context.getOperationRegistry().registerOperation("Reset", [&context] () {
         return new Ocpp16::Reset(context.getModel());});
@@ -90,7 +90,7 @@ std::function<void(bool)> ResetService::getExecuteReset() {
 
 void ResetService::initiateReset(bool isHard) {
     isHardReset = isHard;
-    outstandingResetRetries = 1 + *resetRetries; //one initial try + no. of retries
+    outstandingResetRetries = 1 + resetRetriesInt->getInt(); //one initial try + no. of retries
     if (outstandingResetRetries > 5) {
         MOCPP_DBG_ERR("no. of reset trials exceeds 5");
         outstandingResetRetries = 5;

--- a/src/MicroOcpp/Model/Reset/ResetService.h
+++ b/src/MicroOcpp/Model/Reset/ResetService.h
@@ -5,6 +5,8 @@
 #ifndef RESETSERVICE_H
 #define RESETSERVICE_H
 
+#include <functional>
+
 #include <MicroOcpp/Core/ConfigurationKeyValue.h>
 
 namespace MicroOcpp {
@@ -21,7 +23,7 @@ private:
     bool isHardReset = false;
     unsigned long t_resetRetry;
 
-    std::shared_ptr<Configuration<int>> resetRetries;
+    std::shared_ptr<Configuration> resetRetriesInt;
 
 public:
     ResetService(Context& context);

--- a/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
+++ b/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
@@ -303,20 +303,10 @@ SmartChargingService::SmartChargingService(Context& context, std::shared_ptr<Fil
         connectors.push_back(std::move(SmartChargingConnector(context.getModel(), filesystem, cId, ChargePointMaxProfile, ChargePointTxDefaultProfile)));
     }
 
-    declareConfiguration<int>("ChargeProfileMaxStackLevel", CHARGEPROFILEMAXSTACKLEVEL, CONFIGURATION_VOLATILE, false, true, false, false);
-    declareConfiguration<const char*>("ChargingScheduleAllowedChargingRateUnit", "", CONFIGURATION_VOLATILE, false);
-    declareConfiguration<int>("ChargingScheduleMaxPeriods", CHARGINGSCHEDULEMAXPERIODS, CONFIGURATION_VOLATILE, false, true, false, false);
-    declareConfiguration<int>("MaxChargingProfilesInstalled", MAXCHARGINGPROFILESINSTALLED, CONFIGURATION_VOLATILE, false, true, false, false);
-
-    const char *fpId = "SmartCharging";
-    auto fProfile = declareConfiguration<const char*>("SupportedFeatureProfiles",fpId, CONFIGURATION_VOLATILE, false, true, true, false);
-    if (!strstr(*fProfile, fpId)) {
-        auto fProfilePlus = std::string(*fProfile);
-        if (!fProfilePlus.empty() && fProfilePlus.back() != ',')
-            fProfilePlus += ",";
-        fProfilePlus += fpId;
-        *fProfile = fProfilePlus.c_str();
-    }
+    declareConfiguration<int>("ChargeProfileMaxStackLevel", CHARGEPROFILEMAXSTACKLEVEL, CONFIGURATION_VOLATILE, true);
+    declareConfiguration<const char*>("ChargingScheduleAllowedChargingRateUnit", "", CONFIGURATION_VOLATILE);
+    declareConfiguration<int>("ChargingScheduleMaxPeriods", CHARGINGSCHEDULEMAXPERIODS, CONFIGURATION_VOLATILE, true);
+    declareConfiguration<int>("MaxChargingProfilesInstalled", MAXCHARGINGPROFILESINSTALLED, CONFIGURATION_VOLATILE, true);
 
     context.getOperationRegistry().registerOperation("ClearChargingProfile", [this] () {
         return new Ocpp16::ClearChargingProfile(*this);});
@@ -556,14 +546,14 @@ void SmartChargingService::setSmartChargingOutput(unsigned int connectorId, std:
 void SmartChargingService::updateAllowedChargingRateUnit(bool powerSupported, bool currentSupported) {
     if ((powerSupported != this->powerSupported) || (currentSupported != this->currentSupported)) {
 
-        auto chargingScheduleAllowedChargingRateUnit = declareConfiguration<const char*>("ChargingScheduleAllowedChargingRateUnit", "", CONFIGURATION_VOLATILE, false);
-        if (chargingScheduleAllowedChargingRateUnit) {
+        auto chargingScheduleAllowedChargingRateUnitString = declareConfiguration<const char*>("ChargingScheduleAllowedChargingRateUnit", "", CONFIGURATION_VOLATILE);
+        if (chargingScheduleAllowedChargingRateUnitString) {
             if (powerSupported && currentSupported) {
-                *chargingScheduleAllowedChargingRateUnit = "Current,Power";
+                chargingScheduleAllowedChargingRateUnitString->setString("Current,Power");
             } else if (powerSupported) {
-                *chargingScheduleAllowedChargingRateUnit = "Power";
+                chargingScheduleAllowedChargingRateUnitString->setString("Power");
             } else if (currentSupported) {
-                *chargingScheduleAllowedChargingRateUnit = "Current";
+                chargingScheduleAllowedChargingRateUnitString->setString("Current");
             }
         }
 

--- a/src/MicroOcpp/Model/Transactions/TransactionStore.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionStore.h
@@ -16,6 +16,9 @@
 #define MOCPP_TXRECORD_SIZE 4 //no. of tx to hold on flash storage
 #endif
 
+#define MOCPP_TXSTORE_TXBEGIN_KEY "txBegin_"
+#define MOCPP_TXSTORE_TXEND_KEY "txEnd_"
+
 namespace MicroOcpp {
 
 class TransactionStore;
@@ -26,13 +29,21 @@ private:
     const unsigned int connectorId;
 
     std::shared_ptr<FilesystemAdapter> filesystem;
-    std::shared_ptr<Configuration<int>> txBegin; //if txNr < txBegin, tx has been safely deleted
-    std::shared_ptr<Configuration<int>> txEnd;
+    std::shared_ptr<Configuration> txBeginInt; //if txNr < txBegin, tx has been safely deleted
+    char txBeginKey [sizeof(MOCPP_TXSTORE_TXBEGIN_KEY "xxx") + 1]; //"xxx": placeholder for connectorId
+
+    std::shared_ptr<Configuration> txEndInt;
+    char txEndKey [sizeof(MOCPP_TXSTORE_TXEND_KEY "xxx") + 1];
     
     std::deque<std::weak_ptr<Transaction>> transactions;
 
 public:
     ConnectorTransactionStore(TransactionStore& context, unsigned int connectorId, std::shared_ptr<FilesystemAdapter> filesystem);
+    ConnectorTransactionStore(const ConnectorTransactionStore&) = delete;
+    ConnectorTransactionStore(ConnectorTransactionStore&&) = delete;
+    ConnectorTransactionStore& operator=(const ConnectorTransactionStore&) = delete;
+
+    ~ConnectorTransactionStore();
     
     std::shared_ptr<Transaction> getLatestTransaction();
     bool commit(Transaction *transaction);

--- a/src/MicroOcpp/Operations/BootNotification.cpp
+++ b/src/MicroOcpp/Operations/BootNotification.cpp
@@ -61,9 +61,9 @@ void BootNotification::processConf(JsonObject payload) {
     if (status == RegistrationStatus::Accepted) {
         //only write if in valid range
         if (interval >= 1) {
-            std::shared_ptr<Configuration<int>> intervalConf = declareConfiguration<int>("HeartbeatInterval", 86400);
-            if (intervalConf && interval != *intervalConf) {
-                *intervalConf = interval;
+            auto heartbeatIntervalInt = declareConfiguration<int>("HeartbeatInterval", 86400);
+            if (heartbeatIntervalInt && interval != heartbeatIntervalInt->getInt()) {
+                heartbeatIntervalInt->setInt(interval);
                 configuration_save();
             }
         }

--- a/src/MicroOcpp/Operations/ChangeConfiguration.cpp
+++ b/src/MicroOcpp/Operations/ChangeConfiguration.cpp
@@ -21,7 +21,7 @@ const char* ChangeConfiguration::getOperationType(){
 
 void ChangeConfiguration::processReq(JsonObject payload) {
     const char *key = payload["key"] | "";
-    if (strlen(key) < 1) {
+    if (!*key) {
         errorCode = "FormationViolation";
         MOCPP_DBG_WARN("Could not read key");
         return;
@@ -35,7 +35,7 @@ void ChangeConfiguration::processReq(JsonObject payload) {
 
     const char *value = payload["value"];
 
-    std::shared_ptr<AbstractConfiguration> configuration = getConfiguration(key);
+    std::shared_ptr<Configuration> configuration = getConfigurationPublic(key);
 
     if (!configuration) {
         //configuration not found or hidden configuration
@@ -43,15 +43,9 @@ void ChangeConfiguration::processReq(JsonObject payload) {
         return;
     }
 
-    if (!configuration->permissionRemotePeerCanWrite()) {
+    if (configuration->isReadOnly()) {
         MOCPP_DBG_WARN("Trying to override readonly value");
-
-        if (configuration->permissionRemotePeerCanRead()) {
-            readOnly = true;
-        } else {
-            //can neither read nor write -> hidden config
-            notSupported = true;
-        }
+        readOnly = true;
         return;
     }
 
@@ -133,35 +127,25 @@ void ChangeConfiguration::processReq(JsonObject payload) {
     
     //Store (parsed) value to Config
 
-    if (!strcmp(configuration->getSerializedType(), SerializedType<int>::get()) && convertibleInt) {
-        std::shared_ptr<Configuration<int>> configurationConcrete = std::static_pointer_cast<Configuration<int>>(configuration);
-        *configurationConcrete = numInt;
-    } else if (!strcmp(configuration->getSerializedType(), SerializedType<float>::get()) && convertibleFloat) {
-        std::shared_ptr<Configuration<float>> configurationConcrete = std::static_pointer_cast<Configuration<float>>(configuration);
-        *configurationConcrete = numFloat;
-    } else if (!strcmp(configuration->getSerializedType(), SerializedType<bool>::get()) && convertibleBool) {
-        std::shared_ptr<Configuration<bool>> configurationConcrete = std::static_pointer_cast<Configuration<bool>>(configuration);
-        *configurationConcrete = numBool;
-    } else if (!strcmp(configuration->getSerializedType(), SerializedType<const char *>::get())) {
-        std::shared_ptr<Configuration<const char *>> configurationConcrete = std::static_pointer_cast<Configuration<const char *>>(configuration);
-        
+    if (configuration->getType() == TConfig::Int && convertibleInt) {
+        configuration->setInt(numInt);
+    } else if (configuration->getType() == TConfig::Bool && convertibleBool) {
+        configuration->setBool(numBool);
+    } else if (configuration->getType() == TConfig::String) {
         //string configurations can have a validator
-        auto validator = configurationConcrete->getValidator();
-        if (validator && !validator(value)) {
+        auto validator = getConfigurationValidator(key);
+        if (validator && !(*validator)(value)) {
             //validator exists and validation fails
             reject = true;
             MOCPP_DBG_WARN("validation failed for key=%s value=%s", key, value);
             return;
         }
-
-        *configurationConcrete = value;
+        configuration->setString(value);
     } else {
         reject = true;
         MOCPP_DBG_WARN("Value has incompatible type");
         return;
     }
-
-    //success
 
     if (!configuration_save()) {
         MOCPP_DBG_ERR("could not write changes to flash");
@@ -169,11 +153,9 @@ void ChangeConfiguration::processReq(JsonObject payload) {
         return;
     }
 
-    if (configuration->requiresRebootWhenChanged()) {
+    if (configuration->isRebootRequired()) {
         rebootRequired = true;
     }
-
-    //success
 }
 
 std::unique_ptr<DynamicJsonDocument> ChangeConfiguration::createConf(){

--- a/src/MicroOcpp/Operations/ChangeConfiguration.cpp
+++ b/src/MicroOcpp/Operations/ChangeConfiguration.cpp
@@ -35,7 +35,7 @@ void ChangeConfiguration::processReq(JsonObject payload) {
 
     const char *value = payload["value"];
 
-    std::shared_ptr<Configuration> configuration = getConfigurationPublic(key);
+    auto configuration = getConfigurationPublic(key);
 
     if (!configuration) {
         //configuration not found or hidden configuration

--- a/src/MicroOcpp/Operations/ChangeConfiguration.cpp
+++ b/src/MicroOcpp/Operations/ChangeConfiguration.cpp
@@ -124,7 +124,17 @@ void ChangeConfiguration::processReq(JsonObject payload) {
     } else {
         convertibleBool = false;
     }
-    
+
+    //check against optional validator
+
+    auto validator = getConfigurationValidator(key);
+    if (validator && !(*validator)(value)) {
+        //validator exists and validation fails
+        reject = true;
+        MOCPP_DBG_WARN("validation failed for key=%s value=%s", key, value);
+        return;
+    }
+
     //Store (parsed) value to Config
 
     if (configuration->getType() == TConfig::Int && convertibleInt) {
@@ -132,14 +142,6 @@ void ChangeConfiguration::processReq(JsonObject payload) {
     } else if (configuration->getType() == TConfig::Bool && convertibleBool) {
         configuration->setBool(numBool);
     } else if (configuration->getType() == TConfig::String) {
-        //string configurations can have a validator
-        auto validator = getConfigurationValidator(key);
-        if (validator && !(*validator)(value)) {
-            //validator exists and validation fails
-            reject = true;
-            MOCPP_DBG_WARN("validation failed for key=%s value=%s", key, value);
-            return;
-        }
         configuration->setString(value);
     } else {
         reject = true;

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
         //need to store ints by copied string: measure necessary capacity
         if (config->getType() == TConfig::Int) {
             char vbuf [VALUE_BUFSIZE];
-            auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config.getInt());
+            auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config->getInt());
             if (ret < 0 || ret >= VALUE_BUFSIZE) {
                 continue;
             }
@@ -104,7 +104,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
         const char *v = "";
         switch (config->getType()) {
             case TConfig::Int: {
-                auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config.getInt());
+                auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config->getInt());
                 if (ret < 0 || ret >= VALUE_BUFSIZE) {
                     MOCPP_DBG_ERR("value error");
                     continue;
@@ -112,20 +112,16 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
                 v = vbuf;
             }
             case TConfig::Bool:
-                v = config.getBool() ? "true" : "false";
+                v = config->getBool() ? "true" : "false";
                 break;
             case TConfig::String:
-                v = config.getString();
-                if (!v) {
-                    MOCPP_DBG_ERR("invalid config");
-                    continue;
-                }
+                v = config->getString();
                 break;
         }
 
         JsonObject jconfig = jsonConfigurationKey.createNestedObject();
-        jconfig["key"] = config.getKey();
-        jconfig["readonly"] = config.isReadOnly();
+        jconfig["key"] = config->getKey();
+        jconfig["readonly"] = config->isReadOnly();
         if (v == vbuf) {
             //value points to buffer on stack, needs to be copied into JSON memory pool
             jconfig["value"] = (char*) v;

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
             if (ret < 0 || ret >= VALUE_BUFSIZE) {
                 continue;
             }
-            jcapacity = ret + 1;
+            jcapacity += ret + 1;
         }
     }
 
@@ -110,6 +110,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
                     continue;
                 }
                 v = vbuf;
+                break;
             }
             case TConfig::Bool:
                 v = config->getBool() ? "true" : "false";

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
         for (auto& key : keys) {
             Configuration *res = nullptr;
             for (auto container : containers) {
-                if (res = container->getConfiguration(key.c_str()).get()) {
+                if ((res = container->getConfiguration(key.c_str()).get())) {
                     break;
                 }
             }

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -26,59 +26,120 @@ void GetConfiguration::processReq(JsonObject payload) {
 
 std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
 
-    std::unique_ptr<std::vector<std::shared_ptr<AbstractConfiguration>>> configurationKeys;
     std::vector<Configuration*> configurations;
-    std::vector<std::string> unknownKeys;
+    std::vector<const char*> unknownKeys;
 
-    if (keys.size() == 0){ //return all existing keys
-        configurationKeys = getAllConfigurations();
-    } else { //only return keys that were searched using the "key" parameter
-        configurationKeys = std::unique_ptr<std::vector<std::shared_ptr<AbstractConfiguration>>>(
-                                        new std::vector<std::shared_ptr<AbstractConfiguration>>()
-        );
-        for (size_t i = 0; i < keys.size(); i++) {
-            std::shared_ptr<AbstractConfiguration> entry = getConfiguration(keys.at(i).c_str());
-            if (entry)
-                configurationKeys->push_back(entry);
-            else
-                unknownKeys.push_back(keys.at(i).c_str());
+    auto containers = getConfigurationContainersPublic();
+
+    if (keys.empty()) {
+        //return all existing keys
+        for (auto container : containers) {
+            for (size_t i = 0; i < container->getConfigurationCount(); i++) {
+                if (!container->getConfiguration(i)->getKey()) {
+                    MOCPP_DBG_ERR("invalid config");
+                    continue;
+                }
+                configurations.push_back(container->getConfiguration(i));
+            }
+        }
+    } else {
+        //only return keys that were searched using the "key" parameter
+        for (auto& key : keys) {
+            Configuration *res = nullptr;
+            for (auto container : containers) {
+                if (res = container->getConfiguration(key.c_str())) {
+                    break;
+                }
+            }
+
+            if (res) {
+                configurations.push_back(res);
+            } else {
+                unknownKeys.push_back(key.c_str());
+            }
         }
     }
 
-    size_t capacity = JSON_OBJECT_SIZE(2); //configurationKey, unknownKey
-    std::vector<std::unique_ptr<DynamicJsonDocument>> configurationKeysJson;
+    #define VALUE_BUFSIZE 30
 
-    for (auto confKey = configurationKeys->begin(); confKey != configurationKeys->end(); confKey++) {
-        auto entry = (*confKey)->toJsonOcppMsgEntry();
-        if (entry) {
-            capacity += entry->memoryUsage();
-            configurationKeysJson.push_back(std::move(entry));
+    //capacity of the resulting document
+    size_t jcapacity = JSON_OBJECT_SIZE(2); //document root: configurationKey, unknownKey
+
+    jcapacity += JSON_ARRAY_SIZE(configurations.size()) + configurations.size() * JSON_OBJECT_SIZE(3); //configurationKey: [{"key":...},{"key":...}]
+    for (auto config : configurations) {
+        //need to store ints by copied string: measure necessary capacity
+        if (config->getType() == TConfig::Int) {
+            char vbuf [VALUE_BUFSIZE];
+            auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config.getInt());
+            if (ret < 0 || ret >= VALUE_BUFSIZE) {
+                continue;
+            }
+            jcapacity = ret + 1;
         }
     }
 
-    for (auto unknownKey = unknownKeys.begin(); unknownKey != unknownKeys.end(); unknownKey++) {
-        capacity += unknownKey->length() + 1;
+    jcapacity += JSON_ARRAY_SIZE(unknownKeys.size());
+    
+    MOCPP_DBG_DEBUG("GetConfiguration capacity: %zu", jcapacity);
+
+    std::unique_ptr<DynamicJsonDocument> doc;
+
+    if (jcapacity <= MOCPP_MAX_JSON_CAPACITY) {
+        doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(jcapacity));
     }
 
-    capacity += JSON_ARRAY_SIZE(configurationKeysJson.size())
-                + JSON_ARRAY_SIZE(unknownKeys.size());
-    
-    MOCPP_DBG_DEBUG("GetConfiguration capacity: %zu", capacity);
-    
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(capacity));
+    if (!doc || doc->capacity() < jcapacity) {
+        if (doc) {MOCPP_DBG_ERR("OOM");(void)0;}
+
+        errorCode = "InternalError";
+        errorDescription = "Query too big. Try fewer keys";
+        return nullptr;
+    }
 
     JsonObject payload = doc->to<JsonObject>();
     
     JsonArray jsonConfigurationKey = payload.createNestedArray("configurationKey");
-    for (size_t i = 0; i < configurationKeys->size(); i++) {
-        jsonConfigurationKey.add(configurationKeysJson.at(i)->as<JsonObject>());
+    for (auto config : configurations) {
+        char vbuf [VALUE_BUFSIZE];
+        const char *v = "";
+        switch (config->getType()) {
+            case TConfig::Int: {
+                auto ret = snprintf(vbuf, VALUE_BUFSIZE, "%i", config.getInt());
+                if (ret < 0 || ret >= VALUE_BUFSIZE) {
+                    MOCPP_DBG_ERR("value error");
+                    continue;
+                }
+                v = vbuf;
+            }
+            case TConfig::Bool:
+                v = config.getBool() ? "true" : "false";
+                break;
+            case TConfig::String:
+                v = config.getString();
+                if (!v) {
+                    MOCPP_DBG_ERR("invalid config");
+                    continue;
+                }
+                break;
+        }
+
+        JsonObject jconfig = jsonConfigurationKey.createNestedObject();
+        jconfig["key"] = config.getKey();
+        jconfig["readonly"] = config.isReadOnly();
+        if (v == vbuf) {
+            //value points to buffer on stack, needs to be copied into JSON memory pool
+            jconfig["value"] = (char*) v;
+        } else {
+            //value is static, no-copy mode
+            jconfig["value"] = v;
+        }
     }
 
-    if (unknownKeys.size() > 0) {
+    if (!unknownKeys.empty()) {
         JsonArray jsonUnknownKey = payload.createNestedArray("unknownKey");
-        for (auto unknownKey = unknownKeys.begin(); unknownKey != unknownKeys.end(); unknownKey++) {
-            MOCPP_DBG_DEBUG("Unknown key: %s", unknownKey->c_str())
-            jsonUnknownKey.add(*unknownKey);
+        for (auto key : unknownKeys) {
+            MOCPP_DBG_DEBUG("Unknown key: %s", key)
+            jsonUnknownKey.add(key);
         }
     }
 

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
         for (auto& key : keys) {
             Configuration *res = nullptr;
             for (auto container : containers) {
-                if (res = container->getConfiguration(key.c_str())) {
+                if (res = container->getConfiguration(key.c_str()).get()) {
                     break;
                 }
             }

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -27,6 +27,7 @@ void GetConfiguration::processReq(JsonObject payload) {
 std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
 
     std::unique_ptr<std::vector<std::shared_ptr<AbstractConfiguration>>> configurationKeys;
+    std::vector<Configuration*> configurations;
     std::vector<std::string> unknownKeys;
 
     if (keys.size() == 0){ //return all existing keys

--- a/src/MicroOcpp/Operations/GetConfiguration.h
+++ b/src/MicroOcpp/Operations/GetConfiguration.h
@@ -15,6 +15,9 @@ namespace Ocpp16 {
 class GetConfiguration : public Operation {
 private:
     std::vector<std::string> keys;
+
+    const char *errorCode {nullptr};
+    const char *errorDescription = "";
 public:
     GetConfiguration();
 
@@ -23,6 +26,9 @@ public:
     void processReq(JsonObject payload) override;
 
     std::unique_ptr<DynamicJsonDocument> createConf() override;
+
+    const char *getErrorCode() override {return errorCode;}
+    const char *getErrorDescription() override {return errorDescription;}
 
 };
 

--- a/src/MicroOcpp/Operations/ReserveNow.cpp
+++ b/src/MicroOcpp/Operations/ReserveNow.cpp
@@ -52,8 +52,8 @@ void ReserveNow::processReq(JsonObject payload) {
             return;
         }
 
-        auto reserveConnectorZeroSupported = declareConfiguration<bool>("ReserveConnectorZeroSupported", true, CONFIGURATION_VOLATILE);
-        if (connectorId == 0 && (!reserveConnectorZeroSupported || !*reserveConnectorZeroSupported)) {
+        auto reserveConnectorZeroSupportedBool = declareConfiguration<bool>("ReserveConnectorZeroSupported", true, CONFIGURATION_VOLATILE);
+        if (connectorId == 0 && (!reserveConnectorZeroSupportedBool || !reserveConnectorZeroSupportedBool->getBool())) {
             reservationStatus = "Rejected";
             return;
         }

--- a/tests/Api.cpp
+++ b/tests/Api.cpp
@@ -8,7 +8,7 @@
 #include "./helpers/testHelper.h"
 
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
-#define SCPROFILE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]";
+#define SCPROFILE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
 
 TEST_CASE( "C++ API test" ) {
 
@@ -84,8 +84,7 @@ TEST_CASE( "C++ API test" ) {
         auto MeterValuesSampledData = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
         *MeterValuesSampledData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered";
 
-        std::string out = SCPROFILE;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE, strlen(SCPROFILE));
 
         //run tx management
 
@@ -256,8 +255,7 @@ TEST_CASE( "C API test" ) {
         auto MeterValuesSampledData = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
         *MeterValuesSampledData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered";
 
-        std::string out = SCPROFILE;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE, strlen(SCPROFILE));
 
         //run tx management
 

--- a/tests/Api.cpp
+++ b/tests/Api.cpp
@@ -11,6 +11,7 @@
 #define SCPROFILE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
 
 TEST_CASE( "C++ API test" ) {
+    printf("\nRun %s\n",  "C++ API test");
 
     //initialize Context with dummy socket
     MicroOcpp::LoopbackConnection loopback;
@@ -81,8 +82,8 @@ TEST_CASE( "C++ API test" ) {
 
         //set configuration which uses all Inputs and Outputs
 
-        auto MeterValuesSampledData = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered";
+        auto MeterValuesSampledDataString = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
+        MeterValuesSampledDataString->setString("Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered");
 
         loopback.sendTXT(SCPROFILE, strlen(SCPROFILE));
 
@@ -252,8 +253,8 @@ TEST_CASE( "C API test" ) {
 
         //set configuration which uses all Inputs and Outputs
 
-        auto MeterValuesSampledData = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered";
+        auto MeterValuesSampledDataString = MicroOcpp::declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
+        MeterValuesSampledDataString->setString("Energy.Active.Import.Register,Power.Active.Import,Current.Import,Current.Offered");
 
         loopback.sendTXT(SCPROFILE, strlen(SCPROFILE));
 

--- a/tests/ChargingSessions.cpp
+++ b/tests/ChargingSessions.cpp
@@ -16,6 +16,7 @@ using namespace MicroOcpp;
 
 
 TEST_CASE( "Charging sessions" ) {
+    printf("\nRun %s\n",  "Charging sessions");
 
     //initialize Context with dummy socket
     LoopbackConnection loopback;
@@ -26,10 +27,10 @@ TEST_CASE( "Charging sessions" ) {
 
     mocpp_set_timer(custom_timer_cb);
 
-    auto connectionTimeOut = declareConfiguration<int>("ConnectionTimeOut", 30, CONFIGURATION_FN);
-        *connectionTimeOut = 30;
-    auto minimumStatusDuration = declareConfiguration<int>("MinimumStatusDuration", 0, CONFIGURATION_FN);
-        *minimumStatusDuration = 0;
+    auto connectionTimeOutInt = declareConfiguration<int>("ConnectionTimeOut", 30, CONFIGURATION_FN);
+    connectionTimeOutInt->setInt(30);
+    auto minimumStatusDurationInt = declareConfiguration<int>("MinimumStatusDuration", 0, CONFIGURATION_FN);
+    minimumStatusDurationInt->setInt(0);
     
     std::array<const char*, 2> expectedSN {"Available", "Available"};
     std::array<bool, 2> checkedSN {false, false};
@@ -118,7 +119,7 @@ TEST_CASE( "Charging sessions" ) {
 
             checkedSN[1] = false;
             expectedSN[1] = "Available";
-            mtime += *connectionTimeOut * 1000;
+            mtime += connectionTimeOutInt->getInt() * 1000;
             loop();
             REQUIRE(checkedSN[1]);
         }
@@ -184,7 +185,7 @@ TEST_CASE( "Charging sessions" ) {
         loopback.setConnected(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
-        *declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN) = true;
+        declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
         configuration_save();
 
         loop();
@@ -245,7 +246,7 @@ TEST_CASE( "Charging sessions" ) {
         loopback.setConnected(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
-        *declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN) = true;
+        declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
         configuration_save();
 
         loop();
@@ -259,7 +260,7 @@ TEST_CASE( "Charging sessions" ) {
 
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
-        *declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN) = true;
+        declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
         configuration_save();
 
         bool checkProcessed = false;
@@ -296,7 +297,7 @@ TEST_CASE( "Charging sessions" ) {
         loopback.setConnected(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
-        *declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN) = true;
+        declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
         configuration_save();
 
         loop();
@@ -313,7 +314,7 @@ TEST_CASE( "Charging sessions" ) {
 
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
-        *declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN) = true;
+        declareConfiguration<bool>(MOCPP_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
         configuration_save();
 
         bool checkProcessed = false;

--- a/tests/Configuration.cpp
+++ b/tests/Configuration.cpp
@@ -1,0 +1,510 @@
+#include <MicroOcpp.h>
+#include <MicroOcpp/Core/Connection.h>
+#include "./catch2/catch.hpp"
+#include "./helpers/testHelper.h"
+
+#include <MicroOcpp/Core/FilesystemAdapter.h>
+#include <MicroOcpp/Core/FilesystemUtils.h>
+#include <MicroOcpp/Core/Configuration.h>
+#include <MicroOcpp/Core/ConfigurationContainer.h>
+#include <MicroOcpp/Core/ConfigurationContainerFlash.h>
+
+#include <MicroOcpp/Core/Context.h>
+#include <MicroOcpp/Operations/CustomOperation.h>
+#include <MicroOcpp/Core/SimpleRequestFactory.h>
+
+using namespace MicroOcpp;
+
+#define GET_CONFIG_ALL "[2,\"test-msg\",\"GetConfiguration\",{}]"
+#define KNOWN_KEY "__ExistingKey"
+#define UNKOWN_KEY "__UnknownKey"
+#define GET_CONFIG_KNOWN_UNKOWN "[2,\"test-mst\",\"GetConfiguration\",{\"key\":[\"" KNOWN_KEY "\",\"" UNKOWN_KEY "\"]}]"
+
+TEST_CASE( "Configuration" ) {
+    printf("\nRun %s\n",  "Configuration");
+
+    //clean state
+    auto filesystem = makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail);
+    MOCPP_DBG_DEBUG("remove all");
+    FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
+
+    LoopbackConnection loopback; //initialize Context with dummy socket
+
+    mocpp_set_timer(custom_timer_cb);
+
+    SECTION("Basic container operations"){
+        std::unique_ptr<ConfigurationContainer> container;
+
+        SECTION("Volatile storage") {
+            container = makeConfigurationContainerVolatile(CONFIGURATION_VOLATILE "/volatile1", true);
+        }
+
+        SECTION("Persistent storage") {
+            container = makeConfigurationContainerFlash(filesystem, MOCPP_FILENAME_PREFIX "persistent1.jsn", true);
+        }
+
+        //check emptyness
+        REQUIRE( container->getConfigurationCount() == 0 );
+
+        //add first config, fetch by index
+        auto configFirst = container->createConfiguration(TConfig::Int, "cFirst");
+        REQUIRE( container->getConfigurationCount() == 1 );
+        REQUIRE( container->getConfiguration((size_t) 0) == configFirst.get());
+
+        //add one config of each type
+        auto cInt = container->createConfiguration(TConfig::Int, "cInt");
+        auto cBool = container->createConfiguration(TConfig::Bool, "cBool");
+        auto cString = container->createConfiguration(TConfig::String, "cString");
+        
+        REQUIRE( container->getConfigurationCount() == 4 );
+
+        //fetch config by key
+        REQUIRE( container->getConfiguration(cBool->getKey()) == cBool);
+
+        //remove config
+        container->removeConfiguration(cBool.get());
+        REQUIRE( container->getConfigurationCount() == 3 );
+        REQUIRE( container->getConfiguration(cBool->getKey()) == nullptr);
+
+        //clean container
+        container->removeConfiguration(container->getConfiguration((size_t) 0));
+        container->removeConfiguration(container->getConfiguration((size_t) 0));
+        container->removeConfiguration(container->getConfiguration((size_t) 0));
+        REQUIRE( container->getConfigurationCount() == 0 );
+    }
+
+    SECTION("Persistency on filesystem") {
+
+        auto container = makeConfigurationContainerFlash(filesystem, MOCPP_FILENAME_PREFIX "persistent1.jsn", true);
+
+        //trivial load call
+        REQUIRE( container->load() );
+        REQUIRE( container->getConfigurationCount() == 0 );
+
+        //add config, store, load again
+        auto cString = container->createConfiguration(TConfig::String, "cString");
+        cString->setString("mValue");
+
+        REQUIRE( container->save() ); //store
+
+        container.reset(); //destroy
+
+        //...load again
+        auto container2 = makeConfigurationContainerFlash(filesystem, MOCPP_FILENAME_PREFIX "persistent1.jsn", true);
+        REQUIRE( container2->getConfigurationCount() == 0 );
+        REQUIRE( container2->load() );
+        REQUIRE( container2->getConfigurationCount() == 1 );
+
+        auto cString2 = container2->getConfiguration("cString");
+        REQUIRE( cString2 != nullptr );
+        REQUIRE( !strcmp(cString2->getString(), "mValue") );
+    }
+
+    SECTION("Configuration API") {
+
+        //declare configs
+        REQUIRE( configuration_init(filesystem) );
+        auto cInt = declareConfiguration<int>("cInt", 42);
+        REQUIRE( cInt != nullptr );
+        declareConfiguration<bool>("cBool", true);
+        declareConfiguration<const char*>("cString", "mValue");
+
+        //fetch config
+        REQUIRE( getConfigurationPublic("cInt")->getInt() == 42 );
+
+        //store, destroy, reload
+        REQUIRE( configuration_save() );
+        cInt.reset();
+        configuration_deinit();
+        REQUIRE( getConfigurationPublic("cInt") == nullptr);
+
+        REQUIRE( configuration_init(filesystem) ); //reload
+
+        //fetch configs (declare with different factory default - should remain at original value)
+        auto cInt2 = declareConfiguration<int>("cInt", -1);
+        auto cBool2 = declareConfiguration<bool>("cBool", false);
+        auto cString2 = declareConfiguration<const char*>("cString", "no effect");
+        REQUIRE( configuration_load() ); //load config objects with stored values
+
+        //check load result
+        REQUIRE( cInt2->getInt() == 42 );
+        REQUIRE( cBool2->getBool() == true );
+        REQUIRE( !strcmp(cString2->getString(), "mValue") );
+
+        //declare config twice
+        auto cInt3 = declareConfiguration<int>("cInt", -1);
+        REQUIRE( cInt3 == cInt2 );
+
+        //declare config twice but in different container
+        auto cInt4 = declareConfiguration<int>("cInt", -1, CONFIGURATION_VOLATILE);
+        REQUIRE( cInt4 == cInt2 );
+
+        //declare config twice but with conflicting type (will supersede old type because to simplify FW upgrades)
+        auto cNewType = declareConfiguration<const char*>("cInt", "mValue2");
+        REQUIRE( cNewType != cInt2 );
+        REQUIRE( !strcmp(cNewType->getString(), "mValue2") );
+        
+        //store, destroy, reload
+        REQUIRE( configuration_save() );
+        configuration_deinit();
+        REQUIRE( getConfigurationPublic("cInt") == nullptr);
+        REQUIRE( configuration_init(filesystem) ); //reload
+        auto cNewType2 = declareConfiguration<const char*>("cInt", "no effect");
+        REQUIRE( configuration_load() );
+        REQUIRE( !strcmp(cNewType2->getString(), "mValue2") );
+
+        //get config before declared (container needs to be declared already at this point)
+        auto cString3 = getConfigurationPublic("cString");
+        REQUIRE( !strcmp(cString3->getString(), "mValue") );
+        configuration_deinit();
+
+        //value needs to outlive container
+        configuration_init(filesystem);
+        auto cString4 = declareConfiguration<const char *>("cString2", "mValue3");
+        configuration_deinit();
+        REQUIRE( !strcmp(cString4->getString(), "mValue3") );
+
+        MOCPP_DBG_DEBUG("remove all");
+        FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
+
+        //config accessibility / permissions
+        configuration_init(filesystem);
+        bool readonly = false;
+        bool rebootRequired = false;
+        bool isPublic = true;
+        auto cInt6 = declareConfiguration<int>("cInt", 42, CONFIGURATION_FN, readonly, rebootRequired, isPublic);
+        REQUIRE( !cInt6->isReadOnly() );
+        REQUIRE( !cInt6->isRebootRequired() );
+        REQUIRE( getConfigurationPublic("cInt") );
+
+        //revoke permissions
+        readonly = true;
+        rebootRequired = true;
+        declareConfiguration<int>("cInt", 42, CONFIGURATION_FN, readonly, rebootRequired, isPublic);
+        REQUIRE( cInt6->isReadOnly() );
+        REQUIRE( cInt6->isRebootRequired() );
+
+        //revoked permissions cannot be reverted
+        readonly = false;
+        rebootRequired = false;
+        auto cInt7 = declareConfiguration<int>("cInt", 42, CONFIGURATION_FN, readonly, rebootRequired, isPublic);
+        REQUIRE( cInt7->isReadOnly() );
+        REQUIRE( cInt7->isRebootRequired() );
+
+        //accessibility cannot be changed after first initialization
+        isPublic = false;
+        declareConfiguration<int>("cInt", 42, CONFIGURATION_FN, false, rebootRequired, isPublic);
+        declareConfiguration<int>("cInt2", 42, CONFIGURATION_FN, false, rebootRequired, isPublic);
+        REQUIRE( getConfigurationPublic("cInt") );
+        REQUIRE( getConfigurationPublic("cInt2") );
+
+        //create config in hidden container
+        isPublic = false;
+        auto cHidden = declareConfiguration<int>("cHidden", 42, MOCPP_FILENAME_PREFIX "hidden.jsn", false, false, isPublic);
+        REQUIRE( !getConfigurationPublic("cHidden") );
+        
+        //hidden container cannot be fetched
+        auto configsPublic = getConfigurationContainersPublic();
+        REQUIRE( configsPublic.size() == 1 );
+
+        configuration_deinit();
+    }
+
+    SECTION("ContainerFlash memory optimization") {
+
+        //key storage optimization: the static key provided by declareConfiguration is preferred. If
+        //no static key is available for the config (if the config is loaded from flash without being
+        //declared before), then a key on the heap is allocated. If the config is later allocated,
+        //the heap-key is replaced by the static key
+
+        const char *key_static = "cInt";
+
+        configuration_init(filesystem);
+        auto cInt = declareConfiguration<int>(key_static, 42);
+        configuration_save();
+        configuration_deinit();
+
+        configuration_init(filesystem);
+        declareConfiguration<int>("dummy", 23); //dummy config to declare CONFIGURATION_FN
+        configuration_load();
+        const char *key_heap = getConfigurationPublic(key_static)->getKey();
+        REQUIRE( key_heap != key_static );
+        
+        declareConfiguration<int>(key_static, 42); //replace heap key with static key here
+
+        const char *key_replaced = getConfigurationPublic(key_static)->getKey();
+        REQUIRE( key_replaced == key_static );
+
+        configuration_deinit();
+    }
+
+    SECTION("Main lib integration") {
+
+        //basic lifecycle
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        REQUIRE( getConfigurationPublic("ConnectionTimeOut") );
+        REQUIRE( !getConfigurationContainersPublic().empty() );
+        mocpp_deinitialize();
+        REQUIRE( !getConfigurationPublic("ConnectionTimeOut") );
+        REQUIRE( getConfigurationContainersPublic().empty() );
+
+        //modify standard config ConnectionTimeOut. This config is not modified by the main lib during normal initialization / deinitialization
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        auto config = getConfigurationPublic("ConnectionTimeOut");
+
+        config->setInt(1234); //update
+        configuration_save(); //write back
+
+        mocpp_deinitialize();
+
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        REQUIRE( getConfigurationPublic("ConnectionTimeOut")->getInt() == 1234 );
+
+        mocpp_deinitialize();
+    }
+
+    SECTION("GetConfiguration") {
+
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        loop();
+
+        declareConfiguration<int>(KNOWN_KEY, 1234, MOCPP_FILENAME_PREFIX "persistent1.jsn", false);
+
+        bool checkProcessed = false;
+
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "GetConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
+                    auto payload = doc->to<JsonObject>();
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    JsonArray configurationKey = payload["configurationKey"];
+
+                    bool foundCustomConfig = false;
+                    bool foundStandardConfig = false;
+                    for (JsonObject keyvalue : configurationKey) {
+                        MOCPP_DBG_DEBUG("key %s", keyvalue["key"] | "_Undefined");
+                        if (!strcmp(keyvalue["key"] | "_Undefined", KNOWN_KEY)) {
+                            foundCustomConfig = true;
+                            REQUIRE( (keyvalue["readonly"] | true) == false );
+                            REQUIRE( !strcmp(keyvalue["value"] | "_Undefined", "1234") );
+                        } else if (!strcmp(keyvalue["key"] | "_Undefined", "ConnectionTimeOut")) {
+                            foundStandardConfig = true;
+                        }
+                    }
+
+                    REQUIRE( foundCustomConfig );
+                    REQUIRE( foundStandardConfig );
+                }
+        )));
+
+        loop();
+
+        REQUIRE(checkProcessed);
+
+        checkProcessed = false;
+
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "GetConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1) + JSON_ARRAY_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    auto key = payload.createNestedArray("key");
+                    key.add(KNOWN_KEY);
+                    key.add(UNKOWN_KEY);
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    JsonArray configurationKey = payload["configurationKey"];
+
+                    bool foundCustomConfig = false;
+                    for (JsonObject keyvalue : configurationKey) {
+                        if (!strcmp(keyvalue["key"] | "_Undefined", KNOWN_KEY)) {
+                            foundCustomConfig = true;
+                            break;
+                        }
+                    }
+                    REQUIRE( foundCustomConfig );
+
+                    JsonArray unknownKey = payload["unknownKey"];
+
+                    bool foundUnkownKey = false;
+                    for (const char *key : unknownKey) {
+                        if (!strcmp(key, UNKOWN_KEY)) {
+                            foundUnkownKey = true;
+                        }
+                    }
+
+                    REQUIRE( foundUnkownKey );
+                }
+        )));
+
+        loop();
+
+        REQUIRE(checkProcessed);
+
+        mocpp_deinitialize();
+    }
+
+    SECTION("ChangeConfiguration") {
+
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        loop();
+
+        declareConfiguration<int>(KNOWN_KEY, 0, MOCPP_FILENAME_PREFIX "persistent1.jsn", false);
+
+        //update existing config
+        bool checkProcessed = false;
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "ChangeConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["key"] = KNOWN_KEY;
+                    payload["value"] = "1234";
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    REQUIRE( !strcmp(payload["status"] | "_Undefined", "Accepted") );
+                }
+        )));
+        loop();
+        REQUIRE(checkProcessed);
+        REQUIRE( getConfigurationPublic(KNOWN_KEY)->getInt() == 1234 );
+
+        //try to update not existing key
+        checkProcessed = false;
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "ChangeConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["key"] = UNKOWN_KEY;
+                    payload["value"] = "no effect";
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    REQUIRE( !strcmp(payload["status"] | "_Undefined", "NotSupported") );
+                }
+        )));
+        loop();
+        REQUIRE( checkProcessed );
+
+        //try to update config with malformatted value
+        checkProcessed = false;
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "ChangeConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["key"] = KNOWN_KEY;
+                    payload["value"] = "not convertible to int";
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    REQUIRE( !strcmp(payload["status"] | "_Undefined", "Rejected") );
+                }
+        )));
+        loop();
+        REQUIRE( checkProcessed );
+
+        //try to update config with value validation
+        //value is valid if it begins with 1
+        registerConfigurationValidator(KNOWN_KEY, [] (const char *v) {
+            return v[0] == '1';
+        });
+
+        //validation success
+        checkProcessed = false;
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "ChangeConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["key"] = KNOWN_KEY;
+                    payload["value"] = "100234";
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    REQUIRE( !strcmp(payload["status"] | "_Undefined", "Accepted") );
+                }
+        )));
+        loop();
+        REQUIRE( checkProcessed );
+        REQUIRE( getConfigurationPublic(KNOWN_KEY)->getInt() == 100234 );
+
+        //validation failure
+        checkProcessed = false;
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "ChangeConfiguration",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(2)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["key"] = KNOWN_KEY;
+                    payload["value"] = "4321";
+                    return doc;},
+                [&checkProcessed] (JsonObject payload) {
+                    //receive conf
+                    checkProcessed = true;
+
+                    REQUIRE( !strcmp(payload["status"] | "_Undefined", "Rejected") );
+                }
+        )));
+        loop();
+        REQUIRE( checkProcessed );
+        REQUIRE( getConfigurationPublic(KNOWN_KEY)->getInt() == 100234 ); //keep old value
+
+        mocpp_deinitialize();
+    }
+
+    SECTION("Define factory defaults for standard configs") {
+
+        //set factory default for standard config ConnectionTimeOut
+        configuration_init(filesystem);
+        auto factoryConnectionTimeOut = declareConfiguration<int>("ConnectionTimeOut", 1234, MOCPP_FILENAME_PREFIX "factory.jsn");
+
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+
+        auto connectionTimeout2 = declareConfiguration<int>("ConnectionTimeOut", 4321);
+        REQUIRE( connectionTimeout2->getInt() == 1234 );
+        REQUIRE( connectionTimeout2 == factoryConnectionTimeOut );
+
+        configuration_save();
+        mocpp_deinitialize();
+
+        //this time, factory default is not given (will lead to duplicates, should be considered in sanitization)
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        REQUIRE( getConfigurationPublic("ConnectionTimeOut")->getInt() != 1234 );
+        mocpp_deinitialize();
+
+        //provide factory default again
+        configuration_init(filesystem);
+        declareConfiguration<int>("ConnectionTimeOut", 4321, MOCPP_FILENAME_PREFIX "factory.jsn");
+        mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
+        REQUIRE( getConfigurationPublic("ConnectionTimeOut")->getInt() == 1234 );
+        mocpp_deinitialize();
+
+    }
+
+}

--- a/tests/ConfigurationBehavior.cpp
+++ b/tests/ConfigurationBehavior.cpp
@@ -183,8 +183,8 @@ TEST_CASE( "Configuration Behavior" ) {
         *localAuthListEnabled = true;
 
         //define local auth list with entry local-idtag
-        std::string localListMsg = "[2,\"testmsg-01\",\"SendLocalList\",{\"listVersion\":1,\"localAuthorizationList\":[{\"idTag\":\"local-idtag\",\"idTagInfo\":{\"status\":\"Accepted\"}}],\"updateType\":\"Full\"}]";
-        loopback.sendTXT(localListMsg);
+        const char *localListMsg = "[2,\"testmsg-01\",\"SendLocalList\",{\"listVersion\":1,\"localAuthorizationList\":[{\"idTag\":\"local-idtag\",\"idTagInfo\":{\"status\":\"Accepted\"}}],\"updateType\":\"Full\"}]";
+        loopback.sendTXT(localListMsg, strlen(localListMsg));
         loop();
 
         loopback.setConnected(false); //connection loss

--- a/tests/ConfigurationBehavior.cpp
+++ b/tests/ConfigurationBehavior.cpp
@@ -46,9 +46,10 @@ public:
 };
 
 TEST_CASE( "Configuration Behavior" ) {
+    printf("\nRun %s\n",  "Configuration Behavior");
 
     //clean state
-    auto filesystem = makeDefaultFilesystemAdapter(MicroOcpp::FilesystemOpt::Use_Mount_FormatOnFail);
+    auto filesystem = makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail);
     MOCPP_DBG_DEBUG("remove all");
     FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
 
@@ -70,10 +71,10 @@ TEST_CASE( "Configuration Behavior" ) {
         startTransaction("mIdTag");
         loop();
 
-        auto config = declareConfiguration<bool>("StopTransactionOnEVSideDisconnect", true);
+        auto configBool = declareConfiguration<bool>("StopTransactionOnEVSideDisconnect", true);
 
         SECTION("set true") {
-            *config = true;
+            configBool->setBool(true);
 
             setConnectorPluggedInput([] () {return false;});
             loop();
@@ -82,7 +83,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         SECTION("set false") {
-            *config = false;
+            configBool->setBool(false);
 
             setConnectorPluggedInput([] () {return false;});
             loop();
@@ -97,13 +98,13 @@ TEST_CASE( "Configuration Behavior" ) {
     }
 
     SECTION("StopTransactionOnInvalidId") {
-        auto config = declareConfiguration<bool>("StopTransactionOnInvalidId", true);
+        auto configBool = declareConfiguration<bool>("StopTransactionOnInvalidId", true);
 
         checkMsg.registerOperation("Authorize", [] () {return new CustomAuthorize("Invalid");});
         checkMsg.registerOperation("StartTransaction", [] () {return new CustomStartTransaction("Invalid");});
 
         SECTION("set true") {
-            *config = true;
+            configBool->setBool(true);
 
             beginTransaction("mIdTag");
             loop();
@@ -117,7 +118,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         SECTION("set false") {
-            *config = false;
+            configBool->setBool(false);
 
             beginTransaction("mIdTag");
             loop();
@@ -137,14 +138,14 @@ TEST_CASE( "Configuration Behavior" ) {
     }
 
     SECTION("AllowOfflineTxForUnknownId") {
-        auto config = declareConfiguration<bool>("AllowOfflineTxForUnknownId", true);
-        auto authorizationTimeout = MicroOcpp::declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "AuthorizationTimeout", 1);
-        *authorizationTimeout = 1; //try normal Authorize for 1s, then enter offline mode
+        auto configBool = declareConfiguration<bool>("AllowOfflineTxForUnknownId", true);
+        auto authorizationTimeoutInt = declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "AuthorizationTimeout", 1);
+        authorizationTimeoutInt->setInt(1); //try normal Authorize for 1s, then enter offline mode
 
         loopback.setConnected(false); //connection loss
 
         SECTION("set true") {
-            *config = true;
+            configBool->setBool(true);
 
             beginTransaction("mIdTag");
             loop();
@@ -158,7 +159,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         SECTION("set false") {
-            *config = false;
+            configBool->setBool(false);
 
             beginTransaction("mIdTag");
             REQUIRE(connector->getStatus() == ChargePointStatus::Preparing);
@@ -173,14 +174,12 @@ TEST_CASE( "Configuration Behavior" ) {
     }
 
     SECTION("LocalPreAuthorize") {
-        auto config = declareConfiguration<bool>("LocalPreAuthorize", true);
-        auto authorizationTimeout = MicroOcpp::declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "AuthorizationTimeout", 20);
-        *authorizationTimeout = 300; //try normal Authorize for 5 minutes
+        auto configBool = declareConfiguration<bool>("LocalPreAuthorize", true);
+        auto authorizationTimeoutInt = declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "AuthorizationTimeout", 20);
+        authorizationTimeoutInt->setInt(300); //try normal Authorize for 5 minutes
 
-        auto localAuthorizeOffline = declareConfiguration<bool>("LocalAuthorizeOffline", true, CONFIGURATION_FN, true, true, true, false);
-        *localAuthorizeOffline = true;
-        auto localAuthListEnabled = declareConfiguration<bool>("LocalAuthListEnabled", true, CONFIGURATION_FN, true, true, true, false);
-        *localAuthListEnabled = true;
+        declareConfiguration<bool>("LocalAuthorizeOffline", true)->setBool(true);
+        declareConfiguration<bool>("LocalAuthListEnabled", true)->setBool(true);
 
         //define local auth list with entry local-idtag
         const char *localListMsg = "[2,\"testmsg-01\",\"SendLocalList\",{\"listVersion\":1,\"localAuthorizationList\":[{\"idTag\":\"local-idtag\",\"idTagInfo\":{\"status\":\"Accepted\"}}],\"updateType\":\"Full\"}]";
@@ -190,7 +189,7 @@ TEST_CASE( "Configuration Behavior" ) {
         loopback.setConnected(false); //connection loss
 
         SECTION("set true - accepted idtag") {
-            *config = true;
+            configBool->setBool(true);
 
             beginTransaction("local-idtag");
             loop();
@@ -199,7 +198,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         SECTION("set false") {
-            *config = false;
+            configBool->setBool(false);
 
             beginTransaction("local-idtag");
             loop();

--- a/tests/Metering.cpp
+++ b/tests/Metering.cpp
@@ -12,6 +12,7 @@
 using namespace MicroOcpp;
 
 TEST_CASE("Metering") {
+    printf("\nRun %s\n",  "Metering");
 
     //initialize Context with dummy socket
     LoopbackConnection loopback;
@@ -36,8 +37,8 @@ TEST_CASE("Metering") {
             return 0;
         }, "Voltage");
 
-        auto MeterValuesSampledData = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "";
+        auto MeterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData","");
+        MeterValuesSampledDataString->setString("");
 
         bool checkProcessed = false;
 
@@ -58,7 +59,7 @@ TEST_CASE("Metering") {
         loop();
 
         REQUIRE(checkProcessed);
-        REQUIRE(!strcmp((const char*) *MeterValuesSampledData, ""));
+        REQUIRE(!strcmp(MeterValuesSampledDataString->getString(), ""));
 
         checkProcessed = false;
 
@@ -78,7 +79,7 @@ TEST_CASE("Metering") {
         loop();
 
         REQUIRE(checkProcessed);
-        REQUIRE(!strcmp((const char*) *MeterValuesSampledData, "Voltage,Energy.Active.Import.Register"));
+        REQUIRE(!strcmp(MeterValuesSampledDataString->getString(), "Voltage,Energy.Active.Import.Register"));
     }
 
     SECTION("Capture Periodic data") {
@@ -91,14 +92,14 @@ TEST_CASE("Metering") {
             return getOcppContext()->getModel().getClock().now() - base;
         }, "Energy.Active.Import.Register");
 
-        auto MeterValuesSampledData = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "Energy.Active.Import.Register";
+        auto MeterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
+        MeterValuesSampledDataString->setString("Energy.Active.Import.Register");
 
-        auto MeterValueSampleInterval = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
-        *MeterValueSampleInterval = 10;
+        auto MeterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
+        MeterValueSampleIntervalInt->setInt(10);
 
-        auto MeterValueCacheSize = declareConfiguration(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0, CONFIGURATION_FN);
-        *MeterValueCacheSize = 2;
+        auto MeterValueCacheSizeInt = declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0);
+        MeterValueCacheSizeInt->setInt(2);
 
         bool checkProcessed = false;
 
@@ -150,17 +151,17 @@ TEST_CASE("Metering") {
         }, "Energy.Active.Import.Register");
 
         //disablee sampled data
-        auto MeterValueSampleInterval = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
-        *MeterValueSampleInterval = 0;
+        auto MeterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
+        MeterValueSampleIntervalInt->setInt(0);
 
-        auto ClockAlignedDataInterval  = declareConfiguration("ClockAlignedDataInterval", 0, CONFIGURATION_FN);
-        *ClockAlignedDataInterval = 900;
+        auto ClockAlignedDataIntervalInt  = declareConfiguration<int>("ClockAlignedDataInterval", 0, CONFIGURATION_FN);
+        ClockAlignedDataIntervalInt->setInt(900);
 
-        auto MeterValuesAlignedData = declareConfiguration<const char*>("MeterValuesAlignedData", "", CONFIGURATION_FN);
-        *MeterValuesAlignedData = "Energy.Active.Import.Register";
+        auto MeterValuesAlignedDataString = declareConfiguration<const char*>("MeterValuesAlignedData", "", CONFIGURATION_FN);
+        MeterValuesAlignedDataString->setString("Energy.Active.Import.Register");
 
-        auto MeterValueCacheSize = declareConfiguration(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0, CONFIGURATION_FN);
-        *MeterValueCacheSize = 2;
+        auto MeterValueCacheSizeInt = declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0, CONFIGURATION_FN);
+        MeterValueCacheSizeInt->setInt(2);
 
         bool checkProcessed = false;
 
@@ -212,11 +213,11 @@ TEST_CASE("Metering") {
             return getOcppContext()->getModel().getClock().now() - base;
         }, "Energy.Active.Import.Register");
 
-        auto MeterValueSampleInterval = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
-        *MeterValueSampleInterval = 10;
+        auto MeterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
+        MeterValueSampleIntervalInt->setInt(10);
 
-        auto StopTxnSampledData = declareConfiguration<const char*>("StopTxnSampledData", "", CONFIGURATION_FN);
-        *StopTxnSampledData = "Energy.Active.Import.Register";
+        auto StopTxnSampledDataString = declareConfiguration<const char*>("StopTxnSampledData", "", CONFIGURATION_FN);
+        StopTxnSampledDataString->setString("Energy.Active.Import.Register");
 
         loop();
 
@@ -278,11 +279,11 @@ TEST_CASE("Metering") {
             nullptr,
             connectorId);
 
-        auto MeterValuesSampledData = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "Power.Active.Import";
+        auto MeterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
+        MeterValuesSampledDataString->setString("Power.Active.Import");
 
-        auto MeterValueSampleInterval = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
-        *MeterValueSampleInterval = 10;
+        auto MeterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
+        MeterValueSampleIntervalInt->setInt(10);
 
         bool checkProcessed = false;
 
@@ -315,14 +316,14 @@ TEST_CASE("Metering") {
             return 3600;
         }, "Power.Active.Import");
 
-        auto MeterValuesSampledData = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
-        *MeterValuesSampledData = "Energy.Active.Import.Register";
+        auto MeterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData","", CONFIGURATION_FN);
+        MeterValuesSampledDataString->setString("Energy.Active.Import.Register");
 
-        auto MeterValueSampleInterval = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
-        *MeterValueSampleInterval = 10;
+        auto MeterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval",0, CONFIGURATION_FN);
+        MeterValueSampleIntervalInt->setInt(10);
 
-        auto MeterValueCacheSize = declareConfiguration(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0, CONFIGURATION_FN);
-        *MeterValueCacheSize = 10;
+        auto MeterValueCacheSizeInt = declareConfiguration<int>(MOCPP_CONFIG_EXT_PREFIX "MeterValueCacheSize", 0, CONFIGURATION_FN);
+        MeterValueCacheSizeInt->setInt(10);
 
         bool checkProcessed = false;
 
@@ -353,7 +354,7 @@ TEST_CASE("Metering") {
 
         loop();
 
-        *MeterValuesSampledData = "Power.Active.Import";
+        MeterValuesSampledDataString->setString("Power.Active.Import");
 
         mtime = trackMtime + 20 * 1000;
 

--- a/tests/SmartCharging.cpp
+++ b/tests/SmartCharging.cpp
@@ -11,27 +11,27 @@
 
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
 
-#define SCPROFILE_0                            "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]";
-#define SCPROFILE_0_ALT_SAME_ID                "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":1,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]";
-#define SCPROFILE_0_ALT_SAME_STACKEVEL_PURPOSE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":1,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]";
+#define SCPROFILE_0                            "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]"
+#define SCPROFILE_0_ALT_SAME_ID                "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":1,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]"
+#define SCPROFILE_0_ALT_SAME_STACKEVEL_PURPOSE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":1,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\",\"validFrom\":\"2022-06-12T00:00:00.000Z\",\"validTo\":\"2023-06-21T00:00:00.000Z\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-06-18T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":18000,\"limit\":32,\"numberPhases\":3}],\"minChargingRate\":6}}}]"
 
-#define SCPROFILE_1_ABSOLUTE_LIMIT_16A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":1,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_1_ABSOLUTE_LIMIT_16A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":1,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_2_RELATIVE_TXDEF_24A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":2,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":24,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_2_RELATIVE_TXDEF_24A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":2,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxDefaultProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":24,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_3_TXPROF_TXID123_20A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":3,\"transactionId\":123,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":20,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_3_TXPROF_TXID123_20A         "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":1,\"csChargingProfiles\":{\"chargingProfileId\":3,\"transactionId\":123,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":20,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_4_VALID_FROM_2024_16A        "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":4,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"validFrom\":\"2024-01-01T00:00:00.000Z\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]";
-#define SCPROFILE_5_VALID_UNTIL_2022_16A       "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":5,\"stackLevel\":1,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"validTo\":  \"2022-01-01T00:00:00.000Z\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_4_VALID_FROM_2024_16A        "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":4,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"validFrom\":\"2024-01-01T00:00:00.000Z\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
+#define SCPROFILE_5_VALID_UNTIL_2022_16A       "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":5,\"stackLevel\":1,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"validTo\":  \"2022-01-01T00:00:00.000Z\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_6_MULTIPLE_PERIODS_16A_20A   "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":6,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":20,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_6_MULTIPLE_PERIODS_16A_20A   "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":6,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":20,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_7_RECURRING_DAY_2H_16A_20A   "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":7,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\", \"chargingSchedule\":{\"duration\":7200,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":20,\"numberPhases\":3}]}}}]";
-#define SCPROFILE_8_RECURRING_WEEK_2H_10A_12A  "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":8,\"stackLevel\":1,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Weekly\",\"chargingSchedule\":{\"duration\":7200,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":10,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":12,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_7_RECURRING_DAY_2H_16A_20A   "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":7,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Daily\", \"chargingSchedule\":{\"duration\":7200,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":20,\"numberPhases\":3}]}}}]"
+#define SCPROFILE_8_RECURRING_WEEK_2H_10A_12A  "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":8,\"stackLevel\":1,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Recurring\",\"recurrencyKind\":\"Weekly\",\"chargingSchedule\":{\"duration\":7200,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":10,\"numberPhases\":3},{\"startPeriod\":3600,\"limit\":12,\"numberPhases\":3}]}}}]"
 
-#define SCPROFILE_9_VIA_RMTSTARTTX_20A         "[2,\"testmsg\",\"RemoteStartTransaction\",{\"connectorId\":1,\"idTag\":\"mIdTag\",\"chargingProfile\":{\"chargingProfileId\":9,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":20,\"numberPhases\":1}]}}}]";
+#define SCPROFILE_9_VIA_RMTSTARTTX_20A         "[2,\"testmsg\",\"RemoteStartTransaction\",{\"connectorId\":1,\"idTag\":\"mIdTag\",\"chargingProfile\":{\"chargingProfileId\":9,\"stackLevel\":0,\"chargingProfilePurpose\":\"TxProfile\",\"chargingProfileKind\":\"Relative\",\"chargingSchedule\":{\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":20,\"numberPhases\":1}]}}}]"
 
-#define SCPROFILE_10_ABSOLUTE_LIMIT_5KW        "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":10,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":5000,\"numberPhases\":3}]}}}]";
+#define SCPROFILE_10_ABSOLUTE_LIMIT_5KW        "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":10,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":5000,\"numberPhases\":3}]}}}]"
 
 
 using namespace MicroOcpp;
@@ -78,8 +78,7 @@ TEST_CASE( "SmartCharging" ) {
 
         REQUIRE(count == 0);
 
-        std::string out = SCPROFILE_0;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0, strlen(SCPROFILE_0));
 
         //check if filter works by comparing the outcome of returning false and true and repeating the test
         count = 0;
@@ -109,8 +108,7 @@ TEST_CASE( "SmartCharging" ) {
 
     SECTION("Charging Profiles persistency over reboots") {
 
-        std::string out = SCPROFILE_0;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0, strlen(SCPROFILE_0));
 
         mocpp_deinitialize();
 
@@ -130,11 +128,9 @@ TEST_CASE( "SmartCharging" ) {
 
     SECTION("Set conflicting profile") {
 
-        std::string out = SCPROFILE_0;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0, strlen(SCPROFILE_0));
 
-        out = SCPROFILE_0_ALT_SAME_ID;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0_ALT_SAME_ID, strlen(SCPROFILE_0_ALT_SAME_ID));
 
         unsigned int count = 0;
         scService->clearChargingProfile([&count] (int, int, ChargingProfilePurposeType, int) {
@@ -144,11 +140,9 @@ TEST_CASE( "SmartCharging" ) {
 
         REQUIRE(count == 1);
 
-        out = SCPROFILE_0;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0, strlen(SCPROFILE_0));
 
-        out = SCPROFILE_0_ALT_SAME_STACKEVEL_PURPOSE;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_0_ALT_SAME_STACKEVEL_PURPOSE, strlen(SCPROFILE_0_ALT_SAME_STACKEVEL_PURPOSE));
 
         count = 0;
         scService->clearChargingProfile([&count] (int, int, ChargingProfilePurposeType, int) {
@@ -168,8 +162,7 @@ TEST_CASE( "SmartCharging" ) {
 
         loop();
 
-        std::string out = SCPROFILE_9_VIA_RMTSTARTTX_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_9_VIA_RMTSTARTTX_20A, strlen(SCPROFILE_9_VIA_RMTSTARTTX_20A));
 
         loop();
 
@@ -187,8 +180,7 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
 
-        std::string out = SCPROFILE_1_ABSOLUTE_LIMIT_16A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_1_ABSOLUTE_LIMIT_16A, strlen(SCPROFILE_1_ABSOLUTE_LIMIT_16A));
 
         loop();
 
@@ -202,8 +194,7 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
         
-        std::string out = SCPROFILE_2_RELATIVE_TXDEF_24A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_2_RELATIVE_TXDEF_24A, strlen(SCPROFILE_2_RELATIVE_TXDEF_24A));
 
         loop();
 
@@ -230,8 +221,7 @@ TEST_CASE( "SmartCharging" ) {
         });
         
         //send before transaction - expect rejection
-        std::string out = SCPROFILE_3_TXPROF_TXID123_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_3_TXPROF_TXID123_20A, strlen(SCPROFILE_3_TXPROF_TXID123_20A));
 
         unsigned int count = 0;
         scService->clearChargingProfile([&count] (int, int, ChargingProfilePurposeType, int) {
@@ -245,8 +235,7 @@ TEST_CASE( "SmartCharging" ) {
         beginTransaction_authorized("mIdTag");
 
         //send during transaction but wrong txId - expect rejection
-        out = SCPROFILE_3_TXPROF_TXID123_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_3_TXPROF_TXID123_20A, strlen(SCPROFILE_3_TXPROF_TXID123_20A));
 
         loop();
 
@@ -261,8 +250,7 @@ TEST_CASE( "SmartCharging" ) {
         getTransaction()->setTransactionId(123);
 
         //send during tx with matchin txId - accept
-        out = SCPROFILE_3_TXPROF_TXID123_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_3_TXPROF_TXID123_20A, strlen(SCPROFILE_3_TXPROF_TXID123_20A));
 
         loop();
 
@@ -289,11 +277,9 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
         
-        std::string out = SCPROFILE_4_VALID_FROM_2024_16A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_4_VALID_FROM_2024_16A, strlen(SCPROFILE_4_VALID_FROM_2024_16A));
 
-        out = SCPROFILE_5_VALID_UNTIL_2022_16A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_5_VALID_UNTIL_2022_16A, strlen(SCPROFILE_5_VALID_UNTIL_2022_16A));
 
         loop();
 
@@ -314,8 +300,7 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
 
-        std::string out = SCPROFILE_6_MULTIPLE_PERIODS_16A_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_6_MULTIPLE_PERIODS_16A_20A, strlen(SCPROFILE_6_MULTIPLE_PERIODS_16A_20A));
 
         loop();
 
@@ -336,8 +321,7 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
 
-        std::string out = SCPROFILE_7_RECURRING_DAY_2H_16A_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_7_RECURRING_DAY_2H_16A_20A, strlen(SCPROFILE_7_RECURRING_DAY_2H_16A_20A));
 
         loop();
 
@@ -365,8 +349,7 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
 
-        std::string out = SCPROFILE_8_RECURRING_WEEK_2H_10A_12A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_8_RECURRING_WEEK_2H_10A_12A, strlen(SCPROFILE_8_RECURRING_WEEK_2H_10A_12A));
 
         loop();
 
@@ -394,11 +377,9 @@ TEST_CASE( "SmartCharging" ) {
             current = limit_current;
         });
 
-        std::string out = SCPROFILE_7_RECURRING_DAY_2H_16A_20A; //stackLevel: 0
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_7_RECURRING_DAY_2H_16A_20A, strlen(SCPROFILE_7_RECURRING_DAY_2H_16A_20A)); //stackLevel: 0
 
-        out = SCPROFILE_8_RECURRING_WEEK_2H_10A_12A; //stackLevel: 1
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_8_RECURRING_WEEK_2H_10A_12A, strlen(SCPROFILE_8_RECURRING_WEEK_2H_10A_12A)); //stackLevel: 1
 
         loop();
 
@@ -437,13 +418,11 @@ TEST_CASE( "SmartCharging" ) {
 
         loop();
 
-        std::string out = SCPROFILE_9_VIA_RMTSTARTTX_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_9_VIA_RMTSTARTTX_20A, strlen(SCPROFILE_9_VIA_RMTSTARTTX_20A));
 
         loop();
 
-        out = SCPROFILE_1_ABSOLUTE_LIMIT_16A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_1_ABSOLUTE_LIMIT_16A, strlen(SCPROFILE_1_ABSOLUTE_LIMIT_16A));
 
         loop();
 
@@ -466,13 +445,11 @@ TEST_CASE( "SmartCharging" ) {
 
         loop();
 
-        std::string out = SCPROFILE_9_VIA_RMTSTARTTX_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_9_VIA_RMTSTARTTX_20A, strlen(SCPROFILE_9_VIA_RMTSTARTTX_20A));
 
         loop();
 
-        out = SCPROFILE_10_ABSOLUTE_LIMIT_5KW;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_10_ABSOLUTE_LIMIT_5KW, strlen(SCPROFILE_10_ABSOLUTE_LIMIT_5KW));
 
         loop();
 
@@ -486,8 +463,7 @@ TEST_CASE( "SmartCharging" ) {
 
     SECTION("Get composite schedule") {
 
-        std::string out = SCPROFILE_6_MULTIPLE_PERIODS_16A_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_6_MULTIPLE_PERIODS_16A_20A, strlen(SCPROFILE_6_MULTIPLE_PERIODS_16A_20A));
 
         bool checkProcessed = false;
 
@@ -538,8 +514,7 @@ TEST_CASE( "SmartCharging" ) {
 
     SECTION("Get composite schedule with definition gap") {
 
-        std::string out = SCPROFILE_7_RECURRING_DAY_2H_16A_20A;
-        loopback.sendTXT(out);
+        loopback.sendTXT(SCPROFILE_7_RECURRING_DAY_2H_16A_20A, strlen(SCPROFILE_7_RECURRING_DAY_2H_16A_20A));
 
         auto schedule = scService->getCompositeSchedule(1, 86401);
 

--- a/tests/SmartCharging.cpp
+++ b/tests/SmartCharging.cpp
@@ -38,6 +38,7 @@ using namespace MicroOcpp;
 
 
 TEST_CASE( "SmartCharging" ) {
+    printf("\nRun %s\n",  "SmartCharging");
 
     //initialize Context with dummy socket
     LoopbackConnection loopback;

--- a/tests/TransactionSafety.cpp
+++ b/tests/TransactionSafety.cpp
@@ -14,6 +14,7 @@ using namespace MicroOcpp;
 
 
 TEST_CASE( "Transaction safety" ) {
+    printf("\nRun %s\n",  "Transaction safety");
 
     //initialize Context with dummy socket
     LoopbackConnection loopback;
@@ -21,8 +22,7 @@ TEST_CASE( "Transaction safety" ) {
 
     mocpp_set_timer(custom_timer_cb);
 
-    auto connectionTimeOut = declareConfiguration<int>("ConnectionTimeOut", 30, CONFIGURATION_FN);
-        *connectionTimeOut = 30;
+    declareConfiguration<int>("ConnectionTimeOut", 30)->setInt(30);
 
     SECTION("Basic transaction") {
         MOCPP_DBG_DEBUG("Basic transaction");

--- a/tests/ocppEngineLifecycle.cpp
+++ b/tests/ocppEngineLifecycle.cpp
@@ -4,6 +4,7 @@
 #include "./helpers/testHelper.h"
 
 TEST_CASE( "Context lifecycle" ) {
+    printf("\nRun %s\n",  "Context lifecycle");
 
     //set console output to the cpp console to display outputs
     //mo_set_console_out(cpp_console_out);


### PR DESCRIPTION
The configuration class structure has been changed so that the library can work on a single abstract config interface instead of a few concrete config classes (previously one per type). The config API changes:

```cpp
//old - instantiation
std::shared_ptr<Configuration<int>> connectionTimeOut = declareConfiguration<int>("ConnectionTimeOut", 30);
printf("value: %i", *connectionTimeOut); //"value: 30"
*connectionTimeOut = 40; //changed to 40 seconds

//new - instantiation
std::shared_ptr<Configuration> connectionTimeOutInt = declareConfiguration<int>("ConnectionTimeOut", 30);
printf("value: %i", connectionTimeOutInt->getInt()); //"value: 30"
connectionTimeOutInt->setInt(40);
```

Previously, `Configuration<T>` were concrete classes. Now, `Configuration` is an interface. A guide on how to integrate custom concrete config classes will follow.

Type safety has been weakened in favor of simpler interfaces:

```cpp
//old - type safety ensured by compiler
*connectionTimeOut = "wrong data type"; //won't compile

//new - correct types responsibility of client code
connectionTimeOutInt->setString("wrong data type"); //compiles, but undefined behavior
```

Furthermore, an optimization of the config data structures reduces the heap memory occupation by 2.9kB and the firmware binary size by 6kB