### PR TITLE
Allow to disable Reservation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
-- Build flag `MO_ENABLE_V16_RESERVATION=0` disables Reservation module
+- Build flag `MO_ENABLE_V16_RESERVATION=0` disables Reservation module ([#302](https://github.com/matth-x/MicroOcpp/pull/302))
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
+- Build flag `MO_ENABLE_V16_RESERVATION=0` disables Reservation module
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -289,8 +289,11 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
         new HeartbeatService(*context)));
     model.setAuthorizationService(std::unique_ptr<AuthorizationService>(
         new AuthorizationService(*context, filesystem)));
+
+#if MO_ENABLE_V16_RESERVATION
     model.setReservationService(std::unique_ptr<ReservationService>(
         new ReservationService(*context, MO_NUMCONNECTORS)));
+#endif
 
 #if MO_ENABLE_V201
     model.setVariableService(std::unique_ptr<VariableService>(

--- a/src/MicroOcpp/Model/Model.cpp
+++ b/src/MicroOcpp/Model/Model.cpp
@@ -54,25 +54,27 @@ void Model::loop() {
 
     if (chargeControlCommon)
         chargeControlCommon->loop();
-    
+
     if (smartChargingService)
         smartChargingService->loop();
-    
+
     if (heartbeatService)
         heartbeatService->loop();
-    
+
     if (meteringService)
         meteringService->loop();
-    
+
     if (diagnosticsService)
         diagnosticsService->loop();
-    
+
     if (firmwareService)
         firmwareService->loop();
-    
+
+#if MO_ENABLE_V16_RESERVATION
     if (reservationService)
         reservationService->loop();
-    
+#endif //MO_ENABLE_V16_RESERVATION
+
     if (resetService)
         resetService->loop();
 
@@ -171,6 +173,7 @@ AuthorizationService *Model::getAuthorizationService() {
     return authorizationService.get();
 }
 
+#if MO_ENABLE_V16_RESERVATION
 void Model::setReservationService(std::unique_ptr<ReservationService> rs) {
     reservationService = std::move(rs);
     capabilitiesUpdated = true;
@@ -179,6 +182,7 @@ void Model::setReservationService(std::unique_ptr<ReservationService> rs) {
 ReservationService *Model::getReservationService() {
     return reservationService.get();
 }
+#endif //MO_ENABLE_V16_RESERVATION
 
 void Model::setBootService(std::unique_ptr<BootService> bs){
     bootService = std::move(bs);
@@ -286,12 +290,14 @@ void Model::updateSupportedStandardProfiles() {
         }
     }
 
+#if MO_ENABLE_V16_RESERVATION
     if (reservationService) {
         if (!strstr(supportedFeatureProfilesString->getString(), "Reservation")) {
             if (!buf.empty()) buf += ',';
             buf += "Reservation";
         }
     }
+#endif //MO_ENABLE_V16_RESERVATION
 
     if (smartChargingService) {
         if (!strstr(supportedFeatureProfilesString->getString(), "SmartCharging")) {

--- a/src/MicroOcpp/Model/Model.h
+++ b/src/MicroOcpp/Model/Model.h
@@ -21,9 +21,12 @@ class FirmwareService;
 class DiagnosticsService;
 class HeartbeatService;
 class AuthorizationService;
-class ReservationService;
 class BootService;
 class ResetService;
+
+#if MO_ENABLE_V16_RESERVATION
+class ReservationService;
+#endif //MO_ENABLE_V16_RESERVATION
 
 #if MO_ENABLE_CERT_MGMT
 class CertificateService;
@@ -49,9 +52,12 @@ private:
     std::unique_ptr<DiagnosticsService> diagnosticsService;
     std::unique_ptr<HeartbeatService> heartbeatService;
     std::unique_ptr<AuthorizationService> authorizationService;
-    std::unique_ptr<ReservationService> reservationService;
     std::unique_ptr<BootService> bootService;
     std::unique_ptr<ResetService> resetService;
+
+#if MO_ENABLE_V16_RESERVATION
+    std::unique_ptr<ReservationService> reservationService;
+#endif //MO_ENABLE_V16_RESERVATION
 
 #if MO_ENABLE_CERT_MGMT
     std::unique_ptr<CertificateService> certService;
@@ -110,8 +116,10 @@ public:
     void setAuthorizationService(std::unique_ptr<AuthorizationService> authorizationService);
     AuthorizationService *getAuthorizationService();
 
+#if MO_ENABLE_V16_RESERVATION
     void setReservationService(std::unique_ptr<ReservationService> reservationService);
     ReservationService *getReservationService();
+#endif //MO_ENABLE_V16_RESERVATION
 
     void setBootService(std::unique_ptr<BootService> bs);
     BootService *getBootService() const;

--- a/src/MicroOcpp/Model/Reservation/Reservation.cpp
+++ b/src/MicroOcpp/Model/Reservation/Reservation.cpp
@@ -1,6 +1,10 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Model/Reservation/Reservation.h>
 #include <MicroOcpp/Model/Model.h>
@@ -130,3 +134,5 @@ void Reservation::clear() {
 
     configuration_save();
 }
+
+#endif //MO_ENABLE_V16_RESERVATION

--- a/src/MicroOcpp/Model/Reservation/Reservation.h
+++ b/src/MicroOcpp/Model/Reservation/Reservation.h
@@ -1,9 +1,13 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef RESERVATION_H
-#define RESERVATION_H
+#ifndef MO_RESERVATION_H
+#define MO_RESERVATION_H
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Core/Time.h>
@@ -65,4 +69,5 @@ public:
 
 }
 
+#endif //MO_ENABLE_V16_RESERVATION
 #endif

--- a/src/MicroOcpp/Model/Reservation/ReservationService.cpp
+++ b/src/MicroOcpp/Model/Reservation/ReservationService.cpp
@@ -28,8 +28,8 @@ ReservationService::ReservationService(Context& context, unsigned int numConnect
 
     reserveConnectorZeroSupportedBool = declareConfiguration<bool>("ReserveConnectorZeroSupported", true, CONFIGURATION_VOLATILE, true);
     
-    context.getOperationRegistry().registerOperation("CancelReservation", [&context] () {
-        return new Ocpp16::CancelReservation(context.getModel());});
+    context.getOperationRegistry().registerOperation("CancelReservation", [this] () {
+        return new Ocpp16::CancelReservation(*this);});
     context.getOperationRegistry().registerOperation("ReserveNow", [&context] () {
         return new Ocpp16::ReserveNow(context.getModel());});
 }

--- a/src/MicroOcpp/Model/Reservation/ReservationService.cpp
+++ b/src/MicroOcpp/Model/Reservation/ReservationService.cpp
@@ -1,6 +1,10 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Model/Reservation/ReservationService.h>
 #include <MicroOcpp/Core/Context.h>
@@ -210,3 +214,5 @@ bool ReservationService::updateReservation(int reservationId, unsigned int conne
     MO_DBG_ERR("error finding blocking reservation");
     return false;
 }
+
+#endif //MO_ENABLE_V16_RESERVATION

--- a/src/MicroOcpp/Model/Reservation/ReservationService.h
+++ b/src/MicroOcpp/Model/Reservation/ReservationService.h
@@ -1,9 +1,13 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef RESERVATIONSERVICE_H
-#define RESERVATIONSERVICE_H
+#ifndef MO_RESERVATIONSERVICE_H
+#define MO_RESERVATIONSERVICE_H
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Model/Reservation/Reservation.h>
 
@@ -44,4 +48,5 @@ public:
 
 }
 
+#endif //MO_ENABLE_V16_RESERVATION
 #endif

--- a/src/MicroOcpp/Operations/CancelReservation.cpp
+++ b/src/MicroOcpp/Operations/CancelReservation.cpp
@@ -1,15 +1,18 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
+
 #include <MicroOcpp/Operations/CancelReservation.h>
-#include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Reservation/ReservationService.h>
 #include <MicroOcpp/Debug.h>
 
 using MicroOcpp::Ocpp16::CancelReservation;
 
-CancelReservation::CancelReservation(Model& model) : model(model) {
+CancelReservation::CancelReservation(ReservationService& reservationService) : reservationService(reservationService) {
   
 }
 
@@ -23,13 +26,9 @@ void CancelReservation::processReq(JsonObject payload) {
         return;
     }
 
-    if (model.getReservationService()) {
-        if (auto reservation = model.getReservationService()->getReservationById(payload["reservationId"])) {
-            found = true;
-            reservation->clear();
-        }
-    } else {
-        errorCode = "InternalError";
+    if (auto reservation = reservationService.getReservationById(payload["reservationId"])) {
+        found = true;
+        reservation->clear();
     }
 }
 
@@ -43,3 +42,5 @@ std::unique_ptr<DynamicJsonDocument> CancelReservation::createConf(){
     }
     return doc;
 }
+
+#endif //MO_ENABLE_V16_RESERVATION

--- a/src/MicroOcpp/Operations/CancelReservation.h
+++ b/src/MicroOcpp/Operations/CancelReservation.h
@@ -1,25 +1,29 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef CANCELRESERVATION_H
-#define CANCELRESERVATION_H
+#ifndef MO_CANCELRESERVATION_H
+#define MO_CANCELRESERVATION_H
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Core/Operation.h>
 
 namespace MicroOcpp {
 
-class Model;
+class ReservationService;
 
 namespace Ocpp16 {
 
 class CancelReservation : public Operation {
 private:
-    Model& model;
+    ReservationService& reservationService;
     bool found = false;
     const char *errorCode = nullptr;
 public:
-    CancelReservation(Model& model);
+    CancelReservation(ReservationService& reservationService);
 
     const char* getOperationType() override;
 
@@ -33,4 +37,5 @@ public:
 } //end namespace Ocpp16
 } //end namespace MicroOcpp
 
+#endif //MO_ENABLE_V16_RESERVATION
 #endif

--- a/src/MicroOcpp/Operations/ReserveNow.cpp
+++ b/src/MicroOcpp/Operations/ReserveNow.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
+
 #include <MicroOcpp/Operations/ReserveNow.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Reservation/ReservationService.h>
@@ -123,3 +127,5 @@ std::unique_ptr<DynamicJsonDocument> ReserveNow::createConf(){
     
     return doc;
 }
+
+#endif //MO_ENABLE_V16_RESERVATION

--- a/src/MicroOcpp/Operations/ReserveNow.h
+++ b/src/MicroOcpp/Operations/ReserveNow.h
@@ -1,9 +1,13 @@
 // matth-x/MicroOcpp
-// Copyright Matthias Akstaller 2019 - 2023
+// Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef RESERVENOW_H
-#define RESERVENOW_H
+#ifndef MO_RESERVENOW_H
+#define MO_RESERVENOW_H
+
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_V16_RESERVATION
 
 #include <MicroOcpp/Core/Operation.h>
 
@@ -35,4 +39,5 @@ public:
 } //end namespace Ocpp16
 } //end namespace MicroOcpp
 
+#endif //MO_ENABLE_V16_RESERVATION
 #endif

--- a/src/MicroOcpp/Version.h
+++ b/src/MicroOcpp/Version.h
@@ -39,4 +39,9 @@ struct ProtocolVersion {
 #define MO_ENABLE_CERT_MGMT MO_ENABLE_V201
 #endif
 
+// Reservations, OCPP 1.6 implementation
+#ifndef MO_ENABLE_V16_RESERVATION
+#define MO_ENABLE_V16_RESERVATION 1
+#endif
+
 #endif

--- a/tests/Reservation.cpp
+++ b/tests/Reservation.cpp
@@ -12,6 +12,8 @@
 #include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Model/Reservation/ReservationService.h>
 
+#if MO_ENABLE_V16_RESERVATION
+
 
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
 
@@ -504,3 +506,5 @@ TEST_CASE( "Reservation" ) {
 
     mocpp_deinitialize();
 }
+
+#endif //MO_ENABLE_V16_RESERVATION


### PR DESCRIPTION
Add build flag `MO_ENABLE_V16_RESERVATION` which allows to disable the Reservation functionality.

As a result of disabling the Reservation module, MicroOcpp rejects incoming ReserveNow and CancelReservation messages and does not advertise Reservation support in the SupportedFeatureProfiles configuration. All code is excluded from the compiled firmware, which saves some flash space on top.

To disable Reservation, set the build flag `MO_ENABLE_V16_RESERVATION=0`. The Reservation module is enabled by default, so `MO_ENABLE_V16_RESERVATION` doesn't need to be explicitly set to 1 otherwise.