### PR TITLE
Fix multiple operation executions and update FW-/DiagService API

### DIFF
--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
@@ -27,7 +27,7 @@ private:
     Context& context;
     
     std::string location;
-    int retries = 0;
+    unsigned int retries = 0;
     unsigned int retryInterval = 0;
     Timestamp startTime;
     Timestamp stopTime;
@@ -35,7 +35,7 @@ private:
     Timestamp nextTry;
 
     std::function<std::string()> refreshFilename;
-    std::function<bool(const std::string &location, Timestamp &startTime, Timestamp &stopTime)> onUpload;
+    std::function<bool(const char *location, Timestamp &startTime, Timestamp &stopTime)> onUpload;
     std::function<UploadStatus()> uploadStatusInput;
     bool uploadIssued = false;
 
@@ -51,13 +51,13 @@ public:
     //timestamps before year 2021 will be treated as "undefined"
     //returns empty std::string if onUpload is missing or upload cannot be scheduled for another reason
     //returns fileName of diagnostics file to be uploaded if upload has been scheduled
-    std::string requestDiagnosticsUpload(const std::string &location, int retries = 1, unsigned int retryInterval = 0, Timestamp startTime = Timestamp(), Timestamp stopTime = Timestamp());
+    std::string requestDiagnosticsUpload(const char *location, unsigned int retries = 1, unsigned int retryInterval = 0, Timestamp startTime = Timestamp(), Timestamp stopTime = Timestamp());
 
     Ocpp16::DiagnosticsStatus getDiagnosticsStatus();
 
     void setRefreshFilename(std::function<std::string()> refreshFn); //refresh a new filename which will be used for the subsequent upload tries
 
-    void setOnUpload(std::function<bool(const std::string &location, Timestamp &startTime, Timestamp &stopTime)> onUpload);
+    void setOnUpload(std::function<bool(const char *location, Timestamp &startTime, Timestamp &stopTime)> onUpload);
 
     void setOnUploadStatusInput(std::function<UploadStatus()> uploadStatusInput);
 };

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
@@ -45,13 +45,13 @@ private:
     Ocpp16::FirmwareStatus lastReportedStatus = Ocpp16::FirmwareStatus::Idle;
     bool checkedSuccessfulFwUpdate = false;
 
-    std::string location {};
-    Timestamp retreiveDate = Timestamp();
-    int retries = 0;
+    std::string location;
+    Timestamp retreiveDate;
+    unsigned int retries = 0;
     unsigned int retryInterval = 0;
 
-    std::function<bool(const std::string &location)> onDownload;
-    std::function<bool(const std::string &location)> onInstall;
+    std::function<bool(const char *location)> onDownload;
+    std::function<bool(const char *location)> onInstall;
 
     unsigned long delayTransition = 0;
     unsigned long timestampTransition = 0;
@@ -76,15 +76,15 @@ public:
 
     void loop();
 
-    void scheduleFirmwareUpdate(const std::string &location, Timestamp retreiveDate, int retries = 1, unsigned int retryInterval = 0);
+    void scheduleFirmwareUpdate(const char *location, Timestamp retreiveDate, unsigned int retries = 1, unsigned int retryInterval = 0);
 
     Ocpp16::FirmwareStatus getFirmwareStatus();
 
-    void setOnDownload(std::function<bool(const std::string &location)> onDownload);
+    void setOnDownload(std::function<bool(const char *location)> onDownload);
 
     void setDownloadStatusInput(std::function<DownloadStatus()> downloadStatusInput);
 
-    void setOnInstall(std::function<bool(const std::string &location)> onInstall);
+    void setOnInstall(std::function<bool(const char *location)> onInstall);
 
     void setInstallationStatusInput(std::function<InstallationStatus()> installationStatusInput);
 };

--- a/src/MicroOcpp/Operations/GetDiagnostics.h
+++ b/src/MicroOcpp/Operations/GetDiagnostics.h
@@ -10,24 +10,18 @@
 
 namespace MicroOcpp {
 
-class Model;
+class DiagnosticsService;
 
 namespace Ocpp16 {
 
 class GetDiagnostics : public Operation {
 private:
-    Model& model;
-    std::string location {};
-    int retries = 1;
-    unsigned long retryInterval = 180;
-    Timestamp startTime = Timestamp();
-    Timestamp stopTime = Timestamp();
+    DiagnosticsService& diagService;
+    std::string fileName;
 
-    std::string fileName {};
-    
-    bool formatError = false;
+    const char *errorCode = nullptr;
 public:
-    GetDiagnostics(Model& model);
+    GetDiagnostics(DiagnosticsService& diagService);
 
     const char* getOperationType() override {return "GetDiagnostics";}
 
@@ -35,7 +29,7 @@ public:
 
     std::unique_ptr<DynamicJsonDocument> createConf() override;
 
-    const char *getErrorCode() override {return formatError ? "FormationViolation" : nullptr;}
+    const char *getErrorCode() override {return errorCode;}
 };
 
 } //end namespace Ocpp16

--- a/src/MicroOcpp/Operations/RemoteStartTransaction.h
+++ b/src/MicroOcpp/Operations/RemoteStartTransaction.h
@@ -18,10 +18,8 @@ namespace Ocpp16 {
 class RemoteStartTransaction : public Operation {
 private:
     Model& model;
-    int connectorId;
-    char idTag [IDTAG_LEN_MAX + 1] = {'\0'};
 
-    std::unique_ptr<ChargingProfile> chargingProfile;
+    bool accepted = false;
     
     const char *errorCode {nullptr};
     const char *errorDescription = "";

--- a/src/MicroOcpp/Operations/RemoteStopTransaction.cpp
+++ b/src/MicroOcpp/Operations/RemoteStopTransaction.cpp
@@ -18,29 +18,29 @@ const char* RemoteStopTransaction::getOperationType(){
 }
 
 void RemoteStopTransaction::processReq(JsonObject payload) {
-    transactionId = payload["transactionId"] | -1;
-}
 
-std::unique_ptr<DynamicJsonDocument> RemoteStopTransaction::createConf(){
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
-    JsonObject payload = doc->to<JsonObject>();
-    
-    bool canStopTransaction = false;
+    if (!payload.containsKey("transactionId")) {
+        errorCode = "FormationViolation";
+    }
+    int transactionId = payload["transactionId"];
 
     for (unsigned int cId = 0; cId < model.getNumConnectors(); cId++) {
         auto connector = model.getConnector(cId);
         if (connector->getTransaction() &&
                 connector->getTransaction()->getTransactionId() == transactionId) {
-            canStopTransaction = true;
             connector->endTransaction(nullptr, "Remote");
+            accepted = true;
         }
     }
+}
 
-    if (canStopTransaction){
+std::unique_ptr<DynamicJsonDocument> RemoteStopTransaction::createConf(){
+    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
+    JsonObject payload = doc->to<JsonObject>();
+    if (accepted){
         payload["status"] = "Accepted";
     } else {
         payload["status"] = "Rejected";
     }
-    
     return doc;
 }

--- a/src/MicroOcpp/Operations/RemoteStopTransaction.h
+++ b/src/MicroOcpp/Operations/RemoteStopTransaction.h
@@ -16,7 +16,9 @@ namespace Ocpp16 {
 class RemoteStopTransaction : public Operation {
 private:
     Model& model;
-    int transactionId;
+    bool accepted = false;
+
+    const char *errorCode = nullptr;
 public:
     RemoteStopTransaction(Model& model);
 
@@ -25,6 +27,8 @@ public:
     void processReq(JsonObject payload) override;
 
     std::unique_ptr<DynamicJsonDocument> createConf() override;
+
+    const char *getErrorCode() override {return errorCode;}
 };
 
 } //end namespace Ocpp16

--- a/src/MicroOcpp/Operations/TriggerMessage.h
+++ b/src/MicroOcpp/Operations/TriggerMessage.h
@@ -12,15 +12,13 @@
 namespace MicroOcpp {
 
 class Context;
-class Request;
 
 namespace Ocpp16 {
 
 class TriggerMessage : public Operation {
 private:
     Context& context;
-    std::vector<std::unique_ptr<Request>> triggeredOperations;
-    const char *statusMessage {nullptr};
+    const char *statusMessage = nullptr;
 
     const char *errorCode = nullptr;
 public:

--- a/src/MicroOcpp/Operations/UpdateFirmware.h
+++ b/src/MicroOcpp/Operations/UpdateFirmware.h
@@ -10,20 +10,17 @@
 
 namespace MicroOcpp {
 
-class Model;
+class FirmwareService;
 
 namespace Ocpp16 {
 
 class UpdateFirmware : public Operation {
 private:
-  Model& model;
-  std::string location {};
-  Timestamp retreiveDate = Timestamp();
-  int retries = 1;
-  unsigned long retryInterval = 180;
-  bool formatError = false;
+  FirmwareService& fwService;
+
+  const char *errorCode = nullptr;
 public:
-  UpdateFirmware(Model& model);
+  UpdateFirmware(FirmwareService& fwService);
 
   const char* getOperationType() override {return "UpdateFirmware";}
 
@@ -31,7 +28,7 @@ public:
 
   std::unique_ptr<DynamicJsonDocument> createConf() override;
 
-  const char *getErrorCode() override {if (formatError) return "FormationViolation"; else return NULL;}
+  const char *getErrorCode() override {return errorCode;}
 };
 
 } //end namespace Ocpp16


### PR DESCRIPTION
For some incoming operation types, the operation was executed inside the `createConf()` handler. This could glitch when sending the confirmation is attempted multiple times, e.g. when the device is getting offline. 

While fixing this, some function signatures of the DiagnosticsService and FirmwareService were updated to match the current coding style, i.e. `const std::string&` became `const char*` and `int` became `unsigned int` where appropriate.