### PR TITLE
Add more build switches for TLS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
     - name: Check out repository code
       uses: actions/checkout@v3
+    - name: Check out MbedTLS
+      uses: actions/checkout@v3
+      with:
+        repository: Mbed-TLS/mbedtls
+        ref: v2.28.1
+        path: lib/mbedtls
     - name: Get build tools
       run: |
         sudo apt update
@@ -25,23 +31,21 @@ jobs:
     - name: Get ArduinoJson
       run: wget -Uri https://github.com/bblanchon/ArduinoJson/releases/download/v6.21.3/ArduinoJson-v6.21.3.h -O ./src/ArduinoJson.h
     - name: Generate CMake build files
-      run: cmake -S . -B ./build
+      run: cmake -S . -B ./build -DMO_BUILD_UNIT_MBEDTLS=True
     - name: Compile
-      run: cmake --build ./build -j 16 --target mo_unit_tests
+      run: cmake --build ./build -j 32 --target mo_unit_tests
     - name: Configure FS
       run: mkdir mo_store
-    - name: Run tests
-      run: ./build/mo_unit_tests
     - name: Run tests (valgrind)
-      run: valgrind --error-exitcode=1 --leak-check=full ./build/mo_unit_tests
+      run: valgrind --error-exitcode=1 --leak-check=full ./build/mo_unit_tests --abort
     - name: Generate CMake build files (AddressSanitizer, UndefinedBehaviorSanitizer)
       run: |
         rm -r ./build
-        cmake -S . -B ./build -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address -fsanitize=undefined"
+        cmake -S . -B ./build -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address -fsanitize=undefined" -DMO_BUILD_UNIT_MBEDTLS=True
     - name: Compile (ASan, UBSan)
-      run: cmake --build ./build -j 16 --target mo_unit_tests
+      run: cmake --build ./build -j 32 --target mo_unit_tests
     - name: Run tests (ASan, UBSan)
-      run: ./build/mo_unit_tests
+      run: ./build/mo_unit_tests --abort
     - name: Create coverage report
       run: |
         lcov --directory . --capture --output-file coverage.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.pio
+build
+lib
+mo_store
+src/ArduinoJson*
+src/main.cpp
+coverage.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,22 @@
 
 ### Changed
 
-- Replace `PollResult<bool>` with enum `UnlockConnectorResult`
+- Replace `PollResult<bool>` with enum `UnlockConnectorResult` ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Rename master branch into main
 - Tx logic directly checks if WebSocket is offline ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
+- `ocppPermitsCharge` ignores Faulted state ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
 
 ### Added
 
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
-- Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint
+- Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
-- Build flags for customizing memory limits of SmartCharging
+- Build flags for customizing memory limits of SmartCharging ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))
 - Certificate Management, UCs M03 - M05 ([#262](https://github.com/matth-x/MicroOcpp/pull/262), [#274](https://github.com/matth-x/MicroOcpp/pull/274), [#292](https://github.com/matth-x/MicroOcpp/pull/292))
 - FTP Client ([#291](https://github.com/matth-x/MicroOcpp/pull/291))
 - `ProtocolVersion` selects v1.6 or v2.0.1 ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
-- Build flag `MO_ENABLE_V201` set to 1 enables OCPP 2.0.1 features ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
+- Build flag `MO_ENABLE_V201=1` enables OCPP 2.0.1 features ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
     - Variables (non-persistent), UCs B05 - B07 ([#247](https://github.com/matth-x/MicroOcpp/pull/247), [#284](https://github.com/matth-x/MicroOcpp/pull/284))
     - Transactions (preview only), UCs E01 - E12 ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
     - StatusNotification compatibility ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
@@ -28,15 +29,15 @@
 
 ### Fixed
 
-- Fix defect idTag check in `endTransaction`
+- Fix defect idTag check in `endTransaction` ([#275](https://github.com/matth-x/MicroOcpp/pull/275))
 - Make field localAuthorizationList in SendLocalList optional
 - Update charging profiles when flash disabled (relates to [#260](https://github.com/matth-x/MicroOcpp/pull/260))
-- Ignore UnlockConnector when handler not set
-- Reject ChargingProfile if unit not supported
+- Ignore UnlockConnector when handler not set ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
+- Reject ChargingProfile if unit not supported ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Fix building with debug level warn and error
 - Fix transaction freeze in offline mode ([#279](https://github.com/matth-x/MicroOcpp/pull/279), [#287](https://github.com/matth-x/MicroOcpp/pull/287))
 - Fix compilation error caused by `PRId32` ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
-- Don't load FW-mngt. module when no handlers set
+- Don't load FW-mngt. module when no handlers set ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Avoid creating conf when operation fails ([#290](https://github.com/matth-x/MicroOcpp/pull/290))
 
 ## [1.0.3] - 2024-04-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))
-- Operation GetInstalledCertificateIds, UC M03 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))
-- Operation DeleteCertificate, UC M04 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))
-- Operation InstallCertificate, UC M05 ([#262](https://github.com/matth-x/MicroOcpp/pull/262))
+- Certificate Management, UCs M03 - M05 ([#262](https://github.com/matth-x/MicroOcpp/pull/262), [#274](https://github.com/matth-x/MicroOcpp/pull/274), [#292](https://github.com/matth-x/MicroOcpp/pull/292))
+- FTP Client ([#291](https://github.com/matth-x/MicroOcpp/pull/291))
 - `ProtocolVersion` selects v1.6 or v2.0.1 ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
 - Build flag `MO_ENABLE_V201` set to 1 enables OCPP 2.0.1 features ([#247](https://github.com/matth-x/MicroOcpp/pull/247))
     - Variables (non-persistent), UCs B05 - B07 ([#247](https://github.com/matth-x/MicroOcpp/pull/247), [#284](https://github.com/matth-x/MicroOcpp/pull/284))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,14 +169,6 @@ if (MO_BUILD_UNIT_MBEDTLS)
     )
 endif()
 
-# add MbedTLS for testing (TODO integrate properly into build system)
-#add_subdirectory(lib/mbedtls)
-#target_link_libraries(mo_unit_tests PUBLIC 
-#    mbedtls
-#    mbedcrypto
-#    mbedx509
-#)
-
 target_include_directories(mo_unit_tests PUBLIC
     "./tests/catch2"
     "./tests/helpers"
@@ -197,6 +189,7 @@ target_compile_definitions(mo_unit_tests PUBLIC
     MO_ChargeProfileMaxStackLevel=2
     MO_ChargingScheduleMaxPeriods=4
     MO_MaxChargingProfilesInstalled=3
+    MO_ENABLE_CERT_MGMT=1
 )
 
 target_compile_options(mo_unit_tests PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ set(MO_SRC_UNIT
     tests/LocalAuthList.cpp
     tests/Variables.cpp
     tests/Transactions.cpp
-    #tests/Certificates.cpp # add if MbedTLS is available
+    tests/Certificates.cpp
 )
 
 add_executable(mo_unit_tests
@@ -155,6 +155,19 @@ add_executable(mo_unit_tests
     ${MO_SRC_UNIT}
     ./tests/catch2/catchMain.cpp
 )
+
+if (MO_BUILD_UNIT_MBEDTLS)
+    add_subdirectory(lib/mbedtls)
+    target_link_libraries(mo_unit_tests PUBLIC 
+        mbedtls
+        mbedcrypto
+        mbedx509
+    )
+
+    target_compile_definitions(mo_unit_tests PUBLIC
+        MO_ENABLE_MBEDTLS=1
+    )
+endif()
 
 # add MbedTLS for testing (TODO integrate properly into build system)
 #add_subdirectory(lib/mbedtls)
@@ -181,7 +194,6 @@ target_compile_definitions(mo_unit_tests PUBLIC
     MO_LocalAuthListMaxLength=8
     MO_SendLocalListMaxLength=4
     MO_ENABLE_FILE_INDEX=1
-    #MO_ENABLE_MBEDTLS=1
     MO_ChargeProfileMaxStackLevel=2
     MO_ChargingScheduleMaxPeriods=4
     MO_MaxChargingProfilesInstalled=3

--- a/src/MicroOcpp.h
+++ b/src/MicroOcpp.h
@@ -110,8 +110,7 @@ void mocpp_initialize(
             std::shared_ptr<MicroOcpp::FilesystemAdapter> filesystem =
                 MicroOcpp::makeDefaultFilesystemAdapter(MicroOcpp::FilesystemOpt::Use_Mount_FormatOnFail), //If this library should format the flash if necessary. Find further options in ConfigurationOptions.h
             bool autoRecover = false, //automatically sanitize the local data store when the lib detects recurring crashes. Not recommended during development
-            MicroOcpp::ProtocolVersion version = MicroOcpp::ProtocolVersion(1,6),
-            std::unique_ptr<MicroOcpp::CertificateStore> certStore = nullptr); //optionally use custom Cert Store (default depends on MbedTLS)
+            MicroOcpp::ProtocolVersion version = MicroOcpp::ProtocolVersion(1,6));
 
 /*
  * Stop the OCPP library and release allocated resources.
@@ -355,6 +354,22 @@ MicroOcpp::FirmwareService *getFirmwareService();
  * To use, add `#include <MicroOcpp/Model/Diagnostics/DiagnosticsService.h>`
  */
 MicroOcpp::DiagnosticsService *getDiagnosticsService();
+
+#if MO_ENABLE_CERT_MGMT
+/*
+ * Set a custom Certificate Store which implements certificate updates on the host system. 
+ * MicroOcpp will forward OCPP-side update requests to the certificate store, as well as
+ * query the certificate store upon server request.
+ *
+ * To enable OCPP-side certificate updates (UCs M03 - M05), set the build flag
+ * MO_ENABLE_CERT_MGMT=1 so that this function becomes accessible.
+ * 
+ * To use the built-in certificate store (depends on MbedTLS), set the build flag
+ * MO_ENABLE_MBEDTLS=1. To not use the built-in implementation, but still enable MbedTLS,
+ * additionally set MO_ENABLE_CERT_STORE_MBEDTLS=0.
+ */
+void setCertificateStore(std::unique_ptr<MicroOcpp::CertificateStore> certStore);
+#endif //MO_ENABLE_CERT_MGMT
 
 /*
  * Add features and customize the behavior of the OCPP client

--- a/src/MicroOcpp/Core/FtpMbedTLS.cpp
+++ b/src/MicroOcpp/Core/FtpMbedTLS.cpp
@@ -7,6 +7,7 @@
 #if MO_ENABLE_MBEDTLS
 
 #include <string>
+#include <string.h>
 #include <functional>
 
 #include "mbedtls/net_sockets.h"

--- a/src/MicroOcpp/Model/Certificates/Certificate.cpp
+++ b/src/MicroOcpp/Model/Certificates/Certificate.cpp
@@ -4,6 +4,8 @@
 
 #include <MicroOcpp/Model/Certificates/Certificate.h>
 
+#if MO_ENABLE_CERT_MGMT
+
 #include <string.h>
 #include <stdio.h>
 
@@ -161,3 +163,5 @@ int ocpp_cert_set_serialNumber(ocpp_cert_hash *dst, const char *hex_src) {
 
     return ret;
 }
+
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Model/Certificates/Certificate.h
+++ b/src/MicroOcpp/Model/Certificates/Certificate.h
@@ -5,6 +5,10 @@
 #ifndef MO_CERTIFICATE_H
 #define MO_CERTIFICATE_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -154,5 +158,5 @@ public:
 } //namespace MicroOcpp
 
 #endif //__cplusplus
-
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Model/Certificates/Certificate.h
+++ b/src/MicroOcpp/Model/Certificates/Certificate.h
@@ -144,6 +144,8 @@ struct CertificateChainHash {
  */
 class CertificateStore {
 public:
+    virtual ~CertificateStore() = default;
+
     virtual GetInstalledCertificateStatus getCertificateIds(const std::vector<GetCertificateIdType>& certificateType, std::vector<CertificateChainHash>& out) = 0;
     virtual DeleteCertificateStatus deleteCertificate(const CertificateHash& hash) = 0;
     virtual InstallCertificateStatus installCertificate(InstallCertificateType certificateType, const char *certificate) = 0;

--- a/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.cpp
+++ b/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.cpp
@@ -4,7 +4,7 @@
 
 #include <MicroOcpp/Model/Certificates/CertificateMbedTLS.h>
 
-#if MO_ENABLE_MBEDTLS && MO_ENABLE_CERT_STORE_MBEDTLS
+#if MO_ENABLE_CERT_MGMT && MO_ENABLE_CERT_STORE_MBEDTLS
 
 #include <string.h>
 
@@ -412,4 +412,4 @@ bool printCertFn(const char *certType, size_t index, char *buf, size_t bufsize) 
 
 } //namespace MicroOcpp
 
-#endif //MO_ENABLE_MBEDTLS && MO_ENABLE_CERT_STORE_MBEDTLS
+#endif //MO_ENABLE_CERT_MGMT && MO_ENABLE_CERT_STORE_MBEDTLS

--- a/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.cpp
+++ b/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.cpp
@@ -15,19 +15,7 @@
 
 #include <MicroOcpp/Debug.h>
 
-bool ocpp_get_cert_hash(const unsigned char *buf, size_t len, HashAlgorithmType hashAlg, ocpp_cert_hash *out) {
-
-    mbedtls_x509_crt cacert;
-    mbedtls_x509_crt_init(&cacert);
-
-    int ret;
-
-    if((ret = mbedtls_x509_crt_parse(&cacert, buf, len + 1)) < 0) {
-        char err [100];
-        mbedtls_strerror(ret, err, 100);
-        MO_DBG_ERR("mbedtls_x509_crt_parse: %i -- %s", ret, err);
-        return false;
-    }
+bool ocpp_get_cert_hash(mbedtls_x509_crt& cacert, HashAlgorithmType hashAlg, ocpp_cert_hash *out) {
 
     if (cacert.next) {
         MO_DBG_ERR("only sole root certs supported");
@@ -71,6 +59,8 @@ bool ocpp_get_cert_hash(const unsigned char *buf, size_t len, HashAlgorithmType 
         MO_DBG_ERR("missing issuer name");
         return false;
     }
+
+    int ret;
 
     if ((ret = mbedtls_md(md_info, cacert.issuer_raw.p, cacert.issuer_raw.len, out->issuerNameHash))) {
         MO_DBG_ERR("mbedtls_md: %i", ret);
@@ -120,6 +110,26 @@ bool ocpp_get_cert_hash(const unsigned char *buf, size_t len, HashAlgorithmType 
     memcpy(out->serialNumber, cacert.serial.p + serial_begin, out->serialNumberLen);
 
     return true;
+}
+
+bool ocpp_get_cert_hash(const unsigned char *buf, size_t len, HashAlgorithmType hashAlg, ocpp_cert_hash *out) {
+
+    mbedtls_x509_crt cacert;
+    mbedtls_x509_crt_init(&cacert);
+
+    bool success = false;
+    int ret;
+
+    if((ret = mbedtls_x509_crt_parse(&cacert, buf, len + 1)) >= 0) {
+        success = ocpp_get_cert_hash(cacert, hashAlg, out);
+    } else {
+        char err [100];
+        mbedtls_strerror(ret, err, 100);
+        MO_DBG_ERR("mbedtls_x509_crt_parse: %i -- %s", ret, err);
+    }
+
+    mbedtls_x509_crt_free(&cacert);
+    return success;
 }
 
 namespace MicroOcpp {

--- a/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.h
+++ b/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.h
@@ -9,13 +9,14 @@
  * Built-in implementation of the Certificate interface for MbedTLS
  */
 
+#include <MicroOcpp/Version.h>
 #include <MicroOcpp/Platform.h>
 
 #ifndef MO_ENABLE_CERT_STORE_MBEDTLS
-#define MO_ENABLE_CERT_STORE_MBEDTLS 1
+#define MO_ENABLE_CERT_STORE_MBEDTLS MO_ENABLE_MBEDTLS
 #endif
 
-#if MO_ENABLE_MBEDTLS && MO_ENABLE_CERT_STORE_MBEDTLS
+#if MO_ENABLE_CERT_MGMT && MO_ENABLE_CERT_STORE_MBEDTLS
 
 /*
  * Provide certificate interpreter to facilitate cert store in C. A full implementation is only available for C++
@@ -64,6 +65,6 @@ bool printCertFn(const char *certType, size_t index, char *buf, size_t bufsize);
 } //namespace MicroOcpp
 
 #endif //def __cplusplus
-#endif //MO_ENABLE_MBEDTLS && MO_ENABLE_CERT_STORE_MBEDTLS
+#endif //MO_ENABLE_CERT_MGMT && MO_ENABLE_CERT_STORE_MBEDTLS
 
 #endif

--- a/src/MicroOcpp/Model/Certificates/CertificateService.cpp
+++ b/src/MicroOcpp/Model/Certificates/CertificateService.cpp
@@ -3,6 +3,9 @@
 // MIT License
 
 #include <MicroOcpp/Model/Certificates/CertificateService.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Core/Context.h>
 #include <MicroOcpp/Operations/DeleteCertificate.h>
 #include <MicroOcpp/Operations/GetInstalledCertificateIds.h>
@@ -10,8 +13,8 @@
 
 using namespace MicroOcpp;
 
-CertificateService::CertificateService(Context& context, std::unique_ptr<CertificateStore> certStore)
-        : context(context), certStore(std::move(certStore)) {
+CertificateService::CertificateService(Context& context)
+        : context(context) {
 
     context.getOperationRegistry().registerOperation("DeleteCertificate", [this] () {
         return new Ocpp201::DeleteCertificate(*this);});
@@ -21,6 +24,12 @@ CertificateService::CertificateService(Context& context, std::unique_ptr<Certifi
         return new Ocpp201::InstallCertificate(*this);});
 }
 
+void CertificateService::setCertificateStore(std::unique_ptr<CertificateStore> certStore) {
+    this->certStore = std::move(certStore);
+}
+
 CertificateStore *CertificateService::getCertificateStore() {
     return certStore.get();
 }
+
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Model/Certificates/CertificateService.h
+++ b/src/MicroOcpp/Model/Certificates/CertificateService.h
@@ -14,6 +14,10 @@
 #ifndef MO_CERTIFICATESERVICE_H
 #define MO_CERTIFICATESERVICE_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <functional>
 #include <memory>
 
@@ -28,11 +32,13 @@ private:
     Context& context;
     std::unique_ptr<CertificateStore> certStore;
 public:
-    CertificateService(Context& context, std::unique_ptr<CertificateStore> certStore);
+    CertificateService(Context& context);
 
+    void setCertificateStore(std::unique_ptr<CertificateStore> certStore);
     CertificateStore *getCertificateStore();
 };
 
 }
 
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Model/Certificates/Certificate_c.cpp
+++ b/src/MicroOcpp/Model/Certificates/Certificate_c.cpp
@@ -3,6 +3,9 @@
 // MIT License
 
 #include <MicroOcpp/Model/Certificates/Certificate_c.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Debug.h>
 
 #include <string.h>
@@ -70,3 +73,4 @@ std::unique_ptr<CertificateStore> makeCertificateStoreCwrapper(ocpp_cert_store *
 }
 
 } //namespace MicroOcpp
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Model/Certificates/Certificate_c.h
+++ b/src/MicroOcpp/Model/Certificates/Certificate_c.h
@@ -5,6 +5,10 @@
 #ifndef MO_CERTIFICATE_C_H
 #define MO_CERTIFICATE_C_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <stddef.h>
 
 #include <MicroOcpp/Model/Certificates/Certificate.h>
@@ -44,6 +48,7 @@ std::unique_ptr<CertificateStore> makeCertificateStoreCwrapper(ocpp_cert_store *
 
 } //namespace MicroOcpp
 
-#endif //defined __cplusplus
+#endif //__cplusplus
 
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Model/Model.cpp
+++ b/src/MicroOcpp/Model/Model.cpp
@@ -198,6 +198,7 @@ ResetService *Model::getResetService() const {
     return resetService.get();
 }
 
+#if MO_ENABLE_CERT_MGMT
 void Model::setCertificateService(std::unique_ptr<CertificateService> cs) {
     this->certService = std::move(cs);
     capabilitiesUpdated = true;
@@ -206,6 +207,7 @@ void Model::setCertificateService(std::unique_ptr<CertificateService> cs) {
 CertificateService *Model::getCertificateService() const {
     return certService.get();
 }
+#endif //MO_ENABLE_CERT_MGMT
 
 #if MO_ENABLE_V201
 void Model::setVariableService(std::unique_ptr<VariableService> vs) {

--- a/src/MicroOcpp/Model/Model.h
+++ b/src/MicroOcpp/Model/Model.h
@@ -24,7 +24,10 @@ class AuthorizationService;
 class ReservationService;
 class BootService;
 class ResetService;
+
+#if MO_ENABLE_CERT_MGMT
 class CertificateService;
+#endif //MO_ENABLE_CERT_MGMT
 
 #if MO_ENABLE_V201
 class VariableService;
@@ -33,7 +36,7 @@ class TransactionService;
 namespace Ocpp201 {
 class ResetService;
 }
-#endif
+#endif //MO_ENABLE_V201
 
 class Model {
 private:
@@ -49,7 +52,10 @@ private:
     std::unique_ptr<ReservationService> reservationService;
     std::unique_ptr<BootService> bootService;
     std::unique_ptr<ResetService> resetService;
+
+#if MO_ENABLE_CERT_MGMT
     std::unique_ptr<CertificateService> certService;
+#endif //MO_ENABLE_CERT_MGMT
 
 #if MO_ENABLE_V201
     std::unique_ptr<VariableService> variableService;
@@ -113,8 +119,10 @@ public:
     void setResetService(std::unique_ptr<ResetService> rs);
     ResetService *getResetService() const;
 
+#if MO_ENABLE_CERT_MGMT
     void setCertificateService(std::unique_ptr<CertificateService> cs);
     CertificateService *getCertificateService() const;
+#endif //MO_ENABLE_CERT_MGMT
 
 #if MO_ENABLE_V201
     void setVariableService(std::unique_ptr<VariableService> vs);

--- a/src/MicroOcpp/Operations/DeleteCertificate.cpp
+++ b/src/MicroOcpp/Operations/DeleteCertificate.cpp
@@ -3,6 +3,9 @@
 // MIT License
 
 #include <MicroOcpp/Operations/DeleteCertificate.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Model/Certificates/Certificate.h>
 #include <MicroOcpp/Model/Certificates/CertificateService.h>
 #include <MicroOcpp/Debug.h>
@@ -88,3 +91,5 @@ std::unique_ptr<DynamicJsonDocument> DeleteCertificate::createConf(){
     payload["status"] = status;
     return doc;
 }
+
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Operations/DeleteCertificate.h
+++ b/src/MicroOcpp/Operations/DeleteCertificate.h
@@ -5,6 +5,10 @@
 #ifndef MO_DELETECERTIFICATE_H
 #define MO_DELETECERTIFICATE_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Core/Operation.h>
 
 namespace MicroOcpp {
@@ -33,4 +37,5 @@ public:
 } //end namespace Ocpp201
 } //end namespace MicroOcpp
 
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Operations/GetInstalledCertificateIds.cpp
+++ b/src/MicroOcpp/Operations/GetInstalledCertificateIds.cpp
@@ -3,6 +3,9 @@
 // MIT License
 
 #include <MicroOcpp/Operations/GetInstalledCertificateIds.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Model/Certificates/Certificate.h>
 #include <MicroOcpp/Model/Certificates/CertificateService.h>
 #include <MicroOcpp/Debug.h>
@@ -123,3 +126,5 @@ std::unique_ptr<DynamicJsonDocument> GetInstalledCertificateIds::createConf() {
 
     return doc;
 }
+
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Operations/GetInstalledCertificateIds.h
+++ b/src/MicroOcpp/Operations/GetInstalledCertificateIds.h
@@ -5,6 +5,10 @@
 #ifndef MO_GETINSTALLEDCERTIFICATEIDS_H
 #define MO_GETINSTALLEDCERTIFICATEIDS_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Core/Operation.h>
 #include <MicroOcpp/Model/Certificates/Certificate.h>
 
@@ -35,4 +39,5 @@ public:
 } //end namespace Ocpp201
 } //end namespace MicroOcpp
 
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Operations/InstallCertificate.cpp
+++ b/src/MicroOcpp/Operations/InstallCertificate.cpp
@@ -3,6 +3,9 @@
 // MIT License
 
 #include <MicroOcpp/Operations/InstallCertificate.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Model/Certificates/CertificateService.h>
 #include <MicroOcpp/Debug.h>
 
@@ -77,3 +80,5 @@ std::unique_ptr<DynamicJsonDocument> InstallCertificate::createConf(){
     payload["status"] = status;
     return doc;
 }
+
+#endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Operations/InstallCertificate.h
+++ b/src/MicroOcpp/Operations/InstallCertificate.h
@@ -5,6 +5,10 @@
 #ifndef MO_INSTALLCERTIFICATE_H
 #define MO_INSTALLCERTIFICATE_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_CERT_MGMT
+
 #include <MicroOcpp/Core/Operation.h>
 
 namespace MicroOcpp {
@@ -33,4 +37,5 @@ public:
 } //end namespace Ocpp201
 } //end namespace MicroOcpp
 
+#endif //MO_ENABLE_CERT_MGMT
 #endif

--- a/src/MicroOcpp/Version.h
+++ b/src/MicroOcpp/Version.h
@@ -18,6 +18,8 @@
 #define MO_ENABLE_V201 0
 #endif
 
+#ifdef __cplusplus
+
 namespace MicroOcpp {
 
 /*
@@ -29,5 +31,12 @@ struct ProtocolVersion {
 };
 
 }
+
+#endif //__cplusplus
+
+// Certificate Management (UCs M03 - M05)
+#ifndef MO_ENABLE_CERT_MGMT
+#define MO_ENABLE_CERT_MGMT 0
+#endif
 
 #endif

--- a/src/MicroOcpp/Version.h
+++ b/src/MicroOcpp/Version.h
@@ -6,7 +6,7 @@
 #define MO_VERSION_H
 
 /*
- * Version specification of MicroOcpp library (unrelated with the OCPP version)
+ * Version specification of MicroOcpp library (not related with the OCPP version)
  */
 #define MO_VERSION "1.1.0"
 
@@ -34,9 +34,9 @@ struct ProtocolVersion {
 
 #endif //__cplusplus
 
-// Certificate Management (UCs M03 - M05)
+// Certificate Management (UCs M03 - M05). Works with OCPP 1.6 and 2.0.1
 #ifndef MO_ENABLE_CERT_MGMT
-#define MO_ENABLE_CERT_MGMT 0
+#define MO_ENABLE_CERT_MGMT MO_ENABLE_V201
 #endif
 
 #endif

--- a/src/MicroOcpp_c.cpp
+++ b/src/MicroOcpp_c.cpp
@@ -13,10 +13,10 @@
 MicroOcpp::Connection *ocppSocket = nullptr;
 
 void ocpp_initialize(OCPP_Connection *conn, const char *chargePointModel, const char *chargePointVendor, struct OCPP_FilesystemOpt fsopt, bool autoRecover) {
-    ocpp_initialize_full(conn, ChargerCredentials(chargePointModel, chargePointVendor), fsopt, autoRecover, NULL);
+    ocpp_initialize_full(conn, ChargerCredentials(chargePointModel, chargePointVendor), fsopt, autoRecover);
 }
 
-void ocpp_initialize_full(OCPP_Connection *conn, const char *bootNotificationCredentials, struct OCPP_FilesystemOpt fsopt, bool autoRecover, ocpp_cert_store *certs) {
+void ocpp_initialize_full(OCPP_Connection *conn, const char *bootNotificationCredentials, struct OCPP_FilesystemOpt fsopt, bool autoRecover) {
     if (!conn) {
         MO_DBG_ERR("conn is null");
     }
@@ -25,12 +25,7 @@ void ocpp_initialize_full(OCPP_Connection *conn, const char *bootNotificationCre
 
     MicroOcpp::FilesystemOpt adaptFsopt = fsopt;
 
-    std::unique_ptr<MicroOcpp::CertificateStore> certsCwrapper;
-    if (certs) {
-        certsCwrapper = MicroOcpp::makeCertificateStoreCwrapper(certs);
-    }
-
-    mocpp_initialize(*ocppSocket, bootNotificationCredentials, MicroOcpp::makeDefaultFilesystemAdapter(adaptFsopt), autoRecover, MicroOcpp::ProtocolVersion(1,6),std::move(certsCwrapper));
+    mocpp_initialize(*ocppSocket, bootNotificationCredentials, MicroOcpp::makeDefaultFilesystemAdapter(adaptFsopt), autoRecover, MicroOcpp::ProtocolVersion(1,6));
 }
 
 void ocpp_deinitialize() {
@@ -330,6 +325,16 @@ void ocpp_setOnResetNotify(bool (*onResetNotify)(bool)) {
 void ocpp_setOnResetExecute(void (*onResetExecute)(bool)) {
     setOnResetExecute([onResetExecute] (bool isHard) {onResetExecute(isHard);});
 }
+
+#if MO_ENABLE_CERT_MGMT
+void ocpp_setCertificateStore(ocpp_cert_store *certs) {
+    std::unique_ptr<MicroOcpp::CertificateStore> certsCwrapper;
+    if (certs) {
+        certsCwrapper = MicroOcpp::makeCertificateStoreCwrapper(certs);
+    }
+    setCertificateStore(std::move(certsCwrapper));
+}
+#endif //MO_ENABLE_CERT_MGMT
 
 void ocpp_setOnReceiveRequest(const char *operationType, OnMessage onRequest) {
     setOnReceiveRequest(operationType, adaptFn(onRequest));

--- a/src/MicroOcpp_c.h
+++ b/src/MicroOcpp_c.h
@@ -64,9 +64,7 @@ void ocpp_initialize_full(
             OCPP_Connection *conn,  //WebSocket adapter for MicroOcpp
             const char *bootNotificationCredentials, //e.g. '{"chargePointModel":"Demo Charger","chargePointVendor":"My Company Ltd."}' (refer to OCPP 1.6 Specification - Edition 2 p. 60)
             struct OCPP_FilesystemOpt fsopt, //If this library should format the flash if necessary. Find further options in ConfigurationOptions.h
-            bool autoRecover, //automatically sanitize the local data store when the lib detects recurring crashes. During development, `false` is recommended
-            ocpp_cert_store *certs); //optional. If provided, use given Cert Store, if NULL, use default (default depends on MbedTLS)
-
+            bool autoRecover); //automatically sanitize the local data store when the lib detects recurring crashes. During development, `false` is recommended
 
 void ocpp_deinitialize();
 
@@ -167,6 +165,10 @@ bool ocpp_isOperative_m(unsigned int connectorId);
 void ocpp_setOnResetNotify(bool (*onResetNotify)(bool));
 
 void ocpp_setOnResetExecute(void (*onResetExecute)(bool));
+
+#if MO_ENABLE_CERT_MGMT
+void ocpp_setCertificateStore(ocpp_cert_store *certs);
+#endif //MO_ENABLE_CERT_MGMT
 
 void ocpp_setOnReceiveRequest(const char *operationType, OnMessage onRequest);
 

--- a/tests/Certificates.cpp
+++ b/tests/Certificates.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Platform.h>
+
+#if MO_ENABLE_MBEDTLS
+
 #include <MicroOcpp.h>
 #include <MicroOcpp/Core/Connection.h>
 #include "./catch2/catch.hpp"
@@ -17,11 +21,6 @@
 
 #include <MicroOcpp/Model/Certificates/CertificateService.h>
 #include <MicroOcpp/Model/Certificates/CertificateMbedTLS.h>
-
-#if !MO_ENABLE_MBEDTLS
-#error Certificates unit tests depend on MbedTLS
-#endif
-
 
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
 
@@ -255,3 +254,7 @@ TEST_CASE( "M - Certificates" ) {
 
     mocpp_deinitialize();
 }
+
+#else
+#warning Certificates unit tests depend on MbedTLS
+#endif //MO_ENABLE_MBEDTLS


### PR DESCRIPTION
Add a global integration of MbedTLS into MicroOcpp.

At the moment, there are two (optional) features of MicroOcpp which relate to TLS:

- Certificate Management (UCs M03 - M05)
- FTP client

The Certificate Management module consists of an ordinary messaging part which does not depend on MbedTLS (can be reused with other TLS libraries) and a reference implementation of the required X.509 certificate parsing and storage functions which do depend on MbedTLS.

With this PR, the following switches exist to control the TLS-related modules:

- `MO_ENABLE_MBEDTLS=1`: enable modules which depend on MbedTLS
- `MO_ENABLE_CERT_MGMT=1`: enable general Certificate Management support
- `MO_ENABLE_CERT_STORE_MBEDTLS=1`: enable Certificate Management X.509 parsing and storage implementation

cmake switches:

- `MO_BUILD_UNIT_MBEDTLS=True`: build unit tests with MbedTLS (requires copy in `lib/mbedtls` checked out to `v2.28.1` - must be done by hand)

This PR removes the `certStore` parameter from the `mocpp_initialize(...)` functions again (planned for the 1.1.0 release, but now withdrawn). A custom cert store implementation can be set via `setCertificateStore(...)` now.

Furthermore, this PR adds a .gitignore. If someone needs more entries, feel free to make suggestions!