### PR TITLE
Add filesystem index structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ target_compile_definitions(mo_unit_tests PUBLIC
     MO_FILENAME_PREFIX="./mo_store/"
     MO_LocalAuthListMaxLength=8
     MO_SendLocalListMaxLength=4
+    MO_ENABLE_FILE_INDEX=1
 )
 
 target_compile_options(mo_unit_tests PUBLIC

--- a/src/MicroOcpp/Core/FilesystemAdapter.cpp
+++ b/src/MicroOcpp/Core/FilesystemAdapter.cpp
@@ -510,6 +510,10 @@ std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt co
 
 namespace MicroOcpp {
 
+#if MO_ENABLE_FILE_INDEX
+std::weak_ptr<FilesystemAdapter> filesystemCache; //dummy cache
+#endif //MO_ENABLE_FILE_INDEX
+
 std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt config) {
     return nullptr;
 }
@@ -517,3 +521,230 @@ std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt co
 } //end namespace MicroOcpp
 
 #endif //switch-case MO_USE_FILEAPI
+
+#define MO_ENABLE_FILE_INDEX 1
+
+#if MO_ENABLE_FILE_INDEX
+
+#include <vector>
+#include <algorithm>
+#include <string>
+
+namespace MicroOcpp {
+
+class FilesystemAdapterIndex;
+
+class IndexedFileAdapter : public FileAdapter {
+private:
+    FilesystemAdapterIndex& index;
+    char fn [MO_MAX_PATH_SIZE];
+    std::unique_ptr<FileAdapter> file;
+
+    size_t written = 0;
+public:
+    IndexedFileAdapter(FilesystemAdapterIndex& index, const char *fn, std::unique_ptr<FileAdapter> file);
+    ~IndexedFileAdapter();
+
+    size_t read(char *buf, size_t len) override;
+    size_t write(const char *buf, size_t len) override;
+    size_t seek(size_t offset) override;
+    int read() override;
+};
+
+class FilesystemAdapterIndex : public FilesystemAdapter {
+private:
+    std::shared_ptr<FilesystemAdapter> filesystem;
+
+    using IndexEntry = std::pair<std::string, size_t>; //fname x fsize;
+    std::vector<IndexEntry> index;
+
+    IndexEntry *getEntryByFname(const char *fn) {
+        auto entry = std::find_if(index.begin(), index.end(),
+            [fn] (const IndexEntry& el) -> bool {
+                return el.first.compare(fn) == 0;
+            });
+
+        if (entry != index.end()) {
+            return &(*entry);
+        } else {
+            return nullptr;
+        }
+    }
+
+    IndexEntry *getEntryByPath(const char *path) {
+        if (strlen(path) < sizeof(MO_FILENAME_PREFIX) - 1) {
+            MO_DBG_ERR("invalid fn");
+            return nullptr;
+        }
+
+        const char *fn = path + sizeof(MO_FILENAME_PREFIX) - 1;
+        return getEntryByFname(fn);
+    }
+public:
+    FilesystemAdapterIndex(std::shared_ptr<FilesystemAdapter> filesystem) : filesystem(std::move(filesystem)) { }
+
+    ~FilesystemAdapterIndex() = default;
+
+    int stat(const char *path, size_t *size) override {
+        if (auto file = getEntryByPath(path)) {
+            *size = file->second;
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+
+    std::unique_ptr<FileAdapter> open(const char *path, const char *mode) {
+        if (!strcmp(mode, "r")) {
+            return filesystem->open(path, "r");
+        } else if (!strcmp(mode, "w")) {
+
+            if (strlen(path) < sizeof(MO_FILENAME_PREFIX) - 1) {
+                MO_DBG_ERR("invalid fn");
+                return nullptr;
+            }
+
+            const char *fn = path + sizeof(MO_FILENAME_PREFIX) - 1;
+
+            auto file = filesystem->open(path, "w");
+            if (!file) {
+                return nullptr;
+            }
+
+            IndexEntry *entry = nullptr;
+            if (!(entry = getEntryByFname(fn))) {
+                index.push_back({fn, 0});
+                entry = &index.back();
+            }
+
+            if (!entry) {
+                MO_DBG_ERR("internal error");
+                return nullptr;
+            }
+
+            entry->second = 0; //write always empties the file
+
+            return std::unique_ptr<IndexedFileAdapter>(new IndexedFileAdapter(*this, entry->first.c_str(), std::move(file)));
+        } else {
+            MO_DBG_ERR("only support r or w");
+            return nullptr;
+        }
+    }
+
+    bool remove(const char *path) override {
+        if (strlen(path) >= sizeof(MO_FILENAME_PREFIX) - 1) {
+            //valid path
+            const char *fn = path + sizeof(MO_FILENAME_PREFIX) - 1;
+            index.erase(std::remove_if(index.begin(), index.end(),
+                [fn] (const IndexEntry& el) -> bool {
+                    return el.first.compare(fn) == 0;
+                }), index.end());
+        }
+
+        return filesystem->remove(path);
+    }
+
+    int ftw_root(std::function<int(const char *fpath)> fn) {
+        for (const auto& file : index) {
+            if (!fn(file.first.c_str())) {
+                return -1;
+            }
+        }
+        return 0;
+    }
+
+    bool createIndex() {
+        if (!index.empty()) {
+            return false;
+        }
+        auto ret = filesystem->ftw_root([this] (const char *fn) -> int {
+            int ret;
+            char path [MO_MAX_PATH_SIZE];
+
+            ret = snprintf(path, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "%s", fn);
+            if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
+                MO_DBG_ERR("fn error: %i", ret);
+                return 0; //ignore this entry and continue ftw
+            }
+
+            size_t size;
+            ret = filesystem->stat(path, &size);
+            if (ret == 0) {
+                //add fn and size to index
+                MO_DBG_DEBUG("add file to index: %s (%zuB)", fn, size);
+                index.push_back({fn, size});
+                return 0; //successfully added filename to index
+            } else {
+                MO_DBG_ERR("unexpected entry: %s", fn);
+                return 0; //ignore this entry and continue ftw
+            }
+        });
+
+        return ret == 0;
+    }
+
+    void updateFilesize(const char *fn, size_t size) {
+        if (auto entry = getEntryByFname(fn)) {
+            entry->second = size;
+            MO_DBG_DEBUG("update index: %s (%zuB)", entry->first.c_str(), entry->second);
+        }
+    }
+};
+
+IndexedFileAdapter::IndexedFileAdapter(FilesystemAdapterIndex& index, const char *fn, std::unique_ptr<FileAdapter> file)
+        : index(index), file(std::move(file)) {
+    snprintf(this->fn, sizeof(this->fn), "%s", fn);
+}
+
+IndexedFileAdapter::~IndexedFileAdapter() {
+    index.updateFilesize(fn, written);
+}
+
+size_t IndexedFileAdapter::read(char *buf, size_t len) {
+    return file->read(buf, len);
+}
+
+size_t IndexedFileAdapter::write(const char *buf, size_t len) {
+    auto ret = file->write(buf, len);
+    written += ret;
+    return ret;
+}
+
+size_t IndexedFileAdapter::seek(size_t offset) {
+    auto ret = file->seek(offset);
+    written = ret;
+    return ret;
+}
+
+int IndexedFileAdapter::read() {
+    return file->read();
+}
+
+std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapterIndexed(FilesystemOpt config) {
+    if (auto cached = filesystemCache.lock()) {
+        return cached;
+    }
+
+    auto filesystem = makeDefaultFilesystemAdapter(config);
+    if (!filesystem) {
+        return nullptr;
+    }
+
+    auto fsIndex = std::make_shared<FilesystemAdapterIndex>(std::move(filesystem));
+    if (!fsIndex) {
+        MO_DBG_ERR("OOM");
+        return nullptr;
+    }
+
+    if (!fsIndex->createIndex()) {
+        MO_DBG_ERR("createIndex err");
+        return nullptr;
+    }
+
+    filesystemCache = fsIndex;
+    return fsIndex;
+}
+
+} //end namespace MicroOcpp
+
+#endif //MO_ENABLE_FILE_INDEX

--- a/src/MicroOcpp/Core/FilesystemAdapter.h
+++ b/src/MicroOcpp/Core/FilesystemAdapter.h
@@ -51,6 +51,10 @@
 #endif
 #endif
 
+#ifndef MO_ENABLE_FILE_INDEX
+#define MO_ENABLE_FILE_INDEX 0
+#endif
+
 namespace MicroOcpp {
 
 class FileAdapter {
@@ -84,16 +88,6 @@ public:
  * Returns null if platform is not supported or Filesystem is disabled
  */
 std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt config);
-
-#ifndef MO_ENABLE_FILE_INDEX
-#define MO_ENABLE_FILE_INDEX 0
-#endif
-
-#if MO_ENABLE_FILE_INDEX
-
-std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapterIndexed(FilesystemOpt config);
-
-#endif // MO_ENABLE_FILE_INDEX
 
 } //end namespace MicroOcpp
 

--- a/src/MicroOcpp/Core/FilesystemAdapter.h
+++ b/src/MicroOcpp/Core/FilesystemAdapter.h
@@ -85,6 +85,16 @@ public:
  */
 std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapter(FilesystemOpt config);
 
+#ifndef MO_ENABLE_FILE_INDEX
+#define MO_ENABLE_FILE_INDEX 0
+#endif
+
+#if MO_ENABLE_FILE_INDEX
+
+std::shared_ptr<FilesystemAdapter> makeDefaultFilesystemAdapterIndexed(FilesystemOpt config);
+
+#endif // MO_ENABLE_FILE_INDEX
+
 } //end namespace MicroOcpp
 
 #endif

--- a/src/MicroOcpp/Core/FilesystemUtils.cpp
+++ b/src/MicroOcpp/Core/FilesystemUtils.cpp
@@ -116,7 +116,7 @@ bool FilesystemUtils::storeJson(std::shared_ptr<FilesystemAdapter> filesystem, c
 }
 
 bool FilesystemUtils::remove_if(std::shared_ptr<FilesystemAdapter> filesystem, std::function<bool(const char*)> pred) {
-    return filesystem->ftw_root([filesystem, pred] (const char *fpath) {
+    auto ret = filesystem->ftw_root([filesystem, pred] (const char *fpath) {
         if (pred(fpath) && fpath[0] != '.') {
 
             char fn [MO_MAX_PATH_SIZE] = {'\0'};
@@ -130,5 +130,12 @@ bool FilesystemUtils::remove_if(std::shared_ptr<FilesystemAdapter> filesystem, s
             //no error handling - just skip failed file
         }
         return 0;
-    }) == 0;
+    });
+
+    if (ret != 0) {
+        MO_DBG_ERR("ftw_root: %i", ret);
+        (void)0;
+    }
+
+    return ret == 0;
 }


### PR DESCRIPTION
Add an index of all stored files in the OCPP folder on the filesystem. MO will look up if a file exists using the index instead of the host system's `stat` implementation.

On SPIFFS, a high memory usage can lead to a significant slowdown of file operations. That is especially a problem for `stat` which MicroOcpp uses often and in bursts. The index is a minimal data structure which keeps track of all files existing in the OCPP folder and thereby avoiding `stat` after the initial enrollment.

To enable, set the build flag `MO_ENABLE_FILE_INDEX=1` (disabled by default).

Use it with caution. If MO uses this file index implementation, then all operations on the MO files must go through the same file index instance. This is relevant if files are changed manually while MO is running.