### PR TITLE
adapted esp-idf spiffs initialization

### DIFF
--- a/src/MicroOcpp/Core/FilesystemAdapter.cpp
+++ b/src/MicroOcpp/Core/FilesystemAdapter.cpp
@@ -219,6 +219,7 @@ std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt co
 
 #include <sys/stat.h>
 #include <dirent.h>
+#include <string.h>
 #include "esp_spiffs.h"
 
 namespace MicroOcpp {
@@ -337,8 +338,8 @@ std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt co
         mounted = false;
         
         esp_vfs_spiffs_conf_t conf = {
-            .base_path = MOCPP_FILENAME_PREFIX,
-            .partition_label = "mo", //also see deconstructor
+            .base_path = MOCPP_FILENAME_PREFIX[strlen(MOCPP_FILENAME_PREFIX) - 1] == '/' ? strndup(MOCPP_FILENAME_PREFIX, strlen(MOCPP_FILENAME_PREFIX) - 1) : MOCPP_FILENAME_PREFIX,
+            .partition_label = MOCPP_PARTITION_LABEL, //also see deconstructor
             .max_files = 5,
             .format_if_mount_failed = config.formatOnFail()
         };

--- a/src/MicroOcpp/Core/FilesystemAdapter.cpp
+++ b/src/MicroOcpp/Core/FilesystemAdapter.cpp
@@ -258,7 +258,7 @@ public:
 
     ~EspIdfFilesystemAdapter() {
         if (config.mustMount()) {
-            esp_vfs_spiffs_unregister("mo"); //partition label
+            esp_vfs_spiffs_unregister(MOCPP_PARTITION_LABEL); //partition label
             MOCPP_DBG_DEBUG("SPIFFS unmounted");
         }
     }

--- a/src/MicroOcpp/Core/FilesystemAdapter.cpp
+++ b/src/MicroOcpp/Core/FilesystemAdapter.cpp
@@ -338,7 +338,7 @@ std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt co
         mounted = false;
         
         esp_vfs_spiffs_conf_t conf = {
-            .base_path = MOCPP_FILENAME_PREFIX[strlen(MOCPP_FILENAME_PREFIX) - 1] == '/' ? strndup(MOCPP_FILENAME_PREFIX, strlen(MOCPP_FILENAME_PREFIX) - 1) : MOCPP_FILENAME_PREFIX,
+            .base_path = (MOCPP_FILENAME_PREFIX[0] == '/' && MOCPP_FILENAME_PREFIX[1] == '\0') ? MOCPP_FILENAME_PREFIX : (MOCPP_FILENAME_PREFIX[strlen(MOCPP_FILENAME_PREFIX) - 1] == '/' ? strndup(MOCPP_FILENAME_PREFIX, strlen(MOCPP_FILENAME_PREFIX) - 1) : MOCPP_FILENAME_PREFIX),
             .partition_label = MOCPP_PARTITION_LABEL, //also see deconstructor
             .max_files = 5,
             .format_if_mount_failed = config.formatOnFail()

--- a/src/MicroOcpp/Core/FilesystemAdapter.h
+++ b/src/MicroOcpp/Core/FilesystemAdapter.h
@@ -15,6 +15,10 @@
 #define MOCPP_FILENAME_PREFIX "/"
 #endif
 
+#ifndef MOCPP_PARTITION_LABEL
+#define MOCPP_PARTITION_LABEL "mo"
+#endif
+
 #define DISABLE_FS       0
 #define ARDUINO_LITTLEFS 1
 #define ARDUINO_SPIFFS   2


### PR DESCRIPTION
Hi @matth-x,

If you use more than one spiffs partition in your project, it makes sense to adjust the .base_path of the partitions so that it is not just "/".
In the current version, however, this unfortunately leads to problems when using the esp-idf:

if you set the base_path to "/mo/", for example, you get an invalid argument error when initialising the spiffs partition, as the base path must not contain a slash at the end.
if you set the base_path to "/mo", the initialisation works, but the file names are no longer correct because they do not begin with a "/". An attempt is then made to save /mobootstats.jsn, for example, which does not work.
For this reason, a check has been introduced which, when setting the base_path, checks whether a "/" is present at the end of the define MOCPP_FILENAME_PREFIX. If this is the case, it is only removed for the base_path. Thus, the file names in the further course are also correct.

In addition, the define MOCPP_PARTITION_LABEL was introduced. The change from the former "ao" to "mo" could lead to problems in a production environment if devices are in circulation that have partitions with the name "ao", as these cannot or should not be changed OTA without further ado.