### PR TITLE
Allow to disable Local Authorization module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Build flag `MO_ENABLE_V16_RESERVATION=0` disables Reservation module ([#302](https://github.com/matth-x/MicroOcpp/pull/302))
-- Build flag `MO_ENABLE_LOCAL_AUTH=0` disables LocalAuthList module
+- Build flag `MO_ENABLE_LOCAL_AUTH=0` disables LocalAuthList module ([#303](https://github.com/matth-x/MicroOcpp/pull/303))
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - File index ([#270](https://github.com/matth-x/MicroOcpp/pull/270))
 - Config `Cst_TxStartOnPowerPathClosed` to put back TxStartPoint ([#271](https://github.com/matth-x/MicroOcpp/pull/271))
 - Build flag `MO_ENABLE_V16_RESERVATION=0` disables Reservation module ([#302](https://github.com/matth-x/MicroOcpp/pull/302))
+- Build flag `MO_ENABLE_LOCAL_AUTH=0` disables LocalAuthList module
 - Function `bool isConnected()` in `Connection` interface ([#282](https://github.com/matth-x/MicroOcpp/pull/282))
 - Build flags for customizing memory limits of SmartCharging ([#260](https://github.com/matth-x/MicroOcpp/pull/260))
 - SConscript ([#287](https://github.com/matth-x/MicroOcpp/pull/287))

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -287,8 +287,11 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
     model.setConnectors(std::move(connectors));
     model.setHeartbeatService(std::unique_ptr<HeartbeatService>(
         new HeartbeatService(*context)));
+
+#if MO_ENABLE_LOCAL_AUTH
     model.setAuthorizationService(std::unique_ptr<AuthorizationService>(
         new AuthorizationService(*context, filesystem)));
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
     model.setReservationService(std::unique_ptr<ReservationService>(

--- a/src/MicroOcpp/Model/Authorization/AuthorizationData.cpp
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationData.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Model/Authorization/AuthorizationData.h>
 
 using namespace MicroOcpp;
@@ -152,3 +156,5 @@ MicroOcpp::AuthorizationStatus MicroOcpp::deserializeAuthorizationStatus(const c
         return AuthorizationStatus::UNDEFINED;
     }
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH

--- a/src/MicroOcpp/Model/Authorization/AuthorizationData.h
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationData.h
@@ -5,6 +5,10 @@
 #ifndef MO_AUTHORIZATIONDATA_H
 #define MO_AUTHORIZATIONDATA_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Operations/CiStrings.h>
 #include <MicroOcpp/Core/Time.h>
 #include <ArduinoJson.h>
@@ -64,4 +68,5 @@ public:
 
 }
 
+#endif //MO_ENABLE_LOCAL_AUTH
 #endif

--- a/src/MicroOcpp/Model/Authorization/AuthorizationList.cpp
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationList.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Model/Authorization/AuthorizationList.h>
 #include <MicroOcpp/Debug.h>
 
@@ -194,3 +198,5 @@ void AuthorizationList::writeJson(JsonArray authListOut, bool compact) {
 size_t AuthorizationList::size() {
     return localAuthorizationList.size();
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH

--- a/src/MicroOcpp/Model/Authorization/AuthorizationList.h
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationList.h
@@ -5,6 +5,10 @@
 #ifndef MO_AUTHORIZATIONLIST_H
 #define MO_AUTHORIZATIONLIST_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Model/Authorization/AuthorizationData.h>
 #include <vector>
 
@@ -41,4 +45,5 @@ public:
 
 }
 
+#endif //MO_ENABLE_LOCAL_AUTH
 #endif

--- a/src/MicroOcpp/Model/Authorization/AuthorizationService.cpp
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationService.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Model/Authorization/AuthorizationService.h>
 #include <MicroOcpp/Model/ConnectorBase/Connector.h>
 #include <MicroOcpp/Core/FilesystemUtils.h>
@@ -192,3 +196,5 @@ void AuthorizationService::notifyAuthorization(const char *idTag, JsonObject idT
         context.initiateRequest(std::move(statusNotification));
     }
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH

--- a/src/MicroOcpp/Model/Authorization/AuthorizationService.h
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationService.h
@@ -5,6 +5,10 @@
 #ifndef MO_AUTHORIZATIONSERVICE_H
 #define MO_AUTHORIZATIONSERVICE_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Model/Authorization/AuthorizationList.h>
 #include <MicroOcpp/Core/FilesystemAdapter.h>
 #include <MicroOcpp/Core/Configuration.h>
@@ -39,4 +43,5 @@ public:
 
 }
 
+#endif //MO_ENABLE_LOCAL_AUTH
 #endif

--- a/src/MicroOcpp/Model/Model.cpp
+++ b/src/MicroOcpp/Model/Model.cpp
@@ -164,6 +164,7 @@ void Model::setHeartbeatService(std::unique_ptr<HeartbeatService> hs) {
     capabilitiesUpdated = true;
 }
 
+#if MO_ENABLE_LOCAL_AUTH
 void Model::setAuthorizationService(std::unique_ptr<AuthorizationService> as) {
     authorizationService = std::move(as);
     capabilitiesUpdated = true;
@@ -172,6 +173,7 @@ void Model::setAuthorizationService(std::unique_ptr<AuthorizationService> as) {
 AuthorizationService *Model::getAuthorizationService() {
     return authorizationService.get();
 }
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
 void Model::setReservationService(std::unique_ptr<ReservationService> rs) {
@@ -283,12 +285,14 @@ void Model::updateSupportedStandardProfiles() {
         }
     }
 
+#if MO_ENABLE_LOCAL_AUTH
     if (authorizationService) {
         if (!strstr(supportedFeatureProfilesString->getString(), "LocalAuthListManagement")) {
             if (!buf.empty()) buf += ',';
             buf += "LocalAuthListManagement";
         }
     }
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
     if (reservationService) {

--- a/src/MicroOcpp/Model/Model.h
+++ b/src/MicroOcpp/Model/Model.h
@@ -20,9 +20,12 @@ class MeteringService;
 class FirmwareService;
 class DiagnosticsService;
 class HeartbeatService;
-class AuthorizationService;
 class BootService;
 class ResetService;
+
+#if MO_ENABLE_LOCAL_AUTH
+class AuthorizationService;
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
 class ReservationService;
@@ -51,9 +54,12 @@ private:
     std::unique_ptr<FirmwareService> firmwareService;
     std::unique_ptr<DiagnosticsService> diagnosticsService;
     std::unique_ptr<HeartbeatService> heartbeatService;
-    std::unique_ptr<AuthorizationService> authorizationService;
     std::unique_ptr<BootService> bootService;
     std::unique_ptr<ResetService> resetService;
+
+#if MO_ENABLE_LOCAL_AUTH
+    std::unique_ptr<AuthorizationService> authorizationService;
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
     std::unique_ptr<ReservationService> reservationService;
@@ -113,8 +119,10 @@ public:
 
     void setHeartbeatService(std::unique_ptr<HeartbeatService> heartbeatService);
 
+#if MO_ENABLE_LOCAL_AUTH
     void setAuthorizationService(std::unique_ptr<AuthorizationService> authorizationService);
     AuthorizationService *getAuthorizationService();
+#endif //MO_ENABLE_LOCAL_AUTH
 
 #if MO_ENABLE_V16_RESERVATION
     void setReservationService(std::unique_ptr<ReservationService> reservationService);

--- a/src/MicroOcpp/Operations/Authorize.cpp
+++ b/src/MicroOcpp/Operations/Authorize.cpp
@@ -42,9 +42,11 @@ void Authorize::processConf(JsonObject payload){
         MO_DBG_INFO("Request has been denied. Reason: %s", idTagInfo);
     }
 
-    if (model.getAuthorizationService()) {
-        model.getAuthorizationService()->notifyAuthorization(idTag, payload["idTagInfo"]);
+#if MO_ENABLE_LOCAL_AUTH
+    if (auto authService = model.getAuthorizationService()) {
+        authService->notifyAuthorization(idTag, payload["idTagInfo"]);
     }
+#endif //MO_ENABLE_LOCAL_AUTH
 }
 
 void Authorize::processReq(JsonObject payload){

--- a/src/MicroOcpp/Operations/GetLocalListVersion.cpp
+++ b/src/MicroOcpp/Operations/GetLocalListVersion.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Operations/GetLocalListVersion.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Authorization/AuthorizationService.h>
@@ -31,3 +35,5 @@ std::unique_ptr<DynamicJsonDocument> GetLocalListVersion::createConf(){
     }
     return doc;
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH

--- a/src/MicroOcpp/Operations/GetLocalListVersion.h
+++ b/src/MicroOcpp/Operations/GetLocalListVersion.h
@@ -5,6 +5,10 @@
 #ifndef MO_GETLOCALLISTVERSION_H
 #define MO_GETLOCALLISTVERSION_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Core/Operation.h>
 
 namespace MicroOcpp {
@@ -28,4 +32,6 @@ public:
 
 } //end namespace Ocpp16
 } //end namespace MicroOcpp
+
+#endif //MO_ENABLE_LOCAL_AUTH
 #endif

--- a/src/MicroOcpp/Operations/SendLocalList.cpp
+++ b/src/MicroOcpp/Operations/SendLocalList.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Operations/SendLocalList.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Authorization/AuthorizationService.h>
@@ -64,3 +68,5 @@ std::unique_ptr<DynamicJsonDocument> SendLocalList::createConf(){
     
     return doc;
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH

--- a/src/MicroOcpp/Operations/SendLocalList.h
+++ b/src/MicroOcpp/Operations/SendLocalList.h
@@ -5,6 +5,10 @@
 #ifndef MO_SENDLOCALLIST_H
 #define MO_SENDLOCALLIST_H
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp/Core/Operation.h>
 
 namespace MicroOcpp {
@@ -35,4 +39,6 @@ public:
 
 } //end namespace Ocpp16
 } //end namespace MicroOcpp
+
+#endif //MO_ENABLE_LOCAL_AUTH
 #endif

--- a/src/MicroOcpp/Operations/StartTransaction.cpp
+++ b/src/MicroOcpp/Operations/StartTransaction.cpp
@@ -10,6 +10,7 @@
 #include <MicroOcpp/Model/Transactions/TransactionStore.h>
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Debug.h>
+#include <MicroOcpp/Version.h>
 
 using MicroOcpp::Ocpp16::StartTransaction;
 
@@ -151,9 +152,11 @@ void StartTransaction::processConf(JsonObject payload) {
     transaction->getStartSync().confirm();
     transaction->commit();
 
+#if MO_ENABLE_LOCAL_AUTH
     if (auto authService = model.getAuthorizationService()) {
         authService->notifyAuthorization(transaction->getIdTag(), payload["idTagInfo"]);
     }
+#endif //MO_ENABLE_LOCAL_AUTH
 }
 
 void StartTransaction::processReq(JsonObject payload) {

--- a/src/MicroOcpp/Operations/StopTransaction.cpp
+++ b/src/MicroOcpp/Operations/StopTransaction.cpp
@@ -11,6 +11,7 @@
 #include <MicroOcpp/Model/Transactions/TransactionStore.h>
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Debug.h>
+#include <MicroOcpp/Version.h>
 
 using MicroOcpp::Ocpp16::StopTransaction;
 
@@ -202,9 +203,11 @@ void StopTransaction::processConf(JsonObject payload) {
 
     MO_DBG_INFO("Request has been accepted!");
 
+#if MO_ENABLE_LOCAL_AUTH
     if (auto authService = model.getAuthorizationService()) {
         authService->notifyAuthorization(transaction->getIdTag(), payload["idTagInfo"]);
     }
+#endif //MO_ENABLE_LOCAL_AUTH
 }
 
 bool StopTransaction::processErr(const char *code, const char *description, JsonObject details) {

--- a/src/MicroOcpp/Version.h
+++ b/src/MicroOcpp/Version.h
@@ -44,4 +44,9 @@ struct ProtocolVersion {
 #define MO_ENABLE_V16_RESERVATION 1
 #endif
 
+// Local Authorization, i.e. feature profile LocalAuthListManagement
+#ifndef MO_ENABLE_LOCAL_AUTH
+#define MO_ENABLE_LOCAL_AUTH 1
+#endif
+
 #endif

--- a/tests/ConfigurationBehavior.cpp
+++ b/tests/ConfigurationBehavior.cpp
@@ -10,6 +10,7 @@
 #include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Core/FilesystemUtils.h>
 #include <MicroOcpp/Debug.h>
+#include <MicroOcpp/Version.h>
 #include "./catch2/catch.hpp"
 #include "./helpers/testHelper.h"
 
@@ -178,6 +179,7 @@ TEST_CASE( "Configuration Behavior" ) {
         loopback.setOnline(true);
     }
 
+#if MO_ENABLE_LOCAL_AUTH
     SECTION("LocalPreAuthorize") {
         auto configBool = declareConfiguration<bool>("LocalPreAuthorize", true);
         auto authorizationTimeoutInt = declareConfiguration<int>(MO_CONFIG_EXT_PREFIX "AuthorizationTimeout", 20);
@@ -220,6 +222,7 @@ TEST_CASE( "Configuration Behavior" ) {
         endTransaction();
         loopback.setOnline(true);
     }
+#endif //MO_ENABLE_LOCAL_AUTH
 
     mocpp_deinitialize();
 }

--- a/tests/LocalAuthList.cpp
+++ b/tests/LocalAuthList.cpp
@@ -2,6 +2,10 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <MicroOcpp/Version.h>
+
+#if MO_ENABLE_LOCAL_AUTH
+
 #include <MicroOcpp.h>
 #include <MicroOcpp/Core/Connection.h>
 #include "./catch2/catch.hpp"
@@ -923,3 +927,5 @@ TEST_CASE( "LocalAuth" ) {
 
     mocpp_deinitialize();
 }
+
+#endif //MO_ENABLE_LOCAL_AUTH


### PR DESCRIPTION
Add build flag `MO_ENABLE_LOCAL_AUTH` which allows to disable the LocalAuthListManagement functionality.

The changes in this PR are same like the PR before (#302) for the Local Auth List functionality instead of Reservation. See the extended description there.