### PR TITLE
Fall back to offline authorization immediately when WebSocket unconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 
 - Replace `PollResult<bool>` with enum `UnlockConnectorResult`
 - Rename master branch into main
+- Tx logic directly checks if WebSocket is offline ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 
 ### Added
 
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint
-- Function `bool isConnected()` in `Connection` interface
+- Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging
 - Operation GetInstalledCertificateIds, UC M03 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))
 - Operation DeleteCertificate, UC M04 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint
+- Function `bool isConnected()` in `Connection` interface
 - Build flags for customizing memory limits of SmartCharging
 - Operation GetInstalledCertificateIds, UC M03 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))
 - Operation DeleteCertificate, UC M04 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))

--- a/src/MicroOcpp/Core/Connection.cpp
+++ b/src/MicroOcpp/Core/Connection.cpp
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #include <MicroOcpp/Core/Connection.h>
@@ -10,7 +10,7 @@ using namespace MicroOcpp;
 void LoopbackConnection::loop() { }
 
 bool LoopbackConnection::sendTXT(const char *msg, size_t length) {
-    if (!connected) {
+    if (!connected || !online) {
         return false;
     }
     if (receiveTXT) {
@@ -31,6 +31,13 @@ unsigned long LoopbackConnection::getLastRecv() {
 
 unsigned long LoopbackConnection::getLastConnected() {
     return lastConn;
+}
+
+void LoopbackConnection::setOnline(bool online) {
+    if (online) {
+        lastConn = mocpp_tick_ms();
+    }
+    this->online = online;
 }
 
 void LoopbackConnection::setConnected(bool connected) {

--- a/src/MicroOcpp/Core/Connection.h
+++ b/src/MicroOcpp/Core/Connection.h
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #ifndef MO_CONNECTION_H
@@ -11,7 +11,7 @@
 #include <MicroOcpp/Platform.h>
 
 //On all platforms other than Arduino, the integrated WS lib (links2004/arduinoWebSockets) cannot be
-//used. On Arduino it's usage is optional.
+//used. On Arduino its usage is optional.
 #ifndef MO_CUSTOM_WS
 #if MO_PLATFORM != MO_PLATFORM_ARDUINO
 #define MO_CUSTOM_WS
@@ -46,6 +46,8 @@ public:
 
     /*
      * Returns the timestamp of the last incoming message. Use mocpp_tick_ms() for creating the correct timestamp
+     *
+     * DEPRECATED: this function is superseded by isConnected(). Will be removed in MO v2.0
      */
     virtual unsigned long getLastRecv() {return 0;}
 
@@ -53,6 +55,20 @@ public:
      * Returns the timestamp of the last time a connection got successfully established. Use mocpp_tick_ms() for creating the correct timestamp
      */
     virtual unsigned long getLastConnected() = 0;
+
+    /*
+     * NEW IN v1.1
+     *
+     * Returns true if the connection is open; false if the charger is known to be offline.
+     * 
+     * This function determines if MO is in "offline mode". In offline mode, MO doesn't wait for Authorize responses
+     * before performing fully local authorization. If the connection is disrupted but isConnected is still true, then
+     * MO will first wait for a timeout to expire (20 seconds) before going into offline mode.
+     * 
+     * Returning true will have no further effects other than  using the timeout-then-offline mechanism. If the
+     * connection status is uncertain, it's best to return true by default.
+     */
+    virtual bool isConnected() {return true;} //MO ignores true. This default implementation keeps backwards-compatibility
 };
 
 class LoopbackConnection : public Connection {
@@ -70,7 +86,7 @@ public:
     unsigned long getLastConnected() override;
 
     void setConnected(bool connected);
-    bool isConnected() {return connected;}
+    bool isConnected() override {return connected;}
 };
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/Connection.h
+++ b/src/MicroOcpp/Core/Connection.h
@@ -75,7 +75,9 @@ class LoopbackConnection : public Connection {
 private:
     ReceiveTXTcallback receiveTXT;
 
-    bool connected = true; //for simulating connection losses
+    //for simulating connection losses
+    bool online = true;
+    bool connected = true;
     unsigned long lastRecv = 0;
     unsigned long lastConn = 0;
 public:
@@ -85,7 +87,9 @@ public:
     unsigned long getLastRecv() override;
     unsigned long getLastConnected() override;
 
-    void setConnected(bool connected);
+    void setOnline(bool online); //"online": sent messages are going through
+    bool isOnline() {return online;}
+    void setConnected(bool connected); //"connected": connection has been established, but messages may not go through (e.g. weak connection)
     bool isConnected() override {return connected;}
 };
 

--- a/src/MicroOcpp/Core/Context.cpp
+++ b/src/MicroOcpp/Core/Context.cpp
@@ -68,3 +68,7 @@ OperationRegistry& Context::getOperationRegistry() {
 const ProtocolVersion& Context::getVersion() {
     return model.getVersion();
 }
+
+Connection& Context::getConnection() {
+    return connection;
+}

--- a/src/MicroOcpp/Core/Context.h
+++ b/src/MicroOcpp/Core/Context.h
@@ -44,6 +44,8 @@ public:
     OperationRegistry& getOperationRegistry();
 
     const ProtocolVersion& getVersion();
+
+    Connection& getConnection();
 };
 
 } //end namespace MicroOcpp

--- a/tests/ChargingSessions.cpp
+++ b/tests/ChargingSessions.cpp
@@ -1,3 +1,7 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
 #include <MicroOcpp.h>
 #include <MicroOcpp/Core/Connection.h>
 #include <MicroOcpp/Core/Context.h>
@@ -182,7 +186,7 @@ TEST_CASE( "Charging sessions" ) {
     SECTION("Preboot transactions - tx before BootNotification") {
         mocpp_deinitialize();
 
-        loopback.setConnected(false);
+        loopback.setOnline(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
         declareConfiguration<bool>(MO_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
@@ -232,7 +236,7 @@ TEST_CASE( "Charging sessions" ) {
                 REQUIRE((adjustmentDelay > 3600 - 10 && adjustmentDelay < 3600 + 10));
             });
         
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
 
         REQUIRE(checkStartProcessed);
@@ -243,7 +247,7 @@ TEST_CASE( "Charging sessions" ) {
 
         mocpp_deinitialize();
 
-        loopback.setConnected(false);
+        loopback.setOnline(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
         declareConfiguration<bool>(MO_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
@@ -273,7 +277,7 @@ TEST_CASE( "Charging sessions" ) {
             checkProcessed = true;
         });
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
 
         loop();
 
@@ -294,7 +298,7 @@ TEST_CASE( "Charging sessions" ) {
 
         mocpp_deinitialize();
 
-        loopback.setConnected(false);
+        loopback.setOnline(false);
         mocpp_initialize(loopback, ChargerCredentials("test-runner1234"));
 
         declareConfiguration<bool>(MO_CONFIG_EXT_PREFIX "PreBootTransactions", true, CONFIGURATION_FN)->setBool(true);
@@ -332,7 +336,7 @@ TEST_CASE( "Charging sessions" ) {
                 REQUIRE(adjustmentDelay == 1);
             });
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
 
         loop();
 

--- a/tests/ConfigurationBehavior.cpp
+++ b/tests/ConfigurationBehavior.cpp
@@ -1,3 +1,7 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
 #include <MicroOcpp.h>
 #include <MicroOcpp/Core/Connection.h>
 #include <MicroOcpp/Core/Context.h>
@@ -143,7 +147,7 @@ TEST_CASE( "Configuration Behavior" ) {
         auto authorizationTimeoutInt = declareConfiguration<int>(MO_CONFIG_EXT_PREFIX "AuthorizationTimeout", 1);
         authorizationTimeoutInt->setInt(1); //try normal Authorize for 1s, then enter offline mode
 
-        loopback.setConnected(false); //connection loss
+        loopback.setOnline(false); //connection loss
 
         SECTION("set true") {
             configBool->setBool(true);
@@ -171,7 +175,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         endTransaction();
-        loopback.setConnected(true);
+        loopback.setOnline(true);
     }
 
     SECTION("LocalPreAuthorize") {
@@ -187,7 +191,7 @@ TEST_CASE( "Configuration Behavior" ) {
         loopback.sendTXT(localListMsg, strlen(localListMsg));
         loop();
 
-        loopback.setConnected(false); //connection loss
+        loopback.setOnline(false); //connection loss
 
         SECTION("set true - accepted idtag") {
             configBool->setBool(true);
@@ -206,7 +210,7 @@ TEST_CASE( "Configuration Behavior" ) {
 
             REQUIRE(connector->getStatus() == ChargePointStatus::Preparing);
 
-            loopback.setConnected(true);
+            loopback.setOnline(true);
             mtime += 20000; //Authorize will be retried after a few seconds
             loop();
 
@@ -214,7 +218,7 @@ TEST_CASE( "Configuration Behavior" ) {
         }
 
         endTransaction();
-        loopback.setConnected(true);
+        loopback.setOnline(true);
     }
 
     mocpp_deinitialize();

--- a/tests/LocalAuthList.cpp
+++ b/tests/LocalAuthList.cpp
@@ -1,3 +1,7 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
 #include <MicroOcpp.h>
 #include <MicroOcpp/Core/Connection.h>
 #include "./catch2/catch.hpp"
@@ -92,7 +96,7 @@ TEST_CASE( "LocalAuth" ) {
         });
 
         //begin transaction and delay Authorize request - tx should start immediately
-        loopback.setConnected(false); //Authorize delayed by short offline period
+        loopback.setOnline(false); //Authorize delayed by short offline period
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -102,13 +106,13 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
         REQUIRE( checkTxAuthorized );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         endTransaction();
         loop();
 
         //begin transaction delay Authorize request, but idTag doesn't match local list - tx should start when online again
         checkTxAuthorized = false;
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -118,7 +122,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
         REQUIRE( !checkTxAuthorized );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
@@ -148,7 +152,7 @@ TEST_CASE( "LocalAuth" ) {
         });
 
         //make charger offline and begin tx - tx should begin after Authorize timeout
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -167,7 +171,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
         REQUIRE( checkTxAuthorized );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         endTransaction();
         loop();
 
@@ -178,7 +182,7 @@ TEST_CASE( "LocalAuth" ) {
                 checkTxTimeout = true;
             }
         });
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -196,7 +200,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
         REQUIRE( checkTxTimeout );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
     }
 
@@ -215,7 +219,7 @@ TEST_CASE( "LocalAuth" ) {
         });
 
         //make charger offline and begin tx - tx should begin after Authorize timeout
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -233,7 +237,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
         REQUIRE( checkTxAuthorized );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         endTransaction();
         loop();
     }
@@ -256,7 +260,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( authService->getLocalAuthorization("mIdTagExpired") );
 
         //begin transaction and delay Authorize request - cannot PreAuthorize because entry is expired
-        loopback.setConnected(false); //Authorize delayed by short offline period
+        loopback.setOnline(false); //Authorize delayed by short offline period
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -265,7 +269,7 @@ TEST_CASE( "LocalAuth" ) {
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
@@ -274,7 +278,7 @@ TEST_CASE( "LocalAuth" ) {
         loop();
 
         //begin transaction and delay Authorize request - cannot PreAuthorize because entry is unauthorized
-        loopback.setConnected(false); //Authorize delayed by short offline period
+        loopback.setOnline(false); //Authorize delayed by short offline period
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -283,7 +287,7 @@ TEST_CASE( "LocalAuth" ) {
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
@@ -309,7 +313,7 @@ TEST_CASE( "LocalAuth" ) {
         REQUIRE( authService->getLocalAuthorization("mIdTagAccepted") );
 
         //begin transaction and delay Authorize request - tx should start immediately
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -318,12 +322,12 @@ TEST_CASE( "LocalAuth" ) {
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         endTransaction();
         loop();
 
         //begin transaction, but idTag is expired - AllowOfflineTxForUnknownId must not apply
-        loopback.setConnected(false);
+        loopback.setOnline(false);
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -340,7 +344,7 @@ TEST_CASE( "LocalAuth" ) {
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
     }
 
@@ -376,7 +380,7 @@ TEST_CASE( "LocalAuth" ) {
                 });});
 
         //begin transaction and delay Authorize request - tx should start immediately
-        loopback.setConnected(false); //Authorize delayed by short offline period
+        loopback.setOnline(false); //Authorize delayed by short offline period
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );
 
@@ -394,7 +398,7 @@ TEST_CASE( "LocalAuth" ) {
             }
         });
 
-        loopback.setConnected(true);
+        loopback.setOnline(true);
         loop();
 
         REQUIRE( connector->getStatus() == ChargePointStatus::Available );


### PR DESCRIPTION
Check the connectivity status of the WebSocket before sending an Authorize request to find out if the charger is offline. 

Previously, MO always tried to send the Authorize request and entered the offline mode when Authorize timed out (after 20 seconds by default).

To implement this, the Connection allows checking if it's offline via `isConnected()`. Furthermore, the transaction logic needs access to the Connection instance.