### PR TITLE
Smart Charging module fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow `nullptr` as parameter for `mocpp_set_console_out` ([#224](https://github.com/matth-x/MicroOcpp/issues/224))
 - Fix `mocpp_tick_ms()` on esp-idf roll-over after 12 hours
 - Pin ArduinoJson to v6.21 ([#245](https://github.com/matth-x/MicroOcpp/issues/245))
+- Fix bounds checking in SmartCharging module ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 
 ## [1.0.0] - 2023-10-22
 

--- a/src/MicroOcpp/Model/SmartCharging/SmartChargingModel.cpp
+++ b/src/MicroOcpp/Model/SmartCharging/SmartChargingModel.cpp
@@ -480,6 +480,11 @@ bool MicroOcpp::loadChargingSchedule(JsonObject& json, ChargingSchedule& out) {
         return false;
     }
 
+    if (periodJsonArray.size() > CHARGINGSCHEDULEMAXPERIODS) {
+        MO_DBG_WARN("exceed ChargingScheduleMaxPeriods");
+        return false;
+    }
+
     for (JsonObject periodJson : periodJsonArray) {
         out.chargingSchedulePeriod.push_back(ChargingSchedulePeriod());
         if (!loadChargingSchedulePeriod(periodJson, out.chargingSchedulePeriod.back())) {

--- a/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
+++ b/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
@@ -274,10 +274,10 @@ std::unique_ptr<ChargingSchedule> SmartChargingConnector::getCompositeSchedule(i
 size_t SmartChargingConnector::getChargingProfilesCount() {
     size_t chargingProfilesCount = 0;
     for (size_t i = 0; i < CHARGEPROFILEMAXSTACKLEVEL + 1; i++) {
-        if (ChargePointTxDefaultProfile[i]) {
+        if (TxDefaultProfile[i]) {
             chargingProfilesCount++;
         }
-        if (ChargePointMaxProfile[i]) {
+        if (TxProfile[i]) {
             chargingProfilesCount++;
         }
     }

--- a/src/MicroOcpp/Operations/SetChargingProfile.cpp
+++ b/src/MicroOcpp/Operations/SetChargingProfile.cpp
@@ -57,8 +57,17 @@ void SetChargingProfile::processReq(JsonObject payload) {
             errorCode = "PropertyConstraintViolation";
             return;
         }
-        if (!connector->getTransaction() || !connector->getTransaction()->isRunning()) {
+
+        auto& transaction = connector->getTransaction();
+        if (!transaction || !connector->getTransaction()->isRunning()) {
             //no transaction running, reject profile
+            accepted = false;
+            return;
+        }
+
+        if (chargingProfile->getTransactionId() < 0 ||
+                chargingProfile->getTransactionId() != transaction->getTransactionId()) {
+            //transactionId undefined / mismatch
             accepted = false;
             return;
         }


### PR DESCRIPTION
During tests, three defects were found:

- Config `ChargingScheduleMaxPeriods` was ignored when interpreting charging schedules
- The installed profiles were not counted correctly, allowing to install more profiles than defined by `MaxChargingProfilesInstalled`
- The transactionId of the TxProfile wasn't checked against the currently running transaction

Thanks again to the engineer who reported all these defects.