### PR TITLE
Fix OCPP 2.0.1 transactions

### DIFF
--- a/src/MicroOcpp/Model/Authorization/IdToken.cpp
+++ b/src/MicroOcpp/Model/Authorization/IdToken.cpp
@@ -66,4 +66,8 @@ const char *IdToken::getTypeCstr() const {
     return res ? res : "";
 }
 
+bool IdToken::equals(const IdToken& other) {
+    return type == other.type && !strcmp(idToken, other.idToken);
+}
+
 #endif // MO_ENABLE_V201

--- a/src/MicroOcpp/Model/Authorization/IdToken.h
+++ b/src/MicroOcpp/Model/Authorization/IdToken.h
@@ -41,6 +41,8 @@ public:
 
     const char *get() const;
     const char *getTypeCstr() const;
+
+    bool equals(const IdToken& other);
 };
 
 } // namespace MicroOcpp

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -39,8 +39,6 @@ public:
         std::function<bool()> evReadyInput;
         std::function<bool()> evseReadyInput;
 
-        IdToken authorization;
-
         std::unique_ptr<Ocpp201::Transaction> allocateTransaction();
     public:
         Evse(Context& context, TransactionService& txService, unsigned int evseId);
@@ -51,9 +49,13 @@ public:
         void setEvReadyInput(std::function<bool()> evRequestsEnergy);
         void setEvseReadyInput(std::function<bool()> connectorEnergized);
 
-        bool beginAuthorization(IdToken idToken);
-        bool endAuthorization(IdToken idToken = IdToken());
-        const char *getAuthorization();
+        bool beginAuthorization(IdToken idToken); // authorize by swipe RFID
+        bool endAuthorization(IdToken idToken = IdToken()); // stop authorization by swipe RFID
+
+        // stop transaction, but neither upon user request nor OCPP server request (e.g. after PowerLoss)
+        bool abortTransaction(Ocpp201::Transaction::StopReason stopReason = Ocpp201::Transaction::StopReason::Other, Ocpp201::TransactionEventTriggerReason stopTrigger = Ocpp201::TransactionEventTriggerReason::AbnormalCondition);
+
+        const std::shared_ptr<Ocpp201::Transaction>& getTransaction();
     };
 
     friend Evse;
@@ -73,8 +75,11 @@ private:
     Context& context;
     std::vector<Evse> evses;
 
-    Variable *TxStartPointString = nullptr;
-    Variable *TxStopPointString = nullptr;
+    Variable *txStartPointString = nullptr;
+    Variable *txStopPointString = nullptr;
+    Variable *stopTxOnInvalidIdBool = nullptr;
+    Variable *stopTxOnEVSideDisconnectBool = nullptr;
+    Variable *evConnectionTimeOutInt = nullptr;
     uint16_t trackTxStartPoint = -1;
     uint16_t trackTxStopPoint = -1;
     std::vector<TxStartStopPoint> txStartPointParsed;

--- a/src/MicroOcpp/Operations/Authorize.cpp
+++ b/src/MicroOcpp/Operations/Authorize.cpp
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #include <MicroOcpp/Operations/Authorize.h>
@@ -8,7 +8,9 @@
 
 #include <MicroOcpp/Debug.h>
 
-using MicroOcpp::Ocpp16::Authorize;
+using namespace MicroOcpp;
+
+namespace MicroOcpp::Ocpp16 {
 
 Authorize::Authorize(Model& model, const char *idTagIn) : model(model) {
     if (idTagIn && strnlen(idTagIn, IDTAG_LEN_MAX + 2) <= IDTAG_LEN_MAX) {
@@ -57,3 +59,59 @@ std::unique_ptr<DynamicJsonDocument> Authorize::createConf(){
     idTagInfo["status"] = "Accepted";
     return doc;
 }
+
+} //namespace MicroOcpp::Ocpp16
+
+#if MO_ENABLE_V201
+
+namespace MicroOcpp::Ocpp201 {
+
+Authorize::Authorize(Model& model, const IdToken& idToken) : model(model) {
+    this->idToken = idToken;
+}
+
+const char* Authorize::getOperationType(){
+    return "Authorize";
+}
+
+std::unique_ptr<DynamicJsonDocument> Authorize::createReq() {
+    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(
+            JSON_OBJECT_SIZE(1) +
+            JSON_OBJECT_SIZE(2)));
+    JsonObject payload = doc->to<JsonObject>();
+    payload["idToken"]["idToken"] = idToken.get();
+    payload["idToken"]["type"] = idToken.getTypeCstr();
+    return doc;
+}
+
+void Authorize::processConf(JsonObject payload){
+    const char *idTagInfo = payload["idTokenInfo"]["status"] | "_Undefined";
+
+    if (!strcmp(idTagInfo, "Accepted")) {
+        MO_DBG_INFO("Request has been accepted");
+    } else {
+        MO_DBG_INFO("Request has been denied. Reason: %s", idTagInfo);
+    }
+
+    //if (model.getAuthorizationService()) {
+    //    model.getAuthorizationService()->notifyAuthorization(idTag, payload["idTagInfo"]);
+    //}
+}
+
+void Authorize::processReq(JsonObject payload){
+    /*
+     * Ignore Contents of this Req-message, because this is for debug purposes only
+     */
+}
+
+std::unique_ptr<DynamicJsonDocument> Authorize::createConf(){
+    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(2 * JSON_OBJECT_SIZE(1)));
+    JsonObject payload = doc->to<JsonObject>();
+    JsonObject idTagInfo = payload.createNestedObject("idTokenInfo");
+    idTagInfo["status"] = "Accepted";
+    return doc;
+}
+
+} //namespace MicroOcpp::Ocpp201
+
+#endif //MO_ENABLE_V201

--- a/src/MicroOcpp/Operations/Authorize.cpp
+++ b/src/MicroOcpp/Operations/Authorize.cpp
@@ -10,7 +10,8 @@
 
 using namespace MicroOcpp;
 
-namespace MicroOcpp::Ocpp16 {
+namespace MicroOcpp {
+namespace Ocpp16 {
 
 Authorize::Authorize(Model& model, const char *idTagIn) : model(model) {
     if (idTagIn && strnlen(idTagIn, IDTAG_LEN_MAX + 2) <= IDTAG_LEN_MAX) {
@@ -60,11 +61,13 @@ std::unique_ptr<DynamicJsonDocument> Authorize::createConf(){
     return doc;
 }
 
-} //namespace MicroOcpp::Ocpp16
+} // namespace Ocpp16
+} // namespace MicroOcpp
 
 #if MO_ENABLE_V201
 
-namespace MicroOcpp::Ocpp201 {
+namespace MicroOcpp {
+namespace Ocpp201 {
 
 Authorize::Authorize(Model& model, const IdToken& idToken) : model(model) {
     this->idToken = idToken;
@@ -112,6 +115,7 @@ std::unique_ptr<DynamicJsonDocument> Authorize::createConf(){
     return doc;
 }
 
-} //namespace MicroOcpp::Ocpp201
+} // namespace Ocpp201
+} // namespace MicroOcpp
 
 #endif //MO_ENABLE_V201

--- a/src/MicroOcpp/Operations/Authorize.h
+++ b/src/MicroOcpp/Operations/Authorize.h
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #ifndef AUTHORIZE_H
@@ -7,6 +7,7 @@
 
 #include <MicroOcpp/Core/Operation.h>
 #include <MicroOcpp/Operations/CiStrings.h>
+#include <MicroOcpp/Version.h>
 
 namespace MicroOcpp {
 
@@ -35,5 +36,36 @@ public:
 
 } //end namespace Ocpp16
 } //end namespace MicroOcpp
+
+#if MO_ENABLE_V201
+
+#include <MicroOcpp/Model/Authorization/IdToken.h>
+
+namespace MicroOcpp {
+namespace Ocpp201 {
+
+class Authorize : public Operation {
+private:
+    Model& model;
+    IdToken idToken;
+public:
+    Authorize(Model& model, const IdToken& idToken);
+
+    const char* getOperationType() override;
+
+    std::unique_ptr<DynamicJsonDocument> createReq() override;
+
+    void processConf(JsonObject payload) override;
+
+    void processReq(JsonObject payload) override;
+
+    std::unique_ptr<DynamicJsonDocument> createConf() override;
+
+};
+
+} //end namespace Ocpp201
+} //end namespace MicroOcpp
+
+#endif //MO_ENABLE_V201
 
 #endif

--- a/src/MicroOcpp/Operations/TransactionEvent.cpp
+++ b/src/MicroOcpp/Operations/TransactionEvent.cpp
@@ -53,67 +53,67 @@ std::unique_ptr<DynamicJsonDocument> TransactionEvent::createReq() {
 
     const char *triggerReason = "";
     switch(txEvent->triggerReason) {
-        case TransactionEventData::TriggerReason::Authorized:
+        case TransactionEventTriggerReason::Authorized:
             triggerReason = "Authorized";
             break;
-        case TransactionEventData::TriggerReason::CablePluggedIn:
+        case TransactionEventTriggerReason::CablePluggedIn:
             triggerReason = "CablePluggedIn";
             break;
-        case TransactionEventData::TriggerReason::ChargingRateChanged:
+        case TransactionEventTriggerReason::ChargingRateChanged:
             triggerReason = "ChargingRateChanged";
             break;
-        case TransactionEventData::TriggerReason::ChargingStateChanged:
+        case TransactionEventTriggerReason::ChargingStateChanged:
             triggerReason = "ChargingStateChanged";
             break;
-        case TransactionEventData::TriggerReason::Deauthorized:
+        case TransactionEventTriggerReason::Deauthorized:
             triggerReason = "Deauthorized";
             break;
-        case TransactionEventData::TriggerReason::EnergyLimitReached:
+        case TransactionEventTriggerReason::EnergyLimitReached:
             triggerReason = "EnergyLimitReached";
             break;
-        case TransactionEventData::TriggerReason::EVCommunicationLost:
+        case TransactionEventTriggerReason::EVCommunicationLost:
             triggerReason = "EVCommunicationLost";
             break;
-        case TransactionEventData::TriggerReason::EVConnectTimeout:
+        case TransactionEventTriggerReason::EVConnectTimeout:
             triggerReason = "EVConnectTimeout";
             break;
-        case TransactionEventData::TriggerReason::MeterValueClock:
+        case TransactionEventTriggerReason::MeterValueClock:
             triggerReason = "MeterValueClock";
             break;
-        case TransactionEventData::TriggerReason::MeterValuePeriodic:
+        case TransactionEventTriggerReason::MeterValuePeriodic:
             triggerReason = "MeterValuePeriodic";
             break;
-        case TransactionEventData::TriggerReason::TimeLimitReached:
+        case TransactionEventTriggerReason::TimeLimitReached:
             triggerReason = "TimeLimitReached";
             break;
-        case TransactionEventData::TriggerReason::Trigger:
+        case TransactionEventTriggerReason::Trigger:
             triggerReason = "Trigger";
             break;
-        case TransactionEventData::TriggerReason::UnlockCommand:
+        case TransactionEventTriggerReason::UnlockCommand:
             triggerReason = "UnlockCommand";
             break;
-        case TransactionEventData::TriggerReason::StopAuthorized:
+        case TransactionEventTriggerReason::StopAuthorized:
             triggerReason = "StopAuthorized";
             break;
-        case TransactionEventData::TriggerReason::EVDeparted:
+        case TransactionEventTriggerReason::EVDeparted:
             triggerReason = "EVDeparted";
             break;
-        case TransactionEventData::TriggerReason::EVDetected:
+        case TransactionEventTriggerReason::EVDetected:
             triggerReason = "EVDetected";
             break;
-        case TransactionEventData::TriggerReason::RemoteStop:
+        case TransactionEventTriggerReason::RemoteStop:
             triggerReason = "RemoteStop";
             break;
-        case TransactionEventData::TriggerReason::RemoteStart:
+        case TransactionEventTriggerReason::RemoteStart:
             triggerReason = "RemoteStart";
             break;
-        case TransactionEventData::TriggerReason::AbnormalCondition:
+        case TransactionEventTriggerReason::AbnormalCondition:
             triggerReason = "AbnormalCondition";
             break;
-        case TransactionEventData::TriggerReason::SignedDataReceived:
+        case TransactionEventTriggerReason::SignedDataReceived:
             triggerReason = "SignedDataReceived";
             break;
-        case TransactionEventData::TriggerReason::ResetCommand:
+        case TransactionEventTriggerReason::ResetCommand:
             triggerReason = "ResetCommand";
             break;
     }
@@ -164,59 +164,59 @@ std::unique_ptr<DynamicJsonDocument> TransactionEvent::createReq() {
     }
 
     const char *stoppedReason = nullptr;
-    switch (txEvent->stoppedReason) {
-        case TransactionEventData::StopReason::DeAuthorized: 
+    switch (txEvent->transaction->stopReason) {
+        case Transaction::StopReason::DeAuthorized: 
             stoppedReason = "DeAuthorized"; 
             break;
-        case TransactionEventData::StopReason::EmergencyStop: 
+        case Transaction::StopReason::EmergencyStop: 
             stoppedReason = "EmergencyStop"; 
             break;
-        case TransactionEventData::StopReason::EnergyLimitReached: 
+        case Transaction::StopReason::EnergyLimitReached: 
             stoppedReason = "EnergyLimitReached";
             break;
-        case TransactionEventData::StopReason::EVDisconnected: 
+        case Transaction::StopReason::EVDisconnected: 
             stoppedReason = "EVDisconnected";
             break;
-        case TransactionEventData::StopReason::GroundFault: 
+        case Transaction::StopReason::GroundFault: 
             stoppedReason = "GroundFault";
             break;
-        case TransactionEventData::StopReason::ImmediateReset:
+        case Transaction::StopReason::ImmediateReset:
             stoppedReason = "ImmediateReset";
             break;
-        case TransactionEventData::StopReason::LocalOutOfCredit:
+        case Transaction::StopReason::LocalOutOfCredit:
             stoppedReason = "LocalOutOfCredit";
             break;
-        case TransactionEventData::StopReason::MasterPass:
+        case Transaction::StopReason::MasterPass:
             stoppedReason = "MasterPass";
             break;
-        case TransactionEventData::StopReason::Other:
+        case Transaction::StopReason::Other:
             stoppedReason = "Other";
             break;
-        case TransactionEventData::StopReason::OvercurrentFault:
+        case Transaction::StopReason::OvercurrentFault:
             stoppedReason = "OvercurrentFault";
             break;
-        case TransactionEventData::StopReason::PowerLoss:
+        case Transaction::StopReason::PowerLoss:
             stoppedReason = "PowerLoss";
             break;
-        case TransactionEventData::StopReason::PowerQuality:
+        case Transaction::StopReason::PowerQuality:
             stoppedReason = "PowerQuality";
             break;
-        case TransactionEventData::StopReason::Reboot:
+        case Transaction::StopReason::Reboot:
             stoppedReason = "Reboot";
             break;
-        case TransactionEventData::StopReason::Remote:
+        case Transaction::StopReason::Remote:
             stoppedReason = "Remote";
             break;
-        case TransactionEventData::StopReason::SOCLimitReached:
+        case Transaction::StopReason::SOCLimitReached:
             stoppedReason = "SOCLimitReached";
             break;
-        case TransactionEventData::StopReason::StoppedByEV:
+        case Transaction::StopReason::StoppedByEV:
             stoppedReason = "StoppedByEV";
             break;
-        case TransactionEventData::StopReason::TimeLimitReached:
+        case Transaction::StopReason::TimeLimitReached:
             stoppedReason = "TimeLimitReached";
             break;
-        case TransactionEventData::StopReason::Timeout:
+        case Transaction::StopReason::Timeout:
             stoppedReason = "Timeout";
             break;
     }
@@ -228,17 +228,17 @@ std::unique_ptr<DynamicJsonDocument> TransactionEvent::createReq() {
         payload["remoteStartId"] = txEvent->transaction->remoteStartId;
     }
 
-    if (txEvent->idTokenTransmit) {
+    if (txEvent->idToken) {
         JsonObject idToken = payload.createNestedObject("idToken");
-        idToken["idToken"] = txEvent->transaction->idToken.get();
-        idToken["type"] = txEvent->transaction->idToken.getTypeCstr();
+        idToken["idToken"] = txEvent->idToken->get();
+        idToken["type"] = txEvent->idToken->getTypeCstr();
     }
 
     if (txEvent->evse.id >= 0) {
         JsonObject evse = payload.createNestedObject("evse");
         evse["id"] = txEvent->evse.id;
-        evse["connectorId"] = 1;
         if (txEvent->evse.connectorId >= 0) {
+            evse["connectorId"] = txEvent->evse.connectorId;
         }
     }
 

--- a/src/MicroOcpp/Operations/TransactionEvent.cpp
+++ b/src/MicroOcpp/Operations/TransactionEvent.cpp
@@ -237,8 +237,8 @@ std::unique_ptr<DynamicJsonDocument> TransactionEvent::createReq() {
     if (txEvent->evse.id >= 0) {
         JsonObject evse = payload.createNestedObject("evse");
         evse["id"] = txEvent->evse.id;
+        evse["connectorId"] = 1;
         if (txEvent->evse.connectorId >= 0) {
-            evse["connectorId"] = txEvent->evse.connectorId;
         }
     }
 
@@ -256,6 +256,16 @@ void TransactionEvent::processConf(JsonObject payload) {
             txEvent->transaction->isDeauthorized = true;
         }
     }
+}
+
+void TransactionEvent::processReq(JsonObject payload) {
+    /**
+     * Ignore Contents of this Req-message, because this is for debug purposes only
+     */
+}
+
+std::unique_ptr<DynamicJsonDocument> TransactionEvent::createConf() {
+    return createEmptyDocument();
 }
 
 #endif // MO_ENABLE_V201

--- a/src/MicroOcpp/Operations/TransactionEvent.h
+++ b/src/MicroOcpp/Operations/TransactionEvent.h
@@ -24,7 +24,7 @@ private:
     Model& model;
     std::shared_ptr<TransactionEventData> txEvent;
 
-    const char *errorCode;
+    const char *errorCode = nullptr;
 public:
 
     TransactionEvent(Model& model, std::shared_ptr<TransactionEventData> txEvent);
@@ -36,6 +36,10 @@ public:
     void processConf(JsonObject payload) override;
 
     const char *getErrorCode() override {return errorCode;}
+
+    void processReq(JsonObject payload) override;
+
+    std::unique_ptr<DynamicJsonDocument> createConf() override;
 };
 
 } //end namespace Ocpp201

--- a/tests/Transactions.cpp
+++ b/tests/Transactions.cpp
@@ -52,6 +52,8 @@ TEST_CASE( "Transactions" ) {
 
     SECTION("Basic transaction") {
 
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
         MO_DBG_DEBUG("plug EV");
         setConnectorPluggedInput([] () {return true;});
 
@@ -72,6 +74,9 @@ TEST_CASE( "Transactions" ) {
 
         loop();
 
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction()->started );
+        REQUIRE( !context->getModel().getTransactionService()->getEvse(1)->getTransaction()->stopped );
+
         MO_DBG_DEBUG("EV idle");
         setEvReadyInput([] () {return false;});
 
@@ -91,6 +96,9 @@ TEST_CASE( "Transactions" ) {
         setConnectorPluggedInput([] () {return false;});
 
         loop();
+
+        REQUIRE( (context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr || 
+                  context->getModel().getTransactionService()->getEvse(1)->getTransaction()->stopped));
     }
 
     mocpp_deinitialize();


### PR DESCRIPTION
The transactions state machine got stuck for some event sequences. This PR contains a redesign of the Tx implementation which returns to a consistent state more reliably.