### PR TITLE
Fix transactions freeze in offline mode

### DIFF
--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -146,7 +146,6 @@ bool Connector::ocppPermitsCharge() {
     return transaction &&
             transaction->isRunning() &&
             transaction->isActive() &&
-            !isFaulted() &&
             !suspendDeAuthorizedIdTag;
 }
 
@@ -154,6 +153,9 @@ void Connector::loop() {
 
     if (!trackLoopExecute) {
         trackLoopExecute = true;
+        if (connectorPluggedInput) {
+            freeVendTrackPlugged = connectorPluggedInput();
+        }
     }
 
     if (transaction && transaction->isAborted() && MO_TX_CLEAN_ABORTED) {
@@ -181,7 +183,7 @@ void Connector::loop() {
         transaction = nullptr;
     }
 
-    if (transaction && transaction->isCompleted()) {
+    if (transaction && transaction->getStopSync().isRequested()) {
         MO_DBG_DEBUG("collect obsolete transaction %u-%u", connectorId, transaction->getTxNr());
         transaction = nullptr;
     }
@@ -384,11 +386,14 @@ void Connector::loop() {
             trackErrorDataInputs[index] = false;
         }
     }
-    
+
     if (status != currentStatus) {
+        MO_DBG_DEBUG("Status changed %s -> %s %s",
+                currentStatus == ChargePointStatus::NOT_SET ? "" : cstrFromOcppEveState(currentStatus),
+                cstrFromOcppEveState(status),
+                minimumStatusDurationInt->getInt() ? " (will report delayed)" : "");
         currentStatus = status;
         t_statusTransition = mocpp_tick_ms();
-        MO_DBG_DEBUG("Status changed%s", minimumStatusDurationInt->getInt() ? ", will report delayed" : "");
     }
 
     if (reportedStatus != currentStatus &&

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
         if (dt <= 0 ||                              //normal case: interval elapsed
                 dt > clockAlignedDataIntervalInt->getInt()) {   //special case: clock has been adjusted or first run
 
-            MO_DBG_DEBUG("Clock aligned measurement %" PRId32 "s: %s", dt,
+            MO_DBG_DEBUG("Clock aligned measurement %ds: %s", dt,
                 abs(dt) <= 60 ?
                 "in time (tolerance <= 60s)" : "off, e.g. because of first run. Ignore");
             if (abs(dt) <= 60) { //is measurement still "clock-aligned"?

--- a/src/MicroOcpp/Operations/StopTransaction.cpp
+++ b/src/MicroOcpp/Operations/StopTransaction.cpp
@@ -127,6 +127,12 @@ std::unique_ptr<DynamicJsonDocument> StopTransaction::createReq() {
         }
     }
 
+    // if StopTx timestamp is before StartTx timestamp, something probably went wrong. Restore reasonable temporal order
+    if (transaction->getStopTimestamp() < transaction->getStartTimestamp()) {
+        MO_DBG_WARN("set stopTime = startTime because stopTime was before startTime");
+        transaction->setStopTimestamp(transaction->getStartTimestamp() + 1); //1s behind startTime to keep order in backend DB
+    }
+
     for (auto mv = transactionData.begin(); mv != transactionData.end(); mv++) {
         if ((*mv)->getTimestamp() < MIN_TIME) {
             //time off. Try to adjust, otherwise send invalid value


### PR DESCRIPTION
The transaction queue could get stuck if PreBootTransactions were enabled (i.e. the charger is allowed to start transactions before the BootNotification succeeds). This PR contains the corresponding fixes.

Furthermore, the format specifier `PRId32` caused problems with `int` and this PR changes it to `%d`.