### PR TITLE
fixed state transition issue in FirmwareService

### DIFF
--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
@@ -111,8 +111,8 @@ void FirmwareService::loop() {
 
                     timestampTransition = mocpp_tick_ms();
                     delayTransition = 10000;
-                    return;
                 }
+                return;
             } else {
                 //if client doesn't report download state, assume download to be finished (at least 30s download time have passed until here)
                 if (downloadStatusInput == nullptr) {


### PR DESCRIPTION
When entering UpdateStage::Downloading the update was aborted immediately because neither DownloadStatus::Downloaded nor DownloadStatus::DownloadFailed was present and so the firmwareService loop executes firmware update failed. This resets the state machine and the update never reaches the install stage.