### PR TITLE
Expose ChargePointStatus in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- Change `MicroOcpp::ChargePointStatus` into C-style enum ([#309](https://github.com/matth-x/MicroOcpp/pull/309))
+
 ### Added
 
-- Provide ChargePointStatus in API
+- Provide ChargePointStatus in API ([#309](https://github.com/matth-x/MicroOcpp/pull/309))
 
 ## [1.1.0] - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Provide ChargePointStatus in API
+
 ## [1.1.0] - 2024-05-21
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(ESP_PLATFORM)
     return()
 endif()
 
-project(MicroOcpp VERSION 1.1.0)
+project(MicroOcpp VERSION 1.2.0)
 
 add_library(MicroOcpp ${MO_SRC})
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "MicroOcpp",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "OCPP 1.6 Client for microcontrollers",
     "keywords": "OCPP, 1.6, OCPP 1.6, Smart Energy, Smart Charging, client, ESP8266, ESP32, Arduino, esp-idf, EVSE, Charge Point",
     "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MicroOcpp
-version=1.1.0
+version=1.2.0
 author=Matthias Akstaller
 maintainer=Matthias Akstaller
 sentence=OCPP 1.6 Client for microcontrollers

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -548,15 +548,15 @@ bool ocppPermitsCharge(unsigned int connectorId) {
     return connector->ocppPermitsCharge();
 }
 
-MicroOcpp::ChargePointStatus getChargePointStatus(unsigned int connectorId) {
+ChargePointStatus getChargePointStatus(unsigned int connectorId) {
     if (!context) {
         MO_DBG_WARN("OCPP uninitialized");
-        return MicroOcpp::ChargePointStatus::NOT_SET;
+        return ChargePointStatus_UNDEFINED;
     }
     auto connector = context->getModel().getConnector(connectorId);
     if (!connector) {
         MO_DBG_ERR("could not find connector");
-        return MicroOcpp::ChargePointStatus::NOT_SET;
+        return ChargePointStatus_UNDEFINED;
     }
     return connector->getStatus();
 }

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -548,6 +548,19 @@ bool ocppPermitsCharge(unsigned int connectorId) {
     return connector->ocppPermitsCharge();
 }
 
+MicroOcpp::ChargePointStatus getChargePointStatus(unsigned int connectorId) {
+    if (!context) {
+        MO_DBG_WARN("OCPP uninitialized");
+        return MicroOcpp::ChargePointStatus::NOT_SET;
+    }
+    auto connector = context->getModel().getConnector(connectorId);
+    if (!connector) {
+        MO_DBG_ERR("could not find connector");
+        return MicroOcpp::ChargePointStatus::NOT_SET;
+    }
+    return connector->getStatus();
+}
+
 void setConnectorPluggedInput(std::function<bool()> pluggedInput, unsigned int connectorId) {
     if (!context) {
         MO_DBG_ERR("OCPP uninitialized"); //need to call mocpp_initialize before

--- a/src/MicroOcpp.h
+++ b/src/MicroOcpp.h
@@ -17,6 +17,7 @@
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Model/ConnectorBase/Notification.h>
 #include <MicroOcpp/Model/ConnectorBase/ChargePointErrorData.h>
+#include <MicroOcpp/Model/ConnectorBase/ChargePointStatus.h>
 #include <MicroOcpp/Model/ConnectorBase/UnlockConnectorResult.h>
 #include <MicroOcpp/Version.h>
 #include <MicroOcpp/Model/Certificates/Certificate.h>
@@ -243,6 +244,8 @@ std::shared_ptr<MicroOcpp::Transaction>& getTransaction(unsigned int connectorId
  * and false means that the Control Pilot must be at a DC voltage.
  */
 bool ocppPermitsCharge(unsigned int connectorId = 1);
+
+MicroOcpp::ChargePointStatus getChargePointStatus(unsigned int connectorId = 1);
 
 /*
  * Define the Inputs and Outputs of this library.

--- a/src/MicroOcpp.h
+++ b/src/MicroOcpp.h
@@ -245,7 +245,10 @@ std::shared_ptr<MicroOcpp::Transaction>& getTransaction(unsigned int connectorId
  */
 bool ocppPermitsCharge(unsigned int connectorId = 1);
 
-MicroOcpp::ChargePointStatus getChargePointStatus(unsigned int connectorId = 1);
+/*
+ * Returns the latest ChargePointStatus as reported via StatusNotification (standard OCPP data type)
+ */
+ChargePointStatus getChargePointStatus(unsigned int connectorId = 1);
 
 /*
  * Define the Inputs and Outputs of this library.

--- a/src/MicroOcpp/Model/Authorization/AuthorizationService.cpp
+++ b/src/MicroOcpp/Model/Authorization/AuthorizationService.cpp
@@ -180,7 +180,7 @@ void AuthorizationService::notifyAuthorization(const char *idTag, JsonObject idT
     if (!equivalent) {
         //send error code "LocalListConflict" to server
 
-        ChargePointStatus cpStatus = ChargePointStatus::NOT_SET;
+        ChargePointStatus cpStatus = ChargePointStatus_UNDEFINED;
         if (context.getModel().getNumConnectors() > 0) {
             cpStatus = context.getModel().getConnector(0)->getStatus();
         }

--- a/src/MicroOcpp/Model/ConnectorBase/ChargePointStatus.h
+++ b/src/MicroOcpp/Model/ConnectorBase/ChargePointStatus.h
@@ -2,31 +2,35 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef OCPP_EVSE_STATE
-#define OCPP_EVSE_STATE
+#ifndef MO_CHARGEPOINTSTATUS_H
+#define MO_CHARGEPOINTSTATUS_H
 
 #include <MicroOcpp/Version.h>
 
-namespace MicroOcpp {
-
-enum class ChargePointStatus {
-    Available,
-    Preparing,
-    Charging,
-    SuspendedEVSE,
-    SuspendedEV,
-    Finishing,
-    Reserved,
-    Unavailable,
-    Faulted,
-
-#if MO_ENABLE_V201
-    Occupied,
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-    NOT_SET //internal value for "undefined"
-};
+typedef enum ChargePointStatus {
+    ChargePointStatus_UNDEFINED, //internal use only - no OCPP standard value 
+    ChargePointStatus_Available,
+    ChargePointStatus_Preparing,
+    ChargePointStatus_Charging,
+    ChargePointStatus_SuspendedEVSE,
+    ChargePointStatus_SuspendedEV,
+    ChargePointStatus_Finishing,
+    ChargePointStatus_Reserved,
+    ChargePointStatus_Unavailable,
+    ChargePointStatus_Faulted
 
-} //end namespace MicroOcpp
+#if MO_ENABLE_V201
+    ,ChargePointStatus_Occupied
+#endif
+
+}   ChargePointStatus;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -44,9 +44,9 @@ private:
     bool isFaulted();
     const char *getErrorCode();
 
-    ChargePointStatus currentStatus = ChargePointStatus::NOT_SET;
+    ChargePointStatus currentStatus = ChargePointStatus_UNDEFINED;
     std::shared_ptr<Configuration> minimumStatusDurationInt; //in seconds
-    ChargePointStatus reportedStatus = ChargePointStatus::NOT_SET;
+    ChargePointStatus reportedStatus = ChargePointStatus_UNDEFINED;
     unsigned long t_statusTransition = 0;
 
     std::function<UnlockConnectorResult()> onUnlockConnector;

--- a/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
@@ -83,7 +83,7 @@ ConnectorsCommon::ConnectorsCommon(Context& context, unsigned int numConn, std::
     }
     // OCPP 1.6 + 2.0.1 compliant echo messages
     context.getOperationRegistry().registerOperation("StatusNotification", [&context] () {
-        return new Ocpp16::StatusNotification(-1, ChargePointStatus::NOT_SET, Timestamp());});
+        return new Ocpp16::StatusNotification(-1, ChargePointStatus_UNDEFINED, Timestamp());});
 }
 
 void ConnectorsCommon::loop() {

--- a/src/MicroOcpp/Model/Reservation/ReservationService.cpp
+++ b/src/MicroOcpp/Model/Reservation/ReservationService.cpp
@@ -46,7 +46,7 @@ void ReservationService::loop() {
 
             //check if connector went inoperative
             auto cStatus = connector->getStatus();
-            if (cStatus == ChargePointStatus::Faulted || cStatus == ChargePointStatus::Unavailable) {
+            if (cStatus == ChargePointStatus_Faulted || cStatus == ChargePointStatus_Unavailable) {
                 reservation->clear();
                 continue;
             }
@@ -157,7 +157,7 @@ Reservation *ReservationService::getReservation(unsigned int connectorId, const 
             continue;
         }
         if (auto connector = context.getModel().getConnector(cId)) {
-            if (connector->getStatus() == ChargePointStatus::Available) {
+            if (connector->getStatus() == ChargePointStatus_Available) {
                 availableCount++;
             }
         }

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -58,7 +58,7 @@ void ResetService::loop() {
                 connector->setAvailabilityVolatile(true);
             }
 
-            ChargePointStatus cpStatus = ChargePointStatus::NOT_SET;
+            ChargePointStatus cpStatus = ChargePointStatus_UNDEFINED;
             if (context.getModel().getNumConnectors() > 0) {
                 cpStatus = context.getModel().getConnector(0)->getStatus();
             }

--- a/src/MicroOcpp/Operations/ReserveNow.cpp
+++ b/src/MicroOcpp/Operations/ReserveNow.cpp
@@ -87,19 +87,19 @@ void ReserveNow::processReq(JsonObject payload) {
             connector = model.getConnector((unsigned int) connectorId);
         }
 
-        if (chargePoint->getStatus() == ChargePointStatus::Faulted ||
-                (connector && connector->getStatus() == ChargePointStatus::Faulted)) {
+        if (chargePoint->getStatus() == ChargePointStatus_Faulted ||
+                (connector && connector->getStatus() == ChargePointStatus_Faulted)) {
             reservationStatus = "Faulted";
             return;
         }
 
-        if (chargePoint->getStatus() == ChargePointStatus::Unavailable ||
-                (connector && connector->getStatus() == ChargePointStatus::Unavailable)) {
+        if (chargePoint->getStatus() == ChargePointStatus_Unavailable ||
+                (connector && connector->getStatus() == ChargePointStatus_Unavailable)) {
             reservationStatus = "Unavailable";
             return;
         }
 
-        if (connector && connector->getStatus() != ChargePointStatus::Available) {
+        if (connector && connector->getStatus() != ChargePointStatus_Available) {
             reservationStatus = "Occupied";
             return;
         }

--- a/src/MicroOcpp/Operations/StatusNotification.cpp
+++ b/src/MicroOcpp/Operations/StatusNotification.cpp
@@ -13,33 +13,33 @@ namespace MicroOcpp {
 //helper function
 const char *cstrFromOcppEveState(ChargePointStatus state) {
     switch (state) {
-        case (ChargePointStatus::Available):
+        case (ChargePointStatus_Available):
             return "Available";
-        case (ChargePointStatus::Preparing):
+        case (ChargePointStatus_Preparing):
             return "Preparing";
-        case (ChargePointStatus::Charging):
+        case (ChargePointStatus_Charging):
             return "Charging";
-        case (ChargePointStatus::SuspendedEVSE):
+        case (ChargePointStatus_SuspendedEVSE):
             return "SuspendedEVSE";
-        case (ChargePointStatus::SuspendedEV):
+        case (ChargePointStatus_SuspendedEV):
             return "SuspendedEV";
-        case (ChargePointStatus::Finishing):
+        case (ChargePointStatus_Finishing):
             return "Finishing";
-        case (ChargePointStatus::Reserved):
+        case (ChargePointStatus_Reserved):
             return "Reserved";
-        case (ChargePointStatus::Unavailable):
+        case (ChargePointStatus_Unavailable):
             return "Unavailable";
-        case (ChargePointStatus::Faulted):
+        case (ChargePointStatus_Faulted):
             return "Faulted";
 #if MO_ENABLE_V201
-        case (ChargePointStatus::Occupied):
+        case (ChargePointStatus_Occupied):
             return "Occupied";
 #endif
         default:
             MO_DBG_ERR("ChargePointStatus not specified");
             /* fall through */
-        case (ChargePointStatus::NOT_SET):
-            return "NOT_SET";
+        case (ChargePointStatus_UNDEFINED):
+            return "UNDEFINED";
     }
 }
 
@@ -48,7 +48,7 @@ namespace Ocpp16 {
 StatusNotification::StatusNotification(int connectorId, ChargePointStatus currentStatus, const Timestamp &timestamp, ErrorData errorData)
         : connectorId(connectorId), currentStatus(currentStatus), timestamp(timestamp), errorData(errorData) {
     
-    if (currentStatus != ChargePointStatus::NOT_SET) {
+    if (currentStatus != ChargePointStatus_UNDEFINED) {
         MO_DBG_INFO("New status: %s (connectorId %d)", cstrFromOcppEveState(currentStatus), connectorId);
     }
 }
@@ -75,7 +75,7 @@ std::unique_ptr<DynamicJsonDocument> StatusNotification::createReq() {
         if (errorData.vendorErrorCode) {
             payload["vendorErrorCode"] = errorData.vendorErrorCode;
         }
-    } else if (currentStatus == ChargePointStatus::NOT_SET) {
+    } else if (currentStatus == ChargePointStatus_UNDEFINED) {
         MO_DBG_ERR("Reporting undefined status");
         payload["errorCode"] = "InternalError";
     } else {

--- a/src/MicroOcpp/Operations/StatusNotification.h
+++ b/src/MicroOcpp/Operations/StatusNotification.h
@@ -20,7 +20,7 @@ namespace Ocpp16 {
 class StatusNotification : public Operation {
 private:
     int connectorId = 1;
-    ChargePointStatus currentStatus = ChargePointStatus::NOT_SET;
+    ChargePointStatus currentStatus = ChargePointStatus_UNDEFINED;
     Timestamp timestamp;
     ErrorData errorData;
 public:
@@ -51,7 +51,7 @@ class StatusNotification : public Operation {
 private:
     EvseId evseId;
     Timestamp timestamp;
-    ChargePointStatus currentStatus = ChargePointStatus::NOT_SET;
+    ChargePointStatus currentStatus = ChargePointStatus_UNDEFINED;
 public:
     StatusNotification(EvseId evseId, ChargePointStatus currentStatus, const Timestamp &timestamp);
 

--- a/src/MicroOcpp/Version.h
+++ b/src/MicroOcpp/Version.h
@@ -8,7 +8,7 @@
 /*
  * Version specification of MicroOcpp library (not related with the OCPP version)
  */
-#define MO_VERSION "1.1.0"
+#define MO_VERSION "1.2.0"
 
 /*
  * Enable OCPP 2.0.1 support. If enabled, library can be initialized with both v1.6 and v2.0.1. The choice

--- a/src/MicroOcpp_c.cpp
+++ b/src/MicroOcpp_c.cpp
@@ -195,6 +195,14 @@ bool ocpp_ocppPermitsCharge_m(unsigned int connectorId) {
     return ocppPermitsCharge(connectorId);
 }
 
+ChargePointStatus ocpp_getChargePointStatus() {
+    return getChargePointStatus();
+}
+
+ChargePointStatus ocpp_getChargePointStatus_m(unsigned int connectorId) {
+    return getChargePointStatus(connectorId);
+}
+
 void ocpp_setConnectorPluggedInput(InputBool pluggedInput) {
     setConnectorPluggedInput(adaptFn(pluggedInput));
 }

--- a/src/MicroOcpp_c.h
+++ b/src/MicroOcpp_c.h
@@ -2,12 +2,13 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef ARDUINOOCPP_C_H
-#define ARDUINOOCPP_C_H
+#ifndef MO_MICROOCPP_C_H
+#define MO_MICROOCPP_C_H
 
 #include <stddef.h>
 
 #include <MicroOcpp/Core/ConfigurationOptions.h>
+#include <MicroOcpp/Model/ConnectorBase/ChargePointStatus.h>
 #include <MicroOcpp/Model/ConnectorBase/Notification.h>
 #include <MicroOcpp/Model/ConnectorBase/UnlockConnectorResult.h>
 #include <MicroOcpp/Model/Transactions/Transaction.h>
@@ -100,6 +101,9 @@ OCPP_Transaction *ocpp_getTransaction_m(unsigned int connectorId);
 
 bool ocpp_ocppPermitsCharge();
 bool ocpp_ocppPermitsCharge_m(unsigned int connectorId);
+
+ChargePointStatus ocpp_getChargePointStatus();
+ChargePointStatus ocpp_getChargePointStatus_m(unsigned int connectorId);
 
 /*
  * Define the Inputs and Outputs of this library.

--- a/tests/ChargingSessions.cpp
+++ b/tests/ChargingSessions.cpp
@@ -40,7 +40,7 @@ TEST_CASE( "Charging sessions" ) {
     
     std::array<const char*, 2> expectedSN {"Available", "Available"};
     std::array<bool, 2> checkedSN {false, false};
-    checkMsg.registerOperation("StatusNotification", [] () -> Operation* {return new Ocpp16::StatusNotification(0, ChargePointStatus::NOT_SET, MIN_TIME);});
+    checkMsg.registerOperation("StatusNotification", [] () -> Operation* {return new Ocpp16::StatusNotification(0, ChargePointStatus_UNDEFINED, MIN_TIME);});
     checkMsg.setOnRequest("StatusNotification",
         [&checkedSN, &expectedSN] (JsonObject request) {
             int connectorId = request["connectorId"] | -1;
@@ -625,7 +625,7 @@ TEST_CASE( "Charging sessions" ) {
         loop();
 
         auto connector = getOcppContext()->getModel().getConnector(1);
-        REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+        REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
         REQUIRE(isOperative());
 
         bool checkProcessed = false;
@@ -650,7 +650,7 @@ TEST_CASE( "Charging sessions" ) {
         loop();
 
         REQUIRE(checkProcessed);
-        REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+        REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
         REQUIRE(isOperative());
 
         mocpp_deinitialize();
@@ -660,19 +660,19 @@ TEST_CASE( "Charging sessions" ) {
 
         loop();
 
-        REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+        REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
         REQUIRE(isOperative());
 
         endTransaction();
 
         loop();
 
-        REQUIRE(connector->getStatus() == ChargePointStatus::Unavailable);
+        REQUIRE(connector->getStatus() == ChargePointStatus_Unavailable);
         REQUIRE(!isOperative());
 
         connector->setAvailability(true);
 
-        REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+        REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         REQUIRE(isOperative());
     }
 

--- a/tests/ConfigurationBehavior.cpp
+++ b/tests/ConfigurationBehavior.cpp
@@ -85,7 +85,7 @@ TEST_CASE( "Configuration Behavior" ) {
             setConnectorPluggedInput([] () {return false;});
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
 
         SECTION("set false") {
@@ -94,12 +94,12 @@ TEST_CASE( "Configuration Behavior" ) {
             setConnectorPluggedInput([] () {return false;});
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::SuspendedEV);
+            REQUIRE(connector->getStatus() == ChargePointStatus_SuspendedEV);
 
             endTransaction();
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
     }
 
@@ -115,12 +115,12 @@ TEST_CASE( "Configuration Behavior" ) {
             beginTransaction("mIdTag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
 
             beginTransaction_authorized("mIdTag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
 
         SECTION("set false") {
@@ -129,17 +129,17 @@ TEST_CASE( "Configuration Behavior" ) {
             beginTransaction("mIdTag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
 
             beginTransaction_authorized("mIdTag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::SuspendedEVSE);
+            REQUIRE(connector->getStatus() == ChargePointStatus_SuspendedEVSE);
 
             endTransaction();
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
     }
 
@@ -156,23 +156,23 @@ TEST_CASE( "Configuration Behavior" ) {
             beginTransaction("mIdTag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
 
             endTransaction();
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
 
         SECTION("set false") {
             configBool->setBool(false);
 
             beginTransaction("mIdTag");
-            REQUIRE(connector->getStatus() == ChargePointStatus::Preparing);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Preparing);
 
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Available);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Available);
         }
 
         endTransaction();
@@ -201,7 +201,7 @@ TEST_CASE( "Configuration Behavior" ) {
             beginTransaction("local-idtag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
         }
 
         SECTION("set false") {
@@ -210,13 +210,13 @@ TEST_CASE( "Configuration Behavior" ) {
             beginTransaction("local-idtag");
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Preparing);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Preparing);
 
             loopback.setOnline(true);
             mtime += 20000; //Authorize will be retried after a few seconds
             loop();
 
-            REQUIRE(connector->getStatus() == ChargePointStatus::Charging);
+            REQUIRE(connector->getStatus() == ChargePointStatus_Charging);
         }
 
         endTransaction();

--- a/tests/LocalAuthList.cpp
+++ b/tests/LocalAuthList.cpp
@@ -102,12 +102,12 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction and delay Authorize request - tx should start immediately
         loopback.setOnline(false); //Authorize delayed by short offline period
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("mIdTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         loopback.setOnline(true);
@@ -118,18 +118,18 @@ TEST_CASE( "LocalAuth" ) {
         checkTxAuthorized = false;
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("wrong idTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
         REQUIRE( !checkTxAuthorized );
 
         loopback.setOnline(true);
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         endTransaction();
@@ -158,7 +158,7 @@ TEST_CASE( "LocalAuth" ) {
         //make charger offline and begin tx - tx should begin after Authorize timeout
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         unsigned long t_before = mocpp_tick_ms();
 
@@ -166,13 +166,13 @@ TEST_CASE( "LocalAuth" ) {
         loop();
 
         REQUIRE( mocpp_tick_ms() - t_before < AUTH_TIMEOUT_MS ); //if this fails, increase AUTH_TIMEOUT_MS
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
         REQUIRE( !checkTxAuthorized );
 
         mtime += AUTH_TIMEOUT_MS - (mocpp_tick_ms() - t_before); //increment clock so that auth timeout is exceeded
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         loopback.setOnline(true);
@@ -188,20 +188,20 @@ TEST_CASE( "LocalAuth" ) {
         });
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         t_before = mocpp_tick_ms();
 
         beginTransaction("wrong idTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
         REQUIRE( !checkTxTimeout );
 
         mtime += AUTH_TIMEOUT_MS - (mocpp_tick_ms() - t_before); //increment clock so that auth timeout is exceeded
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
         REQUIRE( checkTxTimeout );
 
         loopback.setOnline(true);
@@ -225,20 +225,20 @@ TEST_CASE( "LocalAuth" ) {
         //make charger offline and begin tx - tx should begin after Authorize timeout
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         unsigned long t_before = mocpp_tick_ms();
 
         beginTransaction("unknownIdTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
         REQUIRE( !checkTxAuthorized );
 
         mtime += AUTH_TIMEOUT_MS - (mocpp_tick_ms() - t_before); //increment clock so that auth timeout is exceeded
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         loopback.setOnline(true);
@@ -263,14 +263,14 @@ TEST_CASE( "LocalAuth" ) {
         //disconnect WS and begin tx - charger should enter offline mode immediately
         loopback.setConnected(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         unsigned long t_before = mocpp_tick_ms();
 
         beginTransaction("unknownIdTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         loopback.setConnected(true);
@@ -298,17 +298,17 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction and delay Authorize request - cannot PreAuthorize because entry is expired
         loopback.setOnline(false); //Authorize delayed by short offline period
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("mIdTagExpired");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
 
         loopback.setOnline(true);
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
 
         endTransaction();
         loop();
@@ -316,17 +316,17 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction and delay Authorize request - cannot PreAuthorize because entry is unauthorized
         loopback.setOnline(false); //Authorize delayed by short offline period
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("mIdTagUnauthorized");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
 
         loopback.setOnline(true);
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         endTransaction();
         loop();
     }
@@ -351,12 +351,12 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction and delay Authorize request - tx should start immediately
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("mIdTagAccepted");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
 
         loopback.setOnline(true);
         endTransaction();
@@ -365,7 +365,7 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction, but idTag is expired - AllowOfflineTxForUnknownId must not apply
         loopback.setOnline(false);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         unsigned long t_before = mocpp_tick_ms();
 
@@ -373,12 +373,12 @@ TEST_CASE( "LocalAuth" ) {
         loop();
 
         REQUIRE( mocpp_tick_ms() - t_before < AUTH_TIMEOUT_MS ); //if this fails, increase AUTH_TIMEOUT_MS
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
 
         mtime += AUTH_TIMEOUT_MS - (mocpp_tick_ms() - t_before); //increment clock so that auth timeout is exceeded
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         loopback.setOnline(true);
         loop();
@@ -418,12 +418,12 @@ TEST_CASE( "LocalAuth" ) {
         //begin transaction and delay Authorize request - tx should start immediately
         loopback.setOnline(false); //Authorize delayed by short offline period
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         beginTransaction("mIdTag");
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( checkTxAuthorized );
 
         //check TX notification
@@ -437,7 +437,7 @@ TEST_CASE( "LocalAuth" ) {
         loopback.setOnline(true);
         loop();
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
         REQUIRE( checkTxRejected );
 
         loop();

--- a/tests/Reservation.cpp
+++ b/tests/Reservation.cpp
@@ -46,7 +46,7 @@ TEST_CASE( "Reservation" ) {
     loop();
 
     SECTION("Basic reservation") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
         REQUIRE( rService );
 
         //set reservation
@@ -58,7 +58,7 @@ TEST_CASE( "Reservation" ) {
 
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
         
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         //transaction blocked by reservation
         bool checkTxRejected = false;
@@ -70,23 +70,23 @@ TEST_CASE( "Reservation" ) {
 
         beginTransaction("wrong idTag");
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
         REQUIRE( checkTxRejected );
 
         //idTag matches reservation
         beginTransaction("mIdTag");
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( connector->getTransaction()->getReservationId() == reservationId );
 
         //reservation is reset after tx
         endTransaction();
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //RemoteStartTx - idTag doesn't match. The tx will start anyway assuming some start trigger in the backend prevails over reservations in the backend implementation
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
                 "RemoteStartTransaction",
@@ -99,17 +99,17 @@ TEST_CASE( "Reservation" ) {
                 [] (JsonObject) { } //ignore conf
         )));
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( connector->getTransaction()->getReservationId() != reservationId );
 
         //reservation is reset after tx
         endTransaction();
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //RemoteStartTx - idTag does match
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
                 "RemoteStartTransaction",
@@ -122,17 +122,17 @@ TEST_CASE( "Reservation" ) {
                 [] (JsonObject) { } //ignore conf
         )));
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( connector->getTransaction()->getReservationId() == reservationId );
 
         //reservation is reset after tx
         endTransaction();
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("Tx on other connector") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -143,21 +143,21 @@ TEST_CASE( "Reservation" ) {
         const char *parentIdTag = nullptr;
 
         rService->updateReservation(reservationId, connectorIdResvd, expiryDate, idTag, parentIdTag);
-        REQUIRE( model.getConnector(connectorIdResvd)->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( model.getConnector(connectorIdResvd)->getStatus() == ChargePointStatus_Reserved );
 
         beginTransaction(idTag, connectorIdOther);
         loop();
-        REQUIRE( model.getConnector(connectorIdResvd)->getStatus() == ChargePointStatus::Available ); //reservation on first connector withdrawed
-        REQUIRE( model.getConnector(connectorIdOther)->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( model.getConnector(connectorIdResvd)->getStatus() == ChargePointStatus_Available ); //reservation on first connector withdrawed
+        REQUIRE( model.getConnector(connectorIdOther)->getStatus() == ChargePointStatus_Charging );
         REQUIRE( getTransaction(connectorIdOther)->getReservationId() == reservationId ); //reservation transferred to other connector
 
         endTransaction(nullptr, nullptr, connectorIdOther);
         loop();
-        REQUIRE( model.getConnector(connectorIdOther)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( model.getConnector(connectorIdOther)->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("parentIdTag") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -167,7 +167,7 @@ TEST_CASE( "Reservation" ) {
         const char *parentIdTag = "mParentIdTag";
         
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         bool checkProcessed = false;
         getOcppContext()->getOperationRegistry().registerOperation("Authorize",
@@ -188,17 +188,17 @@ TEST_CASE( "Reservation" ) {
         beginTransaction("other idTag");
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Charging );
         REQUIRE( connector->getTransaction()->getReservationId() == reservationId );
 
         //reset tx
         endTransaction();
         loop();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("ConnectorZero") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         Timestamp expiryDate = model.getClock().now() + 3600; //expires one hour in future
@@ -209,19 +209,19 @@ TEST_CASE( "Reservation" ) {
         REQUIRE( rService->updateReservation(1000, 0, expiryDate, idTag, parentIdTag) );
         REQUIRE( rService->updateReservation(1001, 1, expiryDate, idTag, parentIdTag) );
         REQUIRE( !rService->updateReservation(1002, 2, expiryDate, idTag, parentIdTag) );
-        REQUIRE( model.getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( model.getConnector(2)->getStatus() == ChargePointStatus_Available );
 
         //reset reservations
         rService->getReservationById(1000)->clear();
         rService->getReservationById(1001)->clear();
-        REQUIRE( model.getConnector(1)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( model.getConnector(1)->getStatus() == ChargePointStatus_Available );
 
         //if connector 0 is reserved, ensure that at least one physical connector remains available for the idTag of the reservation
         REQUIRE( rService->updateReservation(1000, 0, expiryDate, idTag, parentIdTag) );
 
         beginTransaction("other idTag", 1);
         loop();
-        REQUIRE( model.getConnector(1)->getStatus() == ChargePointStatus::Charging );
+        REQUIRE( model.getConnector(1)->getStatus() == ChargePointStatus_Charging );
 
         bool checkTxRejected = false;
         setTxNotificationOutput([&checkTxRejected] (Transaction*, TxNotification txNotification) {
@@ -233,7 +233,7 @@ TEST_CASE( "Reservation" ) {
         beginTransaction("other idTag 2", 2);
         loop();
         REQUIRE( checkTxRejected );
-        REQUIRE( model.getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( model.getConnector(2)->getStatus() == ChargePointStatus_Available );
         
 
         endTransaction(nullptr, nullptr, 1);
@@ -241,7 +241,7 @@ TEST_CASE( "Reservation" ) {
     }
 
     SECTION("Expiry date") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -252,19 +252,19 @@ TEST_CASE( "Reservation" ) {
 
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
         
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         Timestamp expired = expiryDate + 1;
         char expired_cstr [JSONDATE_LENGTH + 1];
         expired.toJsonString(expired_cstr, JSONDATE_LENGTH + 1);
         model.getClock().setTime(expired_cstr);
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("Reservation persistency") {
         unsigned int connectorId = 1;
-        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -274,7 +274,7 @@ TEST_CASE( "Reservation" ) {
 
         getOcppContext()->getModel().getReservationService()->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
         
-        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus_Reserved );
 
         mocpp_deinitialize();
 
@@ -282,7 +282,7 @@ TEST_CASE( "Reservation" ) {
         getOcppContext()->getModel().getClock().setTime(BASE_TIME);
         loop();
 
-        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus_Reserved );
 
         auto reservation = getOcppContext()->getModel().getReservationService()->getReservationById(reservationId);
         REQUIRE( reservation->getReservationId() == reservationId );
@@ -299,12 +299,12 @@ TEST_CASE( "Reservation" ) {
         getOcppContext()->getModel().getClock().setTime(BASE_TIME);
         loop();
 
-        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( getOcppContext()->getModel().getConnector(connectorId)->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("ReserveNow") {
 
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -340,15 +340,15 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         model.getReservationService()->getReservationById(reservationId)->clear();
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //reserve while charger is in Faulted state
         const char *errorCode = "OtherError";
         addErrorCodeInput([&errorCode] () {return errorCode;});
-        REQUIRE( connector->getStatus() == ChargePointStatus::Faulted );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Faulted );
 
         checkProcessed = false;
         getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
@@ -376,14 +376,14 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Faulted );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Faulted );
 
         errorCode = nullptr; //reset error
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //reserve while connector is already occupied
         setConnectorPluggedInput([] {return true;}); //plug EV
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
 
         checkProcessed = false;
         getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
@@ -411,16 +411,16 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Preparing );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Preparing );
 
         setConnectorPluggedInput(nullptr); //reset ConnectorPluggedInput
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //Rejected ReserveNow status not possible
 
         //reserve while connector is inoperative
         connector->setAvailabilityVolatile(false);
-        REQUIRE( connector->getStatus() == ChargePointStatus::Unavailable );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Unavailable );
 
         checkProcessed = false;
         getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
@@ -448,14 +448,14 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Unavailable );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Unavailable );
 
         connector->setAvailabilityVolatile(true); //revert Unavailable status
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("CancelReservation") {
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //set reservation
         int reservationId = 123;
@@ -465,7 +465,7 @@ TEST_CASE( "Reservation" ) {
         const char *parentIdTag = nullptr;
 
         rService->updateReservation(reservationId, connectorId, expiryDate, idTag, parentIdTag);
-        REQUIRE( connector->getStatus() == ChargePointStatus::Reserved );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Reserved );
 
         //CancelReservation successfully
         bool checkProcessed = false;
@@ -486,7 +486,7 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
         //CancelReservation while no reservation exists
         checkProcessed = false;
@@ -507,7 +507,7 @@ TEST_CASE( "Reservation" ) {
         )));
         loop();
         REQUIRE( checkProcessed );
-        REQUIRE( connector->getStatus() == ChargePointStatus::Available );
+        REQUIRE( connector->getStatus() == ChargePointStatus_Available );
     }
 
     mocpp_deinitialize();

--- a/tests/Reset.cpp
+++ b/tests/Reset.cpp
@@ -133,7 +133,7 @@ TEST_CASE( "Reset" ) {
         REQUIRE( !ocppPermitsCharge(1) );
         REQUIRE( ocppPermitsCharge(2) );
 
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Unavailable );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Unavailable );
 
         context->getModel().getTransactionService()->getEvse(2)->endAuthorization("mIdToken");
         setConnectorPluggedInput([] () {return false;}, 2);
@@ -151,8 +151,8 @@ TEST_CASE( "Reset" ) {
         REQUIRE( checkExecuted[0] );
 
         // Technically, Reset failed at this point, because the program is still running. Check if connectors are Available agin
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Available );
-        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Available );
+        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("Immediate full charger Reset") {
@@ -228,8 +228,8 @@ TEST_CASE( "Reset" ) {
         loop();
 
         // Technically, Reset failed at this point, because the program is still running. Check if connectors are Available agin
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Available );
-        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Available );
+        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("Reject Reset") {
@@ -265,9 +265,9 @@ TEST_CASE( "Reset" ) {
         REQUIRE(checkProcessed);
         REQUIRE(checkNotified[2]);
 
-        REQUIRE( context->getModel().getConnector(0)->getStatus() == ChargePointStatus::Available );
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Available );
-        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( context->getModel().getConnector(0)->getStatus() == ChargePointStatus_Available );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Available );
+        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus_Available );
     }
 
     SECTION("Reset single EVSE") {
@@ -298,14 +298,14 @@ TEST_CASE( "Reset" ) {
         REQUIRE(checkProcessed);
         REQUIRE(checkNotified[1]);
 
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Unavailable );
-        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Unavailable );
+        REQUIRE( context->getModel().getConnector(2)->getStatus() == ChargePointStatus_Available );
 
         mtime += 30000; // Reset has some delays to ensure that the WS is not cut off immediately
         loop();
 
         REQUIRE(checkExecuted[1]);
-        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus::Available );
+        REQUIRE( context->getModel().getConnector(1)->getStatus() == ChargePointStatus_Available );
     }
 
     mocpp_deinitialize();


### PR DESCRIPTION
Introduce a new function `getChargePointStatus()` in the C/C++ API which returns the OCPP field ChargePointStatus as reported via StatusNotification.

Furthermore, this PR changes the scoped enum ChargePointStatus in namespace MicroOcpp to a C-style enum not lying in a namespace. This could break your integration if you fetched the ChargePointStatus over the Connector class (and going beyond the API). To upgrade, the following changes are necessary:

- Definitions: `MicroOcpp::ChargePointStatus myStatus;` --> `ChargePointStatus myStatus;`
- Literals: `MicroOcpp::ChargePointStatus::Available` --> `ChargePointStatus_Available`
- Null-literal: `MicroOcpp::ChargePointStatus::NOT_SET` --> `ChargePointStatus_UNDEFINED`

This refactoring step is part of the changes to make C integrations easier. All enums which could be relevant to the firmware integration will be changed to C-style enums.