### PR TITLE
Optimize log functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(MO_SRC
     src/MicroOcpp/Operations/InstallCertificate.cpp
     src/MicroOcpp/Operations/UnlockConnector.cpp
     src/MicroOcpp/Operations/UpdateFirmware.cpp
+    src/MicroOcpp/Debug.cpp
     src/MicroOcpp/Platform.cpp
     src/MicroOcpp/Core/SimpleRequestFactory.cpp
     src/MicroOcpp/Core/OperationRegistry.cpp

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -445,7 +445,6 @@ bool endTransaction(const char *idTag, const char *reason, unsigned int connecto
             res = endTransaction_authorized(idTag, reason, connectorId);
         } else {
             MO_DBG_INFO("endTransaction: idTag doesn't match");
-            (void)0;
         }
     }
     return res;
@@ -977,7 +976,6 @@ void setCertificateStore(std::unique_ptr<MicroOcpp::CertificateStore> certStore)
         certService->setCertificateStore(std::move(certStore));
     } else {
         MO_DBG_ERR("OOM");
-        (void)0;
     }
 }
 #endif //MO_ENABLE_CERT_MGMT

--- a/src/MicroOcpp/Core/Configuration.cpp
+++ b/src/MicroOcpp/Core/Configuration.cpp
@@ -79,7 +79,6 @@ ConfigurationContainer *declareContainer(const char *filename, bool accessible) 
 
     if (container->isAccessible() != accessible) {
         MO_DBG_ERR("%s: conflicting accessibility declarations (expect %s)", filename, container->isAccessible() ? "accessible" : "inaccessible");
-        (void)0;
     }
 
     return container.get();
@@ -95,7 +94,6 @@ std::shared_ptr<Configuration> loadConfiguration(TConfig type, const char *key, 
             }
             if (container->isAccessible() != accessible) {
                 MO_DBG_ERR("conflicting accessibility for %s", key);
-                (void)0;
             }
             container->loadStaticKey(*config.get(), key);
             return config;

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
@@ -181,7 +181,6 @@ public:
                 }
             } else {
                 MO_DBG_ERR("OOM: %s", key);
-                (void)0;
             }
         }
 

--- a/src/MicroOcpp/Core/FilesystemUtils.cpp
+++ b/src/MicroOcpp/Core/FilesystemUtils.cpp
@@ -134,7 +134,6 @@ bool FilesystemUtils::remove_if(std::shared_ptr<FilesystemAdapter> filesystem, s
 
     if (ret != 0) {
         MO_DBG_ERR("ftw_root: %i", ret);
-        (void)0;
     }
 
     return ret == 0;

--- a/src/MicroOcpp/Core/FtpMbedTLS.cpp
+++ b/src/MicroOcpp/Core/FtpMbedTLS.cpp
@@ -411,7 +411,6 @@ void FtpTransferMbedTLS::send_cmd(const char *cmd, const char *arg, bool disable
         MO_DBG_DEBUG("SEND: %s %s", 
                 cmd,
                 !strncmp((char*) cmd, "PASS", strlen("PASS")) ? "***" : arg ? (char*) arg : "");
-        (void)0;
     }
 
     int ret = -1;
@@ -647,7 +646,6 @@ void FtpTransferMbedTLS::process_ctrl() {
             return;
         } else if (!strncmp("200", line, 3)) { //PBSZ -> 0 and PROT -> P accepted
             MO_DBG_INFO("PBSZ/PROT success: %s", line);
-            (void)0;
         } else if (!strncmp("221", line, 3)) { // Server Goodbye
             MO_DBG_DEBUG("closing ctrl connection");
             close_ctrl();

--- a/src/MicroOcpp/Core/Request.cpp
+++ b/src/MicroOcpp/Core/Request.cpp
@@ -308,7 +308,6 @@ bool Request::restore(std::unique_ptr<StoredOperationHandler> opStorage, Model *
         }
     } else {
         MO_DBG_ERR("cannot set unique msgID counter");
-        (void)0;
         //skip this step but don't abort restore
     }
 
@@ -330,10 +329,8 @@ bool Request::restore(std::unique_ptr<StoredOperationHandler> opStorage, Model *
 
     if (success) {
         MO_DBG_DEBUG("restored opNr %i: %s", opStore->getOpNr(), operation->getOperationType());
-        (void)0;
     } else {
         MO_DBG_ERR("restore opNr %i error", opStore->getOpNr());
-        (void)0;
     }
 
     return success;

--- a/src/MicroOcpp/Core/RequestQueue.cpp
+++ b/src/MicroOcpp/Core/RequestQueue.cpp
@@ -242,10 +242,8 @@ void RequestQueue::receiveResponse(JsonArray json) {
         //didn't find matching Request
         if (json[0] == MESSAGE_TYPE_CALLERROR) {
             MO_DBG_DEBUG("Received CALLERROR did not abort a pending operation");
-            (void)0;
         } else {
             MO_DBG_WARN("Received response doesn't match any pending operation");
-            (void)0;
         }
     }
 }

--- a/src/MicroOcpp/Core/RequestQueueStorageStrategy.cpp
+++ b/src/MicroOcpp/Core/RequestQueueStorageStrategy.cpp
@@ -42,7 +42,6 @@ void VolatileRequestQueue::push_back(std::unique_ptr<Request> op) {
 
     if (queue.size() >= MO_OPERATIONCACHE_MAXSIZE) {
         MO_DBG_WARN("unsafe number of cached operations");
-        (void)0;
     }
 
     queue.push_back(std::move(op));

--- a/src/MicroOcpp/Core/RequestStore.cpp
+++ b/src/MicroOcpp/Core/RequestStore.cpp
@@ -153,7 +153,6 @@ void RequestStore::advanceOpNr(unsigned int oldOpNr) {
     if (oldOpNr != (unsigned int) opBeginInt->getInt()) {
         if ((oldOpNr + MO_MAX_OPNR - (unsigned int) opBeginInt->getInt()) % MO_MAX_OPNR < 100) {
             MO_DBG_ERR("synchronization failure - try to fix");
-            (void)0;
         } else {
             MO_DBG_ERR("synchronization failure");
             return;
@@ -187,7 +186,6 @@ void RequestStore::advanceOpNr(unsigned int oldOpNr) {
         bool success = filesystem->remove(fn);
         if (!success) {
             MO_DBG_ERR("error deleting %s", fn);
-            (void)0;
         }
     }
 

--- a/src/MicroOcpp/Debug.cpp
+++ b/src/MicroOcpp/Debug.cpp
@@ -1,0 +1,54 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
+#include <string.h>
+
+#include <MicroOcpp/Debug.h>
+
+const char *level_label [] = {
+    "",         //MO_DL_NONE 0x00
+    "ERROR",    //MO_DL_ERROR 0x01
+    "warning",  //MO_DL_WARN 0x02
+    "info",     //MO_DL_INFO 0x03
+    "debug",    //MO_DL_DEBUG 0x04
+    "verbose"   //MO_DL_VERBOSE 0x05
+};
+
+#if MO_DBG_FORMAT == MO_DF_MINIMAL
+void mo_dbg_print_prefix(int level, const char *fn, int line) {
+    (void)0;
+}
+
+#elif MO_DBG_FORMAT == MO_DF_COMPACT
+void mo_dbg_print_prefix(int level, const char *fn, int line) {
+        size_t l = strlen(fn);
+        size_t r = l;
+        while (l > 0 && fn[l-1] != '/' && fn[l-1] != '\\') {
+            l--;
+            if (fn[l] == '.') r = l;
+        }
+        MO_CONSOLE_PRINTF("%.*s:%i ", (int) (r - l), fn + l, line);
+}
+
+#elif MO_DBG_FORMAT == MO_DF_FILE_LINE
+void mo_dbg_print_prefix(int level, const char *fn, int line) {
+    size_t l = strlen(fn);
+    while (l > 0 && fn[l-1] != '/' && fn[l-1] != '\\') {
+        l--;
+    }
+    MO_CONSOLE_PRINTF("[MO] %s (%s:%i): ", level_label[level], fn + l, line);
+}
+
+#elif MO_DBG_FORMAT == MO_DF_FULL
+void mo_dbg_print_prefix(int level, const char *fn, int line) {
+    MO_CONSOLE_PRINTF("[MO] %s (%s:%i): ", level_label[level], fn, line);
+}
+
+#else
+#error invalid MO_DBG_FORMAT definition
+#endif
+
+void mo_dbg_print_suffix() {
+    MO_CONSOLE_PRINTF("\n");
+}

--- a/src/MicroOcpp/Debug.h
+++ b/src/MicroOcpp/Debug.h
@@ -32,81 +32,52 @@
 #define MO_DBG_FORMAT MO_DF_FILE_LINE //default
 #endif
 
-
-#if MO_DBG_FORMAT == MO_DF_MINIMAL
-#define MO_DBG(level, X)   \
-    do {                        \
-        MO_CONSOLE_PRINTF X;  \
-        MO_CONSOLE_PRINTF("\n");         \
-    } while (0);
-
-#elif MO_DBG_FORMAT == MO_DF_COMPACT
-#define MO_DBG(level, X)   \
-    do {                        \
-        const char *_mo_file = __FILE__;         \
-        size_t _mo_l = sizeof(__FILE__);         \
-        size_t _mo_r = _mo_l;         \
-        while (_mo_l > 0 && _mo_file[_mo_l-1] != '/' && _mo_file[_mo_l-1] != '\\') {         \
-            _mo_l--;         \
-            if (_mo_file[_mo_l] == '.') _mo_r = _mo_l;         \
-        }         \
-        MO_CONSOLE_PRINTF("%.*s:%i ", (int) (_mo_r - _mo_l), _mo_file + _mo_l,__LINE__);           \
-        MO_CONSOLE_PRINTF X;  \
-        MO_CONSOLE_PRINTF("\n");         \
-    } while (0);
-
-#elif MO_DBG_FORMAT == MO_DF_FILE_LINE
-#define MO_DBG(level, X)   \
-    do {                        \
-        const char *_mo_file = __FILE__;         \
-        size_t _mo_l = sizeof(__FILE__);         \
-        for (; _mo_l > 0 && _mo_file[_mo_l-1] != '/' && _mo_file[_mo_l-1] != '\\'; _mo_l--);         \
-        MO_CONSOLE_PRINTF("[MO] %s (%s:%i): ",level, _mo_file + _mo_l,__LINE__);           \
-        MO_CONSOLE_PRINTF X;  \
-        MO_CONSOLE_PRINTF("\n");         \
-    } while (0);
-
-#elif MO_DBG_FORMAT == MO_DF_FULL
-#define MO_DBG(level, X)   \
-    do {                        \
-        MO_CONSOLE_PRINTF("[MO] %s (%s:%i): ",level, __FILE__,__LINE__);           \
-        MO_CONSOLE_PRINTF X;  \
-        MO_CONSOLE_PRINTF("\n");         \
-    } while (0);
-
-#else
-#error invalid MO_DBG_FORMAT definition
+#ifdef __cplusplus
+extern "C" {
 #endif
 
+void mo_dbg_print_prefix(int level, const char *fn, int line);
+void mo_dbg_print_suffix();
+
+#ifdef __cplusplus
+}
+#endif
+
+#define MO_DBG(level, X) \
+    do { \
+        mo_dbg_print_prefix(level, __FILE__, __LINE__); \
+        MO_CONSOLE_PRINTF X; \
+        mo_dbg_print_suffix(); \
+    } while (0)
 
 #if MO_DBG_LEVEL >= MO_DL_ERROR
-#define MO_DBG_ERR(...) MO_DBG("ERROR",(__VA_ARGS__))
+#define MO_DBG_ERR(...) MO_DBG(MO_DL_ERROR,(__VA_ARGS__))
 #else
-#define MO_DBG_ERR(...)
+#define MO_DBG_ERR(...) ((void)0)
 #endif
 
 #if MO_DBG_LEVEL >= MO_DL_WARN
-#define MO_DBG_WARN(...) MO_DBG("warning",(__VA_ARGS__))
+#define MO_DBG_WARN(...) MO_DBG(MO_DL_WARN,(__VA_ARGS__))
 #else
-#define MO_DBG_WARN(...)
+#define MO_DBG_WARN(...) ((void)0)
 #endif
 
 #if MO_DBG_LEVEL >= MO_DL_INFO
-#define MO_DBG_INFO(...) MO_DBG("info",(__VA_ARGS__))
+#define MO_DBG_INFO(...) MO_DBG(MO_DL_INFO,(__VA_ARGS__))
 #else
-#define MO_DBG_INFO(...)
+#define MO_DBG_INFO(...) ((void)0)
 #endif
 
 #if MO_DBG_LEVEL >= MO_DL_DEBUG
-#define MO_DBG_DEBUG(...) MO_DBG("debug",(__VA_ARGS__))
+#define MO_DBG_DEBUG(...) MO_DBG(MO_DL_DEBUG,(__VA_ARGS__))
 #else
-#define MO_DBG_DEBUG(...)
+#define MO_DBG_DEBUG(...) ((void)0)
 #endif
 
 #if MO_DBG_LEVEL >= MO_DL_VERBOSE
-#define MO_DBG_VERBOSE(...) MO_DBG("verbose",(__VA_ARGS__))
+#define MO_DBG_VERBOSE(...) MO_DBG(MO_DL_VERBOSE,(__VA_ARGS__))
 #else
-#define MO_DBG_VERBOSE(...)
+#define MO_DBG_VERBOSE(...) ((void)0)
 #endif
 
 #ifdef MO_TRAFFIC_OUT
@@ -124,8 +95,8 @@
     } while (0)
 
 #else
-#define MO_DBG_TRAFFIC_OUT(...)
-#define MO_DBG_TRAFFIC_IN(...)
+#define MO_DBG_TRAFFIC_OUT(...) ((void)0)
+#define MO_DBG_TRAFFIC_IN(...)  ((void)0)
 #endif
 
 #endif

--- a/src/MicroOcpp/Model/Boot/BootService.cpp
+++ b/src/MicroOcpp/Model/Boot/BootService.cpp
@@ -40,7 +40,6 @@ BootService::BootService(Context& context, std::shared_ptr<FilesystemAdapter> fi
     
     if (!preBootTransactionsBool) {
         MO_DBG_ERR("initialization error");
-        (void)0;
     }
 
     //Register message handler for TriggerMessage operation

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -68,7 +68,6 @@ Connector::Connector(Context& context, int connectorId)
         transaction = model.getTransactionStore()->getLatestTransaction(connectorId);
     } else {
         MO_DBG_ERR("must initialize TxStore before Connector");
-        (void)0;
     }
 }
 
@@ -398,7 +397,6 @@ void Connector::loop() {
             
             if (!transaction) {
                 MO_DBG_ERR("could not begin FreeVend Tx");
-                (void)0;
             }
         }
 
@@ -574,7 +572,6 @@ std::shared_ptr<Transaction> Connector::allocateTransaction() {
 
             if (tx) {
                 MO_DBG_DEBUG("created silent transaction");
-                (void)0;
             }
         }
     }

--- a/src/MicroOcpp/Model/Metering/MeterStore.cpp
+++ b/src/MicroOcpp/Model/Metering/MeterStore.cpp
@@ -20,7 +20,6 @@ TransactionMeterData::TransactionMeterData(unsigned int connectorId, unsigned in
     
     if (!filesystem) {
         MO_DBG_DEBUG("volatile mode");
-        (void)0;
     }
 }
 
@@ -151,7 +150,6 @@ MeterStore::MeterStore(std::shared_ptr<FilesystemAdapter> filesystem) : filesyst
 
     if (!filesystem) {
         MO_DBG_DEBUG("volatile mode");
-        (void)0;
     }
 }
 
@@ -293,7 +291,6 @@ bool MeterStore::remove(unsigned int connectorId, unsigned int txNr) {
 
     if (success) {
         MO_DBG_DEBUG("Removed meter values for cId %u, txNr %u", connectorId, txNr);
-        (void)0;
     } else {
         MO_DBG_DEBUG("corrupted fs");
     }

--- a/src/MicroOcpp/Model/Reservation/Reservation.cpp
+++ b/src/MicroOcpp/Model/Reservation/Reservation.cpp
@@ -31,7 +31,6 @@ Reservation::Reservation(Model& model, unsigned int slot) : model(model), slot(s
 
     if (!connectorIdInt || !expiryDateRawString || !idTagString || !reservationIdInt || !parentIdTagString) {
         MO_DBG_ERR("initialization failure");
-        (void)0;
     }
 }
 

--- a/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
+++ b/src/MicroOcpp/Model/SmartCharging/SmartChargingService.cpp
@@ -175,7 +175,6 @@ void SmartChargingConnector::loop(){
 void SmartChargingConnector::setSmartChargingOutput(std::function<void(float,float,int)> limitOutput) {
     if (this->limitOutput) {
         MO_DBG_WARN("replacing existing SmartChargingOutput");
-        (void)0;
     }
     this->limitOutput = limitOutput;
 }
@@ -532,7 +531,6 @@ void SmartChargingService::setSmartChargingOutput(unsigned int connectorId, std:
     if (connectorId == 0) {
         if (this->limitOutput) {
             MO_DBG_WARN("replacing existing SmartChargingOutput");
-            (void)0;
         }
         this->limitOutput = limitOutput;
     } else {

--- a/src/MicroOcpp/Model/Transactions/TransactionDeserialize.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionDeserialize.cpp
@@ -240,7 +240,6 @@ bool deserializeTransaction(Transaction& tx, JsonObject state) {
     MO_DBG_DEBUG("Stop  RPC | req: %i, conf: %i",  tx.getStopSync().isRequested(), tx.getStopSync().isConfirmed());
     if (tx.isSilent()) {
         MO_DBG_DEBUG("          | silent Tx");
-        (void)0;
     }
 
     return true;

--- a/src/MicroOcpp/Model/Variables/Variable.cpp
+++ b/src/MicroOcpp/Model/Variables/Variable.cpp
@@ -96,11 +96,9 @@ const ComponentId& Variable::getComponentId() const {
 
 void Variable::setInt(int val, AttributeType) {
     MO_DBG_ERR("type err");
-    (void)0;
 }
 void Variable::setBool(bool val, AttributeType) {
     MO_DBG_ERR("type err");
-    (void)0;
 }
 bool Variable::setString(const char *val, AttributeType) {
     MO_DBG_ERR("type err");

--- a/src/MicroOcpp/Model/Variables/VariableService.cpp
+++ b/src/MicroOcpp/Model/Variables/VariableService.cpp
@@ -123,7 +123,6 @@ VariableContainer *VariableService::declareContainer(const char *filename, bool 
 
     if (container->isAccessible() != accessible) {
         MO_DBG_ERR("%s: conflicting accessibility declarations (expect %s)", filename, container->isAccessible() ? "accessible" : "inaccessible");
-        (void)0;
     }
 
     return container.get();
@@ -142,7 +141,6 @@ Variable *VariableService::getVariable(Variable::InternalDataType type, const Co
             }
             if (container->isAccessible() != accessible) {
                 MO_DBG_ERR("conflicting accessibility for %s", name);
-                (void)0;
             }
             return variable;
         }

--- a/src/MicroOcpp/Operations/Authorize.cpp
+++ b/src/MicroOcpp/Operations/Authorize.cpp
@@ -18,7 +18,6 @@ Authorize::Authorize(Model& model, const char *idTagIn) : model(model) {
         snprintf(idTag, IDTAG_LEN_MAX + 1, "%s", idTagIn);
     } else {
         MO_DBG_WARN("Format violation of idTag. Discard idTag");
-        (void)0;
     }
 }
 

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -89,7 +89,9 @@ std::unique_ptr<DynamicJsonDocument> GetConfiguration::createConf(){
     }
 
     if (!doc || doc->capacity() < jcapacity) {
-        if (doc) {MO_DBG_ERR("OOM");(void)0;}
+        if (doc) {
+            MO_DBG_ERR("OOM");
+        }
 
         errorCode = "InternalError";
         errorDescription = "Query too big. Try fewer keys";

--- a/src/MicroOcpp/Operations/MeterValues.cpp
+++ b/src/MicroOcpp/Operations/MeterValues.cpp
@@ -42,7 +42,6 @@ std::unique_ptr<DynamicJsonDocument> MeterValues::createReq() {
             entries.push_back(std::move(entry));
         } else {
             MO_DBG_ERR("Energy meter reading not convertible to JSON");
-            (void)0;
         }
     }
 

--- a/src/MicroOcpp/Operations/Reset.cpp
+++ b/src/MicroOcpp/Operations/Reset.cpp
@@ -27,7 +27,6 @@ void Reset::processReq(JsonObject payload) {
     if (auto rService = model.getResetService()) {
         if (!rService->getExecuteReset()) {
             MO_DBG_ERR("No reset handler set. Abort operation");
-            (void)0;
             //resetAccepted remains false
         } else {
             if (!rService->getPreReset() || rService->getPreReset()(isHard) || isHard) {

--- a/src/MicroOcpp/Operations/StatusNotification.cpp
+++ b/src/MicroOcpp/Operations/StatusNotification.cpp
@@ -37,7 +37,6 @@ const char *cstrFromOcppEveState(ChargePointStatus state) {
 #endif
         default:
             MO_DBG_ERR("ChargePointStatus not specified");
-            (void)0;
             /* fall through */
         case (ChargePointStatus::NOT_SET):
             return "NOT_SET";
@@ -51,7 +50,6 @@ StatusNotification::StatusNotification(int connectorId, ChargePointStatus curren
     
     if (currentStatus != ChargePointStatus::NOT_SET) {
         MO_DBG_INFO("New status: %s (connectorId %d)", cstrFromOcppEveState(currentStatus), connectorId);
-        (void)0;
     }
 }
 

--- a/src/MicroOcpp/Operations/StopTransaction.cpp
+++ b/src/MicroOcpp/Operations/StopTransaction.cpp
@@ -124,7 +124,7 @@ std::unique_ptr<DynamicJsonDocument> StopTransaction::createReq() {
             transaction->setStopTimestamp(transaction->getStartTimestamp() + 1); //1s behind startTime to keep order in backend DB
         } else {
             MO_DBG_ERR("failed to determine StopTx timestamp");
-            (void)0; //send invalid value
+            //send invalid value
         }
     }
 

--- a/src/MicroOcpp/Platform.h
+++ b/src/MicroOcpp/Platform.h
@@ -5,12 +5,6 @@
 #ifndef MO_PLATFORM_H
 #define MO_PLATFORM_H
 
-#ifdef __cplusplus
-#define EXT_C extern "C"
-#else
-#define EXT_C
-#endif
-
 #define MO_PLATFORM_NONE    0
 #define MO_PLATFORM_ARDUINO 1
 #define MO_PLATFORM_ESPIDF  2


### PR DESCRIPTION
Optimize the firmware footprint of MO_DBG_X statements.

The MO_DBG_X functionality was implemented inside define statements only. This approach leads to much duplicated code after preprocessing. This PR moves a large share of the MO_DBG_X functionality into actual C++ functions. A simple measurement for validation showed a significant firmware footprint decrease of 38 kB.