### PR TITLE
OCPP 2.0.1 Add ocppPermitsCharge()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - Variables (non-persistent), UCs B05 - B07 ([#247](https://github.com/matth-x/MicroOcpp/pull/247), [#284](https://github.com/matth-x/MicroOcpp/pull/284))
     - Transactions (preview only), UCs E01 - E12 ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
     - StatusNotification compatibility ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
+    - ChangeAvailability compatibility ([#285](https://github.com/matth-x/MicroOcpp/pull/285))
 
 ### Fixed
 

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -515,6 +515,19 @@ bool ocppPermitsCharge(unsigned int connectorId) {
         MO_DBG_WARN("OCPP uninitialized");
         return false;
     }
+#if MO_ENABLE_V201
+    if (context->getVersion().major == 2) {
+        TransactionService::Evse *evse = nullptr;
+        if (auto txService = context->getModel().getTransactionService()) {
+            evse = txService->getEvse(connectorId);
+        }
+        if (!evse) {
+            MO_DBG_ERR("could not find EVSE");
+            return false;
+        }
+        return evse->ocppPermitsCharge();
+    }
+#endif
     auto connector = context->getModel().getConnector(connectorId);
     if (!connector) {
         MO_DBG_ERR("could not find connector");

--- a/src/MicroOcpp/Model/Transactions/TransactionService.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.cpp
@@ -417,6 +417,12 @@ const std::shared_ptr<MicroOcpp::Ocpp201::Transaction>& TransactionService::Evse
     return transaction;
 }
 
+bool TransactionService::Evse::ocppPermitsCharge() {
+    return transaction &&
+           transaction->active &&
+           transaction->isAuthorized;
+}
+
 bool TransactionService::isTxStartPoint(TxStartStopPoint check) {
     for (auto& v : txStartPointParsed) {
         if (v == check) {

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -59,6 +59,8 @@ public:
         bool abortTransaction(Ocpp201::Transaction::StopReason stopReason = Ocpp201::Transaction::StopReason::Other, Ocpp201::TransactionEventTriggerReason stopTrigger = Ocpp201::TransactionEventTriggerReason::AbnormalCondition);
 
         const std::shared_ptr<Ocpp201::Transaction>& getTransaction();
+
+        bool ocppPermitsCharge();
     };
 
     friend Evse;


### PR DESCRIPTION
Update `ocppPermitsCharge()` in MicroOcpp.h so that it determines the charge permission based on the selected OCPP version.

Furthermore, upgrade ChangeAvailability to be OCPP 2.0.1 compatible.