### PR TITLE
parse URL instead of explicit host param

### DIFF
--- a/examples/ESP/main.cpp
+++ b/examples/ESP/main.cpp
@@ -18,16 +18,14 @@ ESP8266WiFiMulti WiFiMulti;
 #define STASSID "YOUR_WIFI_SSID"
 #define STAPSK  "YOUR_WIFI_PW"
 
-#define OCPP_HOST "echo.websocket.events"
-#define OCPP_PORT 80
-#define OCPP_URL "ws://echo.websocket.events/"
+#define OCPP_BACKEND_URL   "ws://echo.websocket.events"
+#define OCPP_CHARGE_BOX_ID ""
 
 //
 //  Settings which worked for my SteVe instance:
 //
-//#define OCPP_HOST "my.instance.com"
-//#define OCPP_PORT 80
-//#define OCPP_URL "ws://my.instance.com/steve/websocket/CentralSystemService/esp-charger"
+//#define OCPP_BACKEND_URL   "ws://192.168.178.100:8180/steve/websocket/CentralSystemService"
+//#define OCPP_CHARGE_BOX_ID "esp-charger"
 
 void setup() {
 
@@ -60,7 +58,7 @@ void setup() {
     /*
      * Initialize the OCPP library
      */
-    mocpp_initialize(OCPP_HOST, OCPP_PORT, OCPP_URL, "My Charging Station", "My company name");
+    mocpp_initialize(OCPP_BACKEND_URL, OCPP_CHARGE_BOX_ID, "My Charging Station", "My company name");
 
     /*
      * Integrate OCPP functionality. You can leave out the following part if your EVSE doesn't need it.

--- a/src/MicroOcpp.h
+++ b/src/MicroOcpp.h
@@ -36,19 +36,16 @@ using MicroOcpp::OnReceiveErrorListener;
  * https://github.com/matth-x/MicroOcpp/issues/36#issuecomment-989716573 for recommendations on
  * how to track down the issue with the connection.
  * 
- * This is a convenience function only available for Arduino. For a full initialization with TLS,
- * please refer to https://github.com/matth-x/MicroOcpp/tree/master/examples/ESP-TLS
+ * This is a convenience function only available for Arduino.
  */
 void mocpp_initialize(
-            const char *CS_hostname, //e.g. "example.com"
-            uint16_t CS_port,        //e.g. 80
-            const char *CS_url,      //e.g. "ws://example.com/steve/websocket/CentralSystemService/charger001"
+            const char *backendUrl,    //e.g. "wss://example.com:8443/steve/websocket/CentralSystemService"
+            const char *chargeBoxId,   //e.g. "charger001"
             const char *chargePointModel = "Demo Charger",     //model name of this charger
             const char *chargePointVendor = "My Company Ltd.", //brand name
             MicroOcpp::FilesystemOpt fsOpt = MicroOcpp::FilesystemOpt::Use_Mount_FormatOnFail, //If this library should format the flash if necessary. Find further options in ConfigurationOptions.h
-            const char *login = "", //login present in the websocket message header
-            const char *password = "", //password present in the websocket message header
-            const char *CA_cert = NULL, //TLS certificate
+            const char *password = nullptr, //password present in the websocket message header
+            const char *CA_cert = nullptr, //TLS certificate
             bool autoRecover = false); //automatically sanitize the local data store when the lib detects recurring crashes. Not recommended during development
 #endif
 


### PR DESCRIPTION
This PR changes the signature of `mocpp_initialize(const char *host, ...)`. Instead of an OCPP host, port and URL, it expects the OCPP backend URL and the chargeBoxId. This aligns better with the typical instructions of OCPP backends.

For example, the previous notation

```cpp
const char *host = "my.instance.com";
uint16_t port = 8443;
const char *url = "wss://my.instance.com/steve/websocket/CentralSystemService/charger001";

mocpp_initialize(host, port, url);
```

becomes

```cpp
const char *backendUrl = "wss://my.instance.com:8443/steve/websocket/CentralSystemService";
const char *chargeBoxId = "charger001";

mocpp_initialize(backendUrl, chargeBoxId);
```