### PR TITLE
Eval operation error code before creating conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix transaction freeze in offline mode ([#279](https://github.com/matth-x/MicroOcpp/pull/279), [#287](https://github.com/matth-x/MicroOcpp/pull/287))
 - Fix compilation error caused by `PRId32` ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
 - Don't load FW-mngt. module when no handlers set
+- Avoid creating conf when operation fails ([#290](https://github.com/matth-x/MicroOcpp/pull/290))
 
 ## [1.0.3] - 2024-04-06
 

--- a/src/MicroOcpp/Core/Request.cpp
+++ b/src/MicroOcpp/Core/Request.cpp
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #include <MicroOcpp/Core/Request.h>
@@ -184,16 +184,16 @@ std::unique_ptr<DynamicJsonDocument> Request::createResponse(){
      * Create the OCPP message
      */
     std::unique_ptr<DynamicJsonDocument> response = nullptr;
-    std::unique_ptr<DynamicJsonDocument> payload = operation->createConf();
-    std::unique_ptr<DynamicJsonDocument> errorDetails = nullptr;
-    
+
     bool operationFailure = operation->getErrorCode() != nullptr;
 
-    if (!operationFailure && !payload) {
-        return nullptr; //confirmation message still pending
-    }
-
     if (!operationFailure) {
+
+        std::unique_ptr<DynamicJsonDocument> payload = operation->createConf();
+
+        if (!payload) {
+            return nullptr; //confirmation message still pending
+        }
 
         /*
          * Create OCPP-J Remote Procedure Call header
@@ -213,7 +213,7 @@ std::unique_ptr<DynamicJsonDocument> Request::createResponse(){
 
         const char *errorCode = operation->getErrorCode();
         const char *errorDescription = operation->getErrorDescription();
-        errorDetails = std::unique_ptr<DynamicJsonDocument>(operation->getErrorDetails());
+        std::unique_ptr<DynamicJsonDocument> errorDetails = std::unique_ptr<DynamicJsonDocument>(operation->getErrorDetails());
         if (!errorCode) { //catch corner case when payload is null but errorCode is not set too!
             errorCode = "GenericError";
             errorDescription = "Could not create payload (createConf() returns Null)";


### PR DESCRIPTION
Change the order of when the Operation methods get called. Applies to incoming requests.

Before (on error): create confirmation response, then check if Operation instance returns error code, then discard confirmation and respond with error code.

Now (on error): check if Operation instance returns error code, respond with error code.