### PR TITLE
Update / fix MeterValues format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix compilation error caused by `PRId32` ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
 - Don't load FW-mngt. module when no handlers set ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Avoid creating conf when operation fails ([#290](https://github.com/matth-x/MicroOcpp/pull/290))
+- Fix whitespaces in MeterValues
 
 ## [1.0.3] - 2024-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Rename master branch into main
 - Tx logic directly checks if WebSocket is offline ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - `ocppPermitsCharge` ignores Faulted state ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
+- `setEnergyMeterInput` expects `int` input ([#301](https://github.com/matth-x/MicroOcpp/pull/301))
 
 ### Added
 
@@ -40,7 +41,7 @@
 - Fix compilation error caused by `PRId32` ([#279](https://github.com/matth-x/MicroOcpp/pull/279))
 - Don't load FW-mngt. module when no handlers set ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Avoid creating conf when operation fails ([#290](https://github.com/matth-x/MicroOcpp/pull/290))
-- Fix whitespaces in MeterValues
+- Fix whitespaces in MeterValues ([#301](https://github.com/matth-x/MicroOcpp/pull/301))
 
 ## [1.0.3] - 2024-04-06
 

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -563,7 +563,7 @@ void setConnectorPluggedInput(std::function<bool()> pluggedInput, unsigned int c
     connector->setConnectorPluggedInput(pluggedInput);
 }
 
-void setEnergyMeterInput(std::function<float()> energyInput, unsigned int connectorId) {
+void setEnergyMeterInput(std::function<int()> energyInput, unsigned int connectorId) {
     if (!context) {
         MO_DBG_ERR("OCPP uninitialized"); //need to call mocpp_initialize before
         return;
@@ -576,8 +576,8 @@ void setEnergyMeterInput(std::function<float()> energyInput, unsigned int connec
     SampledValueProperties meterProperties;
     meterProperties.setMeasurand("Energy.Active.Import.Register");
     meterProperties.setUnit("Wh");
-    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>>(
-                           new SampledValueSamplerConcrete<float, SampledValueDeSerializer<float>>(
+    auto mvs = std::unique_ptr<SampledValueSamplerConcrete<int, SampledValueDeSerializer<int>>>(
+                           new SampledValueSamplerConcrete<int, SampledValueDeSerializer<int>>(
             meterProperties,
             [energyInput] (ReadingContext) {return energyInput();}
     ));

--- a/src/MicroOcpp.h
+++ b/src/MicroOcpp.h
@@ -266,9 +266,9 @@ bool ocppPermitsCharge(unsigned int connectorId = 1);
 
 void setConnectorPluggedInput(std::function<bool()> pluggedInput, unsigned int connectorId = 1); //Input about if an EV is plugged to this EVSE
 
-void setEnergyMeterInput(std::function<float()> energyInput, unsigned int connectorId = 1); //Input of the electricity meter register
+void setEnergyMeterInput(std::function<int()> energyInput, unsigned int connectorId = 1); //Input of the electricity meter register in Wh
 
-void setPowerMeterInput(std::function<float()> powerInput, unsigned int connectorId = 1); //Input of the power meter reading
+void setPowerMeterInput(std::function<float()> powerInput, unsigned int connectorId = 1); //Input of the power meter reading in W
 
 //Smart Charging Output, alternative for Watts only, Current only, or Watts x Current x numberPhases. Only one
 //of them can be set at a time

--- a/src/MicroOcpp/Model/Metering/SampledValue.cpp
+++ b/src/MicroOcpp/Model/Metering/SampledValue.cpp
@@ -1,10 +1,14 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #include <MicroOcpp/Model/Metering/SampledValue.h>
 #include <MicroOcpp/Debug.h>
 #include <cinttypes>
+
+#ifndef MO_SAMPLEDVALUE_FLOAT_FORMAT
+#define MO_SAMPLEDVALUE_FLOAT_FORMAT "%.2f"
+#endif
 
 using namespace MicroOcpp;
 
@@ -15,6 +19,13 @@ int32_t SampledValueDeSerializer<int32_t>::deserialize(const char *str) {
 std::string SampledValueDeSerializer<int32_t>::serialize(int32_t& val) {
     char str [12] = {'\0'};
     snprintf(str, 12, "%" PRId32, val);
+    return std::string(str);
+}
+
+std::string SampledValueDeSerializer<float>::serialize(float& val) {
+    char str [20];
+    str[0] = '\0';
+    snprintf(str, 20, MO_SAMPLEDVALUE_FLOAT_FORMAT, val);
     return std::string(str);
 }
 

--- a/src/MicroOcpp/Model/Metering/SampledValue.h
+++ b/src/MicroOcpp/Model/Metering/SampledValue.h
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #ifndef SAMPLEDVALUE_H
@@ -36,11 +36,7 @@ class SampledValueDeSerializer<float> { // Used in meterValues
 public:
     static float deserialize(const char *str) {return atof(str);}
     static bool ready(float& val) {return true;} //float is always valid
-    static std::string serialize(float& val) {
-        char str[20];
-        dtostrf(val,4,1,str);
-        return std::string(str);
-    }
+    static std::string serialize(float& val);
     static int32_t toInteger(float& val) {return (int32_t) val;}
 };
 

--- a/src/MicroOcpp/Platform.cpp
+++ b/src/MicroOcpp/Platform.cpp
@@ -1,5 +1,5 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
 #include <MicroOcpp/Platform.h>
@@ -79,12 +79,4 @@ unsigned long mocpp_tick_ms_unix() {
     return (unsigned long) ms.count();
 }
 #endif
-#endif
-
-#if MO_PLATFORM != MO_PLATFORM_ARDUINO
-void dtostrf(float value, int min_width, int num_digits_after_decimal, char *target){
-    char fmt[20];
-    sprintf(fmt, "%%%d.%df", min_width, num_digits_after_decimal);
-    sprintf(target, fmt, value);
-}
 #endif

--- a/src/MicroOcpp/Platform.h
+++ b/src/MicroOcpp/Platform.h
@@ -102,10 +102,6 @@ unsigned long mocpp_tick_ms_unix();
 #endif
 #endif
 
-#if MO_PLATFORM != MO_PLATFORM_ARDUINO
-void dtostrf(float value, int min_width, int num_digits_after_decimal, char *target);
-#endif
-
 #ifndef MO_ENABLE_MBEDTLS
 #define MO_ENABLE_MBEDTLS 0
 #endif

--- a/tests/Metering.cpp
+++ b/tests/Metering.cpp
@@ -289,8 +289,7 @@ TEST_CASE("Metering") {
 
         setOnReceiveRequest("MeterValues", [base, &checkProcessed] (JsonObject payload) {
             checkProcessed = true;
-            REQUIRE((!strcmp(payload["meterValue"][0]["sampledValue"][0]["value"] | "", "3600") ||
-                     !strcmp(payload["meterValue"][0]["sampledValue"][0]["value"] | "", "3600.0")));
+            REQUIRE( !strncmp(payload["meterValue"][0]["sampledValue"][0]["value"] | "", "3600", strlen("3600")) );
         });
 
         loop();


### PR DESCRIPTION
Change the data type of the default EnergyMeterInput to int.

It may be necessary to patch the data format in the host system integration. For example, the previous usage

```cpp
setEnergyMeterInput([] () -> float {
    return /* energy_register */;
});
```

would become

```cpp
setEnergyMeterInput([] () -> int {
    return /* (int) energy_register */;
});
```

Furthermore, this PR fixes the float format in MeterValues which contained white spaces in some scenarios (e.g. `" 0.0"`).