### PR TITLE
Built-in firmware updates over FTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ lib
 mo_store
 src/ArduinoJson*
 src/main.cpp
+tests/helpers/ArduinoJson*
 coverage.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 ### Added
 
 - Provide ChargePointStatus in API ([#309](https://github.com/matth-x/MicroOcpp/pull/309))
+- Built-in OTA over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
+
+### Removed
+
+- ESP32 built-in HTTP OTA ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
 
 ## [1.1.0] - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Provide ChargePointStatus in API ([#309](https://github.com/matth-x/MicroOcpp/pull/309))
 - Built-in OTA over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
+- Built-in Diagnostics over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - ESP32 built-in HTTP OTA ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
 
+### Fixed
+
+- Skip Unix files . and .. in ftw_root ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
+
 ## [1.1.0] - 2024-05-21
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(MO_SRC_UNIT
     tests/Variables.cpp
     tests/Transactions.cpp
     tests/Certificates.cpp
+    tests/FirmwareManagement.cpp
 )
 
 add_executable(mo_unit_tests

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -274,6 +274,11 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
     configuration_init(filesystem); //call before each other library call
 
     context = new Context(connection, filesystem, bootstats.bootNr, version);
+
+#if MO_ENABLE_MBEDTLS
+    context->setFtpClient(makeFtpClientMbedTLS());
+#endif //MO_ENABLE_MBEDTLS
+
     auto& model = context->getModel();
 
     model.setTransactionStore(std::unique_ptr<TransactionStore>(
@@ -332,9 +337,8 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
 
 #if !defined(MO_CUSTOM_UPDATER)
 #if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
-    std::shared_ptr<FtpClient> ftpClient = makeFtpClientMbedTLS(); //will use it for other services too in future
     model.setFirmwareService(
-        makeDefaultFirmwareService(*context, ftpClient)); //instantiate FW service + ESP installation routine
+        makeDefaultFirmwareService(*context)); //instantiate FW service + ESP installation routine
 #elif MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP8266)
     model.setFirmwareService(
         makeDefaultFirmwareService(*context)); //instantiate FW service + ESP installation routine

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -345,6 +345,16 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
 #endif //MO_PLATFORM
 #endif //!defined(MO_CUSTOM_UPDATER)
 
+#if !defined(MO_CUSTOM_DIAGNOSTICS)
+#if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
+    model.setDiagnosticsService(
+        makeDefaultDiagnosticsService(*context, filesystem)); //instantiate Diag service + ESP hardware diagnostics
+#elif MO_ENABLE_MBEDTLS
+    model.setDiagnosticsService(
+        makeDefaultDiagnosticsService(*context, filesystem)); //instantiate Diag service 
+#endif //MO_PLATFORM
+#endif //!defined(MO_CUSTOM_DIAGNOSTICS)
+
 #if MO_PLATFORM == MO_PLATFORM_ARDUINO && (defined(ESP32) || defined(ESP8266))
     setOnResetExecute(makeDefaultResetFn());
 #endif

--- a/src/MicroOcpp/Core/Context.cpp
+++ b/src/MicroOcpp/Core/Context.cpp
@@ -72,3 +72,11 @@ const ProtocolVersion& Context::getVersion() {
 Connection& Context::getConnection() {
     return connection;
 }
+
+void Context::setFtpClient(std::unique_ptr<FtpClient> ftpClient) {
+    this->ftpClient = std::move(ftpClient);
+}
+
+FtpClient *Context::getFtpClient() {
+    return ftpClient.get();
+}

--- a/src/MicroOcpp/Core/Context.h
+++ b/src/MicroOcpp/Core/Context.h
@@ -9,6 +9,7 @@
 
 #include <MicroOcpp/Core/OperationRegistry.h>
 #include <MicroOcpp/Core/RequestQueue.h>
+#include <MicroOcpp/Core/Ftp.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Version.h>
 
@@ -25,6 +26,8 @@ private:
     RequestQueue reqQueue;
 
     std::unique_ptr<RequestQueue> preBootQueue;
+
+    std::unique_ptr<FtpClient> ftpClient;
 
 public:
     Context(Connection& connection, std::shared_ptr<FilesystemAdapter> filesystem, uint16_t bootNr, ProtocolVersion version);
@@ -46,6 +49,9 @@ public:
     const ProtocolVersion& getVersion();
 
     Connection& getConnection();
+
+    void setFtpClient(std::unique_ptr<FtpClient> ftpClient);
+    FtpClient *getFtpClient();
 };
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/FilesystemAdapter.cpp
+++ b/src/MicroOcpp/Core/FilesystemAdapter.cpp
@@ -709,6 +709,9 @@ public:
 
         int err = 0;
         while (auto entry = readdir(dir)) {
+            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+                continue; //files . and .. are specific to desktop systems and rarely appear on microcontroller filesystems. Filter them
+            }
             err = fn(entry->d_name);
             if (err) {
                 break;

--- a/src/MicroOcpp/Core/FilesystemUtils.cpp
+++ b/src/MicroOcpp/Core/FilesystemUtils.cpp
@@ -117,7 +117,7 @@ bool FilesystemUtils::storeJson(std::shared_ptr<FilesystemAdapter> filesystem, c
 
 bool FilesystemUtils::remove_if(std::shared_ptr<FilesystemAdapter> filesystem, std::function<bool(const char*)> pred) {
     auto ret = filesystem->ftw_root([filesystem, pred] (const char *fpath) {
-        if (pred(fpath) && fpath[0] != '.') {
+        if (pred(fpath)) {
 
             char fn [MO_MAX_PATH_SIZE] = {'\0'};
             auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "%s", fpath);

--- a/src/MicroOcpp/Core/Ftp.h
+++ b/src/MicroOcpp/Core/Ftp.h
@@ -11,16 +11,24 @@
 extern "C" {
 #endif
 
+typedef enum {
+    MO_FtpCloseReason_Undefined,
+    MO_FtpCloseReason_Success,
+    MO_FtpCloseReason_Failure
+}   MO_FtpCloseReason;
+
 typedef struct ocpp_ftp_download {
     void *user_data; //set this at your choice. MO passes it back to the functions below
 
     void (*loop)(void *user_data);
+    void (*is_active)(void *user_data);
 } ocpp_ftp_download;
 
 typedef struct ocpp_ftp_upload {
     void *user_data; //set this at your choice. MO passes it back to the functions below
 
     void (*loop)(void *user_data);
+    void (*is_active)(void *user_data);
 } ocpp_ftp_upload;
 
 typedef struct ocpp_ftp_client {
@@ -31,7 +39,7 @@ typedef struct ocpp_ftp_client {
     ocpp_ftp_download* (*get_file)(void *user_data,
         const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
         size_t (*file_writer)(void *mo_data, unsigned char *data, size_t len),
-        void (*on_close)(void *mo_data),
+        void (*on_close)(void *mo_data, MO_FtpCloseReason reason),
         void *mo_data,
         const char *ca_cert); // nullptr to disable cert check; will be ignored for non-TLS connections
 
@@ -40,7 +48,7 @@ typedef struct ocpp_ftp_client {
     ocpp_ftp_upload* (*post_file)(void *user_data,
         const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
         size_t (*file_reader)(void *mo_data, unsigned char *buf, size_t bufsize),
-        void (*on_close)(void *mo_data),
+        void (*on_close)(void *mo_data, MO_FtpCloseReason reason),
         void *mo_data,
         const char *ca_cert); // nullptr to disable cert check; will be ignored for non-TLS connections
 
@@ -57,27 +65,32 @@ namespace MicroOcpp {
 
 class FtpDownload {
 public:
+    virtual ~FtpDownload() = default;
     virtual void loop() = 0;
+    virtual bool isActive() = 0;
 };
 
 class FtpUpload {
 public:
+    virtual ~FtpUpload() = default;
     virtual void loop() = 0;
+    virtual bool isActive() = 0;
 };
 
 class FtpClient {
 public:
+    virtual ~FtpClient() = default;
 
     virtual std::unique_ptr<FtpDownload> getFile(
                 const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
                 std::function<size_t(unsigned char *data, size_t len)> fileWriter,
-                std::function<void()> onClose,
+                std::function<void(MO_FtpCloseReason reason)> onClose,
                 const char *ca_cert = nullptr) = 0; // nullptr to disable cert check; will be ignored for non-TLS connections
 
     virtual std::unique_ptr<FtpUpload> postFile(
                 const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
                 std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, //write at most buffsize bytes into out-buffer. Return number of bytes written
-                std::function<void()> onClose,
+                std::function<void(MO_FtpCloseReason reason)> onClose,
                 const char *ca_cert = nullptr) = 0; // nullptr to disable cert check; will be ignored for non-TLS connections
 };
 

--- a/src/MicroOcpp/Core/FtpMbedTLS.cpp
+++ b/src/MicroOcpp/Core/FtpMbedTLS.cpp
@@ -64,7 +64,7 @@ private:
     
     std::function<size_t(unsigned char *data, size_t len)> fileWriter;
     std::function<size_t(unsigned char *out, size_t bufsize)> fileReader;
-    std::function<void()> onClose;
+    std::function<void(MO_FtpCloseReason)> onClose;
 
     enum class Method {
         Retrieve,  //download file
@@ -77,8 +77,8 @@ private:
     int connect(mbedtls_net_context& fd, mbedtls_ssl_context& ssl, const char *server_name, const char *server_port);
     int connect_ctrl();
     int connect_data();
-    void close_ctrl();
-    void close_data();
+    void close_ctrl(MO_FtpCloseReason reason);
+    void close_data(MO_FtpCloseReason reason);
 
     int handshake_tls();
 
@@ -97,15 +97,17 @@ public:
     ~FtpTransferMbedTLS();
 
     void loop() override;
+    
+    bool isActive() override;
 
     bool getFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *data, size_t len)> fileWriter,
-            std::function<void()> onClose,
+            std::function<void(MO_FtpCloseReason)> onClose,
             const char *ca_cert = nullptr); // nullptr to disable cert check; will be ignored for non-TLS connections
 
     bool postFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, //write at most buffsize bytes into out-buffer. Return number of bytes written
-            std::function<void()> onClose,
+            std::function<void(MO_FtpCloseReason)> onClose,
             const char *ca_cert = nullptr); // nullptr to disable cert check; will be ignored for non-TLS connections
 };
 
@@ -120,12 +122,12 @@ public:
 
     std::unique_ptr<FtpDownload> getFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *data, size_t len)> fileWriter,
-            std::function<void()> onClose,
+            std::function<void(MO_FtpCloseReason)> onClose,
             const char *ca_cert = nullptr) override; // nullptr to disable cert check; will be ignored for non-TLS connections
 
     std::unique_ptr<FtpUpload> postFile(const char *ftp_url, // ftp[s]://[user[:pass]@]host[:port][/directory]/filename
             std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, //write at most buffsize bytes into out-buffer. Return number of bytes written
-            std::function<void()> onClose,
+            std::function<void(MO_FtpCloseReason)> onClose,
             const char *ca_cert = nullptr) override; // nullptr to disable cert check; will be ignored for non-TLS connections
 };
 
@@ -177,7 +179,7 @@ FtpTransferMbedTLS::FtpTransferMbedTLS(bool tls_only, const char *client_cert, c
 
 FtpTransferMbedTLS::~FtpTransferMbedTLS() {
     if (onClose) {
-        onClose();
+        onClose(MO_FtpCloseReason_Undefined);
         onClose = nullptr;
     }
     delete[] data_buf;
@@ -327,7 +329,7 @@ int FtpTransferMbedTLS::connect_data() {
     return 0; //success
 }
 
-void FtpTransferMbedTLS::close_ctrl() {
+void FtpTransferMbedTLS::close_ctrl(MO_FtpCloseReason reason) {
     if (!ctrl_opened) {
         return;
     }
@@ -340,12 +342,12 @@ void FtpTransferMbedTLS::close_ctrl() {
     ctrl_opened = false;
 
     if (onClose && !data_opened) {
-        onClose();
+        onClose(reason);
         onClose = nullptr;
     }
 }
 
-void FtpTransferMbedTLS::close_data() {
+void FtpTransferMbedTLS::close_data(MO_FtpCloseReason reason) {
     if (!data_opened) {
         return;
     }
@@ -362,7 +364,7 @@ void FtpTransferMbedTLS::close_data() {
     data_conn_accepted = false;
 
     if (onClose && !ctrl_opened) {
-        onClose();
+        onClose(reason);
         onClose = nullptr;
     }
 }
@@ -432,12 +434,12 @@ void FtpTransferMbedTLS::send_cmd(const char *cmd, const char *arg, bool disable
         char buf [1024];
         mbedtls_strerror(ret, (char *) buf, 1024);
         MO_DBG_ERR("fatal - message on ctrl channel lost: %i, %s", ret, buf);
-        close_ctrl();
+        close_ctrl(MO_FtpCloseReason_Failure);
         return;
     }
 }
 
-bool FtpTransferMbedTLS::getFile(const char *ftp_url_raw, std::function<size_t(unsigned char *data, size_t len)> fileWriter, std::function<void()> onClose, const char *ca_cert) {
+bool FtpTransferMbedTLS::getFile(const char *ftp_url_raw, std::function<size_t(unsigned char *data, size_t len)> fileWriter, std::function<void(MO_FtpCloseReason)> onClose, const char *ca_cert) {
 
     if (method != Method::UNDEFINED) {
         MO_DBG_ERR("FTP Client reuse not supported");
@@ -474,7 +476,7 @@ bool FtpTransferMbedTLS::getFile(const char *ftp_url_raw, std::function<size_t(u
     return true;
 }
 
-bool FtpTransferMbedTLS::postFile(const char *ftp_url_raw, std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, std::function<void()> onClose, const char *ca_cert) {
+bool FtpTransferMbedTLS::postFile(const char *ftp_url_raw, std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, std::function<void(MO_FtpCloseReason)> onClose, const char *ca_cert) {
     
     if (method != Method::UNDEFINED) {
         MO_DBG_ERR("FTP Client reuse not supported");
@@ -531,12 +533,12 @@ void FtpTransferMbedTLS::process_ctrl() {
         return;
     } else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || ret == 0) {
         MO_DBG_ERR("FTP transfer aborted");
-        close_ctrl();
+        close_ctrl(MO_FtpCloseReason_Failure);
         return;
     } else if (ret < 0) {
         MO_DBG_ERR("mbedtls_net_recv: %i", ret);
         send_cmd("QUIT");
-        close_ctrl();
+        close_ctrl(MO_FtpCloseReason_Failure);
         return;
     }
 
@@ -649,7 +651,7 @@ void FtpTransferMbedTLS::process_ctrl() {
             MO_DBG_INFO("PBSZ/PROT success: %s", line);
         } else if (!strncmp("221", line, 3)) { // Server Goodbye
             MO_DBG_DEBUG("closing ctrl connection");
-            close_ctrl();
+            close_ctrl(MO_FtpCloseReason_Success);
             return;
         } else {
             MO_DBG_WARN("unkown commad (close connection): %s", line);
@@ -690,11 +692,11 @@ void FtpTransferMbedTLS::process_data() {
                 return;
             } else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || ret == 0) {
                 //download finished
-                close_data();
+                close_data(MO_FtpCloseReason_Success);
                 return;
             } else if (ret < 0) {
                 MO_DBG_ERR("mbedtls_net_recv: %i", ret);
-                close_data();
+                close_data(MO_FtpCloseReason_Failure);
                 return;
             }
 
@@ -747,7 +749,7 @@ void FtpTransferMbedTLS::process_data() {
         } else {
             //no data in fileReader anymore
             MO_DBG_DEBUG("finished file reading");
-            close_data();
+            close_data(MO_FtpCloseReason_Success);
         }
     }
 }
@@ -761,6 +763,10 @@ void FtpTransferMbedTLS::loop() {
     if (data_opened) {
         process_data();
     }
+}
+
+bool FtpTransferMbedTLS::isActive() {
+    return ctrl_opened || data_opened;
 }
 
 bool FtpTransferMbedTLS::read_url_ctrl(const char *ftp_url_raw) {
@@ -888,7 +894,7 @@ FtpClientMbedTLS::FtpClientMbedTLS(bool tls_only, const char *client_cert, const
 
 }
 
-std::unique_ptr<FtpDownload> FtpClientMbedTLS::getFile(const char *ftp_url_raw, std::function<size_t(unsigned char *data, size_t len)> fileWriter, std::function<void()> onClose, const char *ca_cert) {
+std::unique_ptr<FtpDownload> FtpClientMbedTLS::getFile(const char *ftp_url_raw, std::function<size_t(unsigned char *data, size_t len)> fileWriter, std::function<void(MO_FtpCloseReason)> onClose, const char *ca_cert) {
 
     auto ftp_handle = std::unique_ptr<FtpTransferMbedTLS>(new FtpTransferMbedTLS(tls_only, client_cert, client_key));
     if (!ftp_handle) {
@@ -905,7 +911,7 @@ std::unique_ptr<FtpDownload> FtpClientMbedTLS::getFile(const char *ftp_url_raw, 
     }
 }
 
-std::unique_ptr<FtpUpload> FtpClientMbedTLS::postFile(const char *ftp_url_raw, std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, std::function<void()> onClose, const char *ca_cert) {
+std::unique_ptr<FtpUpload> FtpClientMbedTLS::postFile(const char *ftp_url_raw, std::function<size_t(unsigned char *out, size_t buffsize)> fileReader, std::function<void(MO_FtpCloseReason)> onClose, const char *ca_cert) {
     
     auto ftp_handle = std::unique_ptr<FtpTransferMbedTLS>(new FtpTransferMbedTLS(tls_only, client_cert, client_key));
     if (!ftp_handle) {

--- a/src/MicroOcpp/Core/Time.h
+++ b/src/MicroOcpp/Core/Time.h
@@ -11,7 +11,7 @@
 
 #include <MicroOcpp/Platform.h>
 
-#define JSONDATE_LENGTH 24
+#define JSONDATE_LENGTH 24   //max. ISO 8601 date length, excluding the terminating zero
 
 namespace MicroOcpp {
 

--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
@@ -7,9 +7,11 @@
 
 #include <functional>
 #include <memory>
-#include <MicroOcpp/Core/Time.h>
-#include <MicroOcpp/Model/Diagnostics/DiagnosticsStatus.h>
 #include <string>
+#include <deque>
+#include <MicroOcpp/Core/Time.h>
+#include <MicroOcpp/Core/Ftp.h>
+#include <MicroOcpp/Model/Diagnostics/DiagnosticsStatus.h>
 
 namespace MicroOcpp {
 
@@ -21,6 +23,7 @@ enum class UploadStatus {
 
 class Context;
 class Request;
+class FilesystemAdapter;
 
 class DiagnosticsService {
 private:
@@ -39,12 +42,27 @@ private:
     std::function<UploadStatus()> uploadStatusInput;
     bool uploadIssued = false;
 
+    std::unique_ptr<FtpUpload> ftpUpload;
+    UploadStatus ftpUploadStatus = UploadStatus::NotUploaded;
+    const char *ftpServerCert = nullptr;
+    std::shared_ptr<FilesystemAdapter> filesystem;
+    char *diagPreamble = nullptr;
+    size_t diagPreambleLen = 0;
+    size_t diagPreambleTransferred = 0;
+    bool diagReaderHasData = false;
+    char *diagPostamble = nullptr;
+    size_t diagPostambleLen = 0;
+    size_t diagPostambleTransferred = 0;
+    std::deque<std::string> diagFileList;
+    size_t diagFilesFrontTransferred = 0;
+
     std::unique_ptr<Request> getDiagnosticsStatusNotification();
 
     Ocpp16::DiagnosticsStatus lastReportedStatus = Ocpp16::DiagnosticsStatus::Idle;
 
 public:
     DiagnosticsService(Context& context);
+    ~DiagnosticsService();
 
     void loop();
 
@@ -57,11 +75,44 @@ public:
 
     void setRefreshFilename(std::function<std::string()> refreshFn); //refresh a new filename which will be used for the subsequent upload tries
 
+    /*
+     * Sets the diagnostics data reader. When the server sends a GetDiagnostics operation, then MO will open an FTP
+     * connection to the FTP server and upload a diagnostics file. MO automatically creates a small report about
+     * the OCPP-related status data + it uploads the contents of the OCPP directory. In addition to the automatic
+     * report, MO also sends all data provided by the custom diagnosticsReader. Use the diagnosticsReader to add
+     * all data which could be helpful for troubleshooting, i.e.
+     *     - internal status variables, or state machine states
+     *     - error trip counters
+     *     - current sensor readings and all GPIO values
+     *     - Heap statistics, flash memory statistics
+     *     - and more. The more the better
+     *
+     * MO calls the diagnosticsReader output buffer `buf` and the bufsize `size`. Write at most `size` bytes and
+     * return the number of bytes actually written (without terminating zero-byte). It's not necessary to append
+     * a terminating zero, MO will ignore any data after the string. To end the reading process, return 0.
+     *
+     * Note that this function only works if MO_ENABLE_MBEDTLS=1, or MO has been configured with a custom FTP client
+     */
+    void setDiagnosticsReader(std::function<size_t(char *buf, size_t size)> diagnosticsReader, std::function<void()> onClose, std::shared_ptr<FilesystemAdapter> filesystem);
+
+    void setFtpServerCert(const char *cert); //zero-copy mode, i.e. cert must outlive MO
+
     void setOnUpload(std::function<bool(const char *location, Timestamp &startTime, Timestamp &stopTime)> onUpload);
 
     void setOnUploadStatusInput(std::function<UploadStatus()> uploadStatusInput);
 };
 
 } //end namespace MicroOcpp
+
+#if !defined(MO_CUSTOM_DIAGNOSTICS)
+
+#if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
+
+namespace MicroOcpp {
+std::unique_ptr<DiagnosticsService> makeDefaultDiagnosticsService(Context& Context);
+}
+
+#endif //MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
+#endif //!defined(MO_CUSTOM_DIAGNOSTICS)
 
 #endif

--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
@@ -41,11 +41,11 @@ private:
     std::function<bool(const char *location, Timestamp &startTime, Timestamp &stopTime)> onUpload;
     std::function<UploadStatus()> uploadStatusInput;
     bool uploadIssued = false;
+    bool uploadFailure = false;
 
     std::unique_ptr<FtpUpload> ftpUpload;
     UploadStatus ftpUploadStatus = UploadStatus::NotUploaded;
     const char *ftpServerCert = nullptr;
-    std::shared_ptr<FilesystemAdapter> filesystem;
     char *diagPreamble = nullptr;
     size_t diagPreambleLen = 0;
     size_t diagPreambleTransferred = 0;
@@ -109,7 +109,13 @@ public:
 #if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
 
 namespace MicroOcpp {
-std::unique_ptr<DiagnosticsService> makeDefaultDiagnosticsService(Context& Context);
+std::unique_ptr<DiagnosticsService> makeDefaultDiagnosticsService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem);
+}
+
+#elif MO_ENABLE_MBEDTLS
+
+namespace MicroOcpp {
+std::unique_ptr<DiagnosticsService> makeDefaultDiagnosticsService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem);
 }
 
 #endif //MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
@@ -438,8 +438,9 @@ std::unique_ptr<FirmwareService> MicroOcpp::makeDefaultFirmwareService(Context& 
 
 std::unique_ptr<FirmwareService> MicroOcpp::makeDefaultFirmwareService(Context& context) {
     std::unique_ptr<FirmwareService> fwService = std::unique_ptr<FirmwareService>(new FirmwareService(context));
+    auto fwServicePtr = fwService.get();
 
-    fwService->setOnInstall([fwService] (const char *location) {
+    fwService->setOnInstall([fwServicePtr] (const char *location) {
         
         MO_DBG_WARN("Built-in updater for ESP8266 is only intended for demonstration purposes. HTTP support only");
 
@@ -454,15 +455,15 @@ std::unique_ptr<FirmwareService> MicroOcpp::makeDefaultFirmwareService(Context& 
 
         switch (ret) {
             case HTTP_UPDATE_FAILED:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
+                fwServicePtr->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
                 MO_DBG_WARN("HTTP_UPDATE_FAILED Error (%d): %s\n", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
                 break;
             case HTTP_UPDATE_NO_UPDATES:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
+                fwServicePtr->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
                 MO_DBG_WARN("HTTP_UPDATE_NO_UPDATES");
                 break;
             case HTTP_UPDATE_OK:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::Installed;});
+                fwServicePtr->setInstallationStatusInput([](){return InstallationStatus::Installed;});
                 MO_DBG_INFO("HTTP_UPDATE_OK");
                 ESP.restart();
                 break;

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.cpp
@@ -44,6 +44,20 @@ void FirmwareService::setBuildNumber(const char *buildNumber) {
 }
 
 void FirmwareService::loop() {
+
+    if (ftpDownload && ftpDownload->isActive()) {
+        ftpDownload->loop();
+    }
+
+    if (ftpDownload) {
+        if (ftpDownload->isActive()) {
+            ftpDownload->loop();
+        } else {
+            MO_DBG_DEBUG("Deinit FTP download");
+            ftpDownload.reset();
+        }
+    }
+
     auto notification = getFirmwareStatusNotification();
     if (notification) {
         context.initiateRequest(std::move(notification));
@@ -69,7 +83,7 @@ void FirmwareService::loop() {
                 downloadIssued = true;
                 stage = UpdateStage::AwaitDownload;
                 timestampTransition = mocpp_tick_ms();
-                delayTransition = 5000; //delay between state "Downloading" and actually starting the download
+                delayTransition = 2000; //delay between state "Downloading" and actually starting the download
                 return;
             }
         }
@@ -106,9 +120,7 @@ void FirmwareService::loop() {
                 return;
             } else {
                 //if client doesn't report download state, assume download to be finished (at least 30s download time have passed until here)
-                if (downloadStatusInput == nullptr) {
-                    stage = UpdateStage::AfterDownload;
-                }
+                stage = UpdateStage::AfterDownload;
             }
         }
 
@@ -123,11 +135,14 @@ void FirmwareService::loop() {
             }
 
             if (!ongoingTx) {
-                stage = UpdateStage::AwaitInstallation;
-                installationIssued = true;
-
+                if (onInstall == nullptr) {
+                    stage = UpdateStage::Installing;
+                } else {
+                    stage = UpdateStage::AwaitInstallation;
+                }
                 timestampTransition = mocpp_tick_ms();
-                delayTransition = 10000;
+                delayTransition = 2000;
+                installationIssued = true;
             }
 
             return;
@@ -138,13 +153,11 @@ void FirmwareService::loop() {
             stage = UpdateStage::Installing;
 
             if (onInstall) {
-                onInstall(location.c_str()); //should restart the device on success
-            } else {
-                MO_DBG_WARN("onInstall must be set! (see setOnInstall). Will abort");
-            }
+                onInstall(location.c_str()); //may restart the device on success
 
-            timestampTransition = mocpp_tick_ms();
-            delayTransition = installationStatusInput ? 1000 : 120 * 1000;
+                timestampTransition = mocpp_tick_ms();
+                delayTransition = installationStatusInput ? 1000 : 120 * 1000;
+            }
             return;
         }
 
@@ -153,9 +166,11 @@ void FirmwareService::loop() {
             if (installationStatusInput) {
                 if (installationStatusInput() == InstallationStatus::Installed) {
                     MO_DBG_INFO("FW update finished");
-                    //Client should reboot during onInstall. If not, client is responsible to reboot at a later point
+                    //Charger may reboot during onInstall. If it doesn't, server will send Reset request
                     resetStage();
-                    retries = 0; //End of update routine. Client must reboot on its own
+                    retries = 0; //End of update routine
+                    stage = UpdateStage::Installed;
+                    location.clear();
                 } else if (installationStatusInput() == InstallationStatus::InstallationFailed) {
                     MO_DBG_INFO("Installation timeout or failed! Retry");
                     retreiveDate = timestampNow;
@@ -169,9 +184,11 @@ void FirmwareService::loop() {
                 return;
             } else {
                 MO_DBG_INFO("FW update finished");
-                //Client should reboot during onInstall. If not, client is responsible to reboot at a later point
+                //Charger may reboot during onInstall. If it doesn't, server will send Reset request
                 resetStage();
-                retries = 0; //End of update routine. Client must reboot on its own
+                stage = UpdateStage::Installed;
+                retries = 0; //End of update routine
+                location.clear();
                 return;
             }
         }
@@ -180,10 +197,19 @@ void FirmwareService::loop() {
         MO_DBG_ERR("Firmware update failed");
         retries = 0;
         resetStage();
+        stage = UpdateStage::InternalError;
+        location.clear();
     }
 }
 
 void FirmwareService::scheduleFirmwareUpdate(const char *location, Timestamp retreiveDate, unsigned int retries, unsigned int retryInterval) {
+
+    if (!onDownload && !onInstall) {
+        MO_DBG_ERR("FW service not configured");
+        stage = UpdateStage::InternalError; //will send "InstallationFailed" and not proceed with update
+        return;
+    }
+
     this->location = location;
     this->retreiveDate = retreiveDate;
     this->retries = retries;
@@ -197,7 +223,6 @@ void FirmwareService::scheduleFirmwareUpdate(const char *location, Timestamp ret
     char dbuf [JSONDATE_LENGTH + 1] = {'\0'};
     this->retreiveDate.toJsonString(dbuf, JSONDATE_LENGTH + 1);
 
-#if MO_DBG_LEVEL >= MO_DL_INFO
     MO_DBG_INFO("Scheduled FW update!\n" \
                     "                  location = %s\n" \
                     "                  retrieveDate = %s\n" \
@@ -207,7 +232,6 @@ void FirmwareService::scheduleFirmwareUpdate(const char *location, Timestamp ret
             dbuf,
             this->retries,
             this->retryInterval);
-#endif
 
     timestampTransition = mocpp_tick_ms();
     delayTransition = 1000;
@@ -216,6 +240,13 @@ void FirmwareService::scheduleFirmwareUpdate(const char *location, Timestamp ret
 }
 
 FirmwareStatus FirmwareService::getFirmwareStatus() {
+
+    if (stage == UpdateStage::Installed) {
+        return FirmwareStatus::Installed;
+    } else if (stage == UpdateStage::InternalError) {
+        return FirmwareStatus::InstallationFailed; 
+    }
+
     if (installationIssued) {
         if (installationStatusInput != nullptr) {
             if (installationStatusInput() == InstallationStatus::Installed) {
@@ -268,7 +299,7 @@ std::unique_ptr<Request> FirmwareService::getFirmwareStatusNotification() {
 
     if (getFirmwareStatus() != lastReportedStatus) {
         lastReportedStatus = getFirmwareStatus();
-        if (lastReportedStatus != FirmwareStatus::Idle && lastReportedStatus != FirmwareStatus::Installed) {
+        if (lastReportedStatus != FirmwareStatus::Idle) {
             auto fwNotificationMsg = new Ocpp16::FirmwareStatusNotification(lastReportedStatus);
             auto fwNotification = makeRequest(fwNotificationMsg);
             return fwNotification;
@@ -300,59 +331,95 @@ void FirmwareService::resetStage() {
     installationIssued = false;
 }
 
-#if MO_PLATFORM == MO_PLATFORM_ARDUINO && !defined(MO_CUSTOM_UPDATER)
-#if defined(ESP32)
+void FirmwareService::setDownloadFileWriter(std::function<size_t(const unsigned char *buf, size_t size)> firmwareWriter, std::function<void(MO_FtpCloseReason)> onClose) {
+    if (!ftpClient) {
+        MO_DBG_ERR("FTP client not set. Abort");
+        return;
+    }
 
-#include <HTTPUpdate.h>
+    this->onDownload = [this, firmwareWriter, onClose] (const char *location) -> bool {
+        this->ftpDownload = ftpClient->getFile(location, firmwareWriter,
+            [this, onClose] (MO_FtpCloseReason reason) -> void {
+                if (reason == MO_FtpCloseReason_Success) {
+                    MO_DBG_INFO("FTP download success");
+                    this->ftpDownloadStatus = DownloadStatus::Downloaded;
+                } else {
+                    MO_DBG_INFO("FTP download failure (%i)", reason);
+                    this->ftpDownloadStatus = DownloadStatus::DownloadFailed;
+                }
 
-FirmwareService *MicroOcpp::makeDefaultFirmwareService(Context& context) {
-    FirmwareService *fwService = new FirmwareService(context);
+                onClose(reason);
+            });
 
-    /*
-     * example of how to integrate a separate download phase (optional)
-     */
-#if 0 //separate download phase
-    fwService->setOnDownload([] (const char *location) {
-        //download the new binary
-        //...
-        return true;
-    });
+        if (this->ftpDownload) {
+            this->ftpDownloadStatus = DownloadStatus::NotDownloaded;
+            return true;
+        } else {
+            this->ftpDownloadStatus = DownloadStatus::DownloadFailed;
+            return false;
+        }
+    };
 
-    fwService->setDownloadStatusInput([] () {
-        //report the download progress
-        //...
-        return DownloadStatus::NotDownloaded;
-    });
-#endif //separate download phase
+    this->downloadStatusInput = [this] () {
+        return this->ftpDownloadStatus;
+    };
+}
 
-    fwService->setOnInstall([fwService] (const char *location) {
+void FirmwareService::setFtpClient(std::shared_ptr<FtpClient> ftpClient) {
+    this->ftpClient = std::move(ftpClient);
+}
 
-        MO_DBG_WARN("Built-in updater for ESP32 is only intended for demonstration purposes. HTTP support only");
+void FirmwareService::setFtpServerCert(const char *cert) {
+    this->ftpServerCert = cert;
+}
+
+#if !defined(MO_CUSTOM_UPDATER)
+#if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
+
+#include <Update.h>
+
+std::unique_ptr<FirmwareService> MicroOcpp::makeDefaultFirmwareService(Context& context, std::shared_ptr<FtpClient> ftpClient) {
+    std::unique_ptr<FirmwareService> fwService = std::unique_ptr<FirmwareService>(new FirmwareService(context));
+
+    fwService->setFtpClient(ftpClient);
+
+    fwService->setDownloadFileWriter(
+
+        MO_DBG_WARN("Built-in updater for ESP32 is only intended for demonstration purposes");
 
         fwService->setInstallationStatusInput([](){return InstallationStatus::NotInstalled;});
 
-        WiFiClient client;
-        //WiFiClientSecure client;
-        //client.setCACert(rootCACertificate);
-        client.setTimeout(60); //in seconds
-        
-        // httpUpdate.setLedPin(LED_BUILTIN, HIGH);
-        t_httpUpdate_return ret = httpUpdate.update(client, location);
+        [this] (const unsigned char *data, size_t size) -> size_t {
+            if (!Update.isRunning()) {
+                MO_DBG_DEBUG("start writing FW");
+                auto ret = Update.begin();
+                if (!ret) {
+                    MO_DBG_DEBUG("cannot start update");
+                    return 0;
+                }
+            }
 
-        switch (ret) {
-            case HTTP_UPDATE_FAILED:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
-                MO_DBG_WARN("HTTP_UPDATE_FAILED Error (%d): %s\n", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
-                break;
-            case HTTP_UPDATE_NO_UPDATES:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
-                MO_DBG_WARN("HTTP_UPDATE_NO_UPDATES");
-                break;
-            case HTTP_UPDATE_OK:
-                fwService->setInstallationStatusInput([](){return InstallationStatus::Installed;});
-                MO_DBG_INFO("HTTP_UPDATE_OK");
-                ESP.restart();
-                break;
+            size_t written = Update.write((uint8_t*) data, size);
+            MO_DBG_DEBUG("update progress: %zu kB", Update.progress() / 1000);
+            return written;
+        }, [this] (MO_FtpCloseReason reason) {
+            if (reason != MO_FtpCloseReason_Success) {
+                Update.abort();
+            } else {
+                MO_DBG_ERR("update failed: FTP connection closed unexpectedly");
+            }
+        });
+
+    fwService->setOnInstall([fwService] (const char *location) {
+
+        if (Update.isRunning() && Update.end(true)) {
+            MO_DBG_DEBUG("update success");
+            fwService->setInstallationStatusInput([](){return InstallationStatus::Installed;});
+
+            ESP.restart();
+        } else {
+            MO_DBG_ERR("update failed");
+            fwService->setInstallationStatusInput([](){return InstallationStatus::InstallationFailed;});
         }
 
         return true;
@@ -365,12 +432,12 @@ FirmwareService *MicroOcpp::makeDefaultFirmwareService(Context& context) {
     return fwService;
 }
 
-#elif defined(ESP8266)
+#elif MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP8266)
 
 #include <ESP8266httpUpdate.h>
 
-FirmwareService *MicroOcpp::makeDefaultFirmwareService(Context& context) {
-    FirmwareService *fwService = new FirmwareService(context);
+std::unique_ptr<FirmwareService> MicroOcpp::makeDefaultFirmwareService(Context& context) {
+    std::unique_ptr<FirmwareService> fwService = std::unique_ptr<FirmwareService>(new FirmwareService(context));
 
     fwService->setOnInstall([fwService] (const char *location) {
         
@@ -411,5 +478,5 @@ FirmwareService *MicroOcpp::makeDefaultFirmwareService(Context& context) {
     return fwService;
 }
 
-#endif //defined(ESP8266)
-#endif //MO_PLATFORM == MO_PLATFORM_ARDUINO && !defined(MO_CUSTOM_UPDATER)
+#endif //MO_PLATFORM
+#endif //!defined(MO_CUSTOM_UPDATER)

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
@@ -40,7 +40,6 @@ private:
     std::function<DownloadStatus()> downloadStatusInput;
     bool downloadIssued = false;
 
-    std::shared_ptr<FtpClient> ftpClient;
     std::unique_ptr<FtpDownload> ftpDownload;
     DownloadStatus ftpDownloadStatus = DownloadStatus::NotDownloaded;
     const char *ftpServerCert = nullptr;
@@ -99,11 +98,6 @@ public:
      */
     void setDownloadFileWriter(std::function<size_t(const unsigned char *buf, size_t size)> firmwareWriter, std::function<void(MO_FtpCloseReason)> onClose);
 
-    /*
-     * Set an FTP client manually or replace the default FTP client, if built with `MO_ENABLE_MBEDTLS=1`
-     */
-    void setFtpClient(std::shared_ptr<FtpClient> ftpClient);
-
     void setFtpServerCert(const char *cert); //zero-copy mode, i.e. cert must outlive MO
 
     /*
@@ -125,7 +119,7 @@ public:
 #if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
 
 namespace MicroOcpp {
-std::unique_ptr<FirmwareService> makeDefaultFirmwareService(Context& context, std::shared_ptr<FtpClient> ftpClient);
+std::unique_ptr<FirmwareService> makeDefaultFirmwareService(Context& context);
 }
 
 #elif MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP8266)

--- a/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
+++ b/src/MicroOcpp/Model/FirmwareManagement/FirmwareService.h
@@ -11,6 +11,7 @@
 #include <MicroOcpp/Core/ConfigurationKeyValue.h>
 #include <MicroOcpp/Model/FirmwareManagement/FirmwareStatus.h>
 #include <MicroOcpp/Core/Time.h>
+#include <MicroOcpp/Core/Ftp.h>
 
 namespace MicroOcpp {
 
@@ -39,6 +40,11 @@ private:
     std::function<DownloadStatus()> downloadStatusInput;
     bool downloadIssued = false;
 
+    std::shared_ptr<FtpClient> ftpClient;
+    std::unique_ptr<FtpDownload> ftpDownload;
+    DownloadStatus ftpDownloadStatus = DownloadStatus::NotDownloaded;
+    const char *ftpServerCert = nullptr;
+
     std::function<InstallationStatus()> installationStatusInput;
     bool installationIssued = false;
 
@@ -62,8 +68,10 @@ private:
         Downloading,
         AfterDownload,
         AwaitInstallation,
-        Installing
-    } stage;
+        Installing,
+        Installed,
+        InternalError
+    } stage = UpdateStage::Idle;
 
     void resetStage();
 
@@ -80,6 +88,27 @@ public:
 
     Ocpp16::FirmwareStatus getFirmwareStatus();
 
+    /*
+     * Sets the firmware writer. During the UpdateFirmware process, MO will use an FTP client to download the firmware and forward
+     * the binary data to `firmwareWriter`. The binary data comes in chunks. MO executes `firmwareWriter` with `buf` containing the
+     * next chunk of FW data and `size` being the chunk size. `firmwareWriter` must return the number of bytes written, whereas
+     * the result can be between 1 and `size`, and 0 aborts the download. MO executes `onClose` with the reason why the connection
+     * has been closed. If the download hasn't been successful, MO will abort the update routine in any case.
+     * 
+     * Note that this function only works if MO_ENABLE_MBEDTLS=1, or MO has been configured with a custom FTP client
+     */
+    void setDownloadFileWriter(std::function<size_t(const unsigned char *buf, size_t size)> firmwareWriter, std::function<void(MO_FtpCloseReason)> onClose);
+
+    /*
+     * Set an FTP client manually or replace the default FTP client, if built with `MO_ENABLE_MBEDTLS=1`
+     */
+    void setFtpClient(std::shared_ptr<FtpClient> ftpClient);
+
+    void setFtpServerCert(const char *cert); //zero-copy mode, i.e. cert must outlive MO
+
+    /*
+     * Manual alternative for FTP download handler `setDownloadFileWriter`
+     */
     void setOnDownload(std::function<bool(const char *location)> onDownload);
 
     void setDownloadStatusInput(std::function<DownloadStatus()> downloadStatusInput);
@@ -91,16 +120,21 @@ public:
 
 } //endif namespace MicroOcpp
 
-#if MO_PLATFORM == MO_PLATFORM_ARDUINO && !defined(MO_CUSTOM_UPDATER)
-#if defined(ESP32) || defined(ESP8266)
+#if !defined(MO_CUSTOM_UPDATER)
+
+#if MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP32) && MO_ENABLE_MBEDTLS
 
 namespace MicroOcpp {
-
-FirmwareService *makeDefaultFirmwareService(Context& context);
-
+std::unique_ptr<FirmwareService> makeDefaultFirmwareService(Context& context, std::shared_ptr<FtpClient> ftpClient);
 }
 
-#endif //defined(ESP32) || defined(ESP8266)
-#endif //MO_PLATFORM == MO_PLATFORM_ARDUINO && !defined(MO_CUSTOM_UPDATER)
+#elif MO_PLATFORM == MO_PLATFORM_ARDUINO && defined(ESP8266)
+
+namespace MicroOcpp {
+std::unique_ptr<FirmwareService> makeDefaultFirmwareService(Context& context);
+}
+
+#endif //MO_PLATFORM
+#endif //!defined(MO_CUSTOM_UPDATER)
 
 #endif

--- a/tests/FirmwareManagement.cpp
+++ b/tests/FirmwareManagement.cpp
@@ -1,0 +1,597 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
+#include <MicroOcpp.h>
+#include <MicroOcpp/Core/Connection.h>
+#include "./catch2/catch.hpp"
+#include "./helpers/testHelper.h"
+
+#include <MicroOcpp/Core/Context.h>
+#include <MicroOcpp/Operations/CustomOperation.h>
+#include <MicroOcpp/Core/SimpleRequestFactory.h>
+
+#include <MicroOcpp/Core/FilesystemAdapter.h>
+#include <MicroOcpp/Core/FilesystemUtils.h>
+#include <MicroOcpp/Core/Configuration.h>
+
+#include <MicroOcpp/Model/FirmwareManagement/FirmwareService.h>
+
+#define BASE_TIME     "2023-01-01T00:00:00.000Z"
+#define BASE_TIME_1H  "2023-01-01T01:00:00.000Z"
+#define FTP_URL       "ftps://localhost/firmware.bin"
+
+using namespace MicroOcpp;
+
+TEST_CASE( "FirmwareManagement" ) {
+    printf("\nRun %s\n",  "FirmwareManagement");
+
+    //clean state
+    auto filesystem = makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail);
+    FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
+
+    //initialize Context with dummy socket
+    LoopbackConnection loopback;
+
+    mocpp_set_timer(custom_timer_cb);
+
+    mocpp_initialize(loopback, ChargerCredentials("test-runner"));
+    auto& model = getOcppContext()->getModel();
+    auto fwService = getFirmwareService();
+    SECTION("FirmwareService initialized") {
+        REQUIRE(fwService != nullptr);
+    }
+
+    model.getClock().setTime(BASE_TIME);
+
+    loop();
+
+    SECTION("Unconfigured FW service") {
+
+        bool checkProcessed = false;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        checkProcessed = true;
+                        REQUIRE((
+                            !strcmp(payload["status"] | "_Undefined", "DownloadFailed") ||
+                            !strcmp(payload["status"] | "_Undefined", "InstallationFailed")
+                        ));
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 1;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 1;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        loop();
+
+        REQUIRE(checkProcessed);
+    }
+
+    SECTION("Download phase only") {
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloading") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloaded") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 2) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+
+        bool checkProcessedOnDownload = false;
+
+        fwService->setOnDownload([&checkProcessedOnDownload] (const char *location) {
+            checkProcessedOnDownload = true;
+            return true;
+        });
+
+        int checkProcessedOnDownloadStatus = 0;
+
+        fwService->setDownloadStatusInput([&checkProcessed, &checkProcessedOnDownloadStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnDownloadStatus == 0) checkProcessedOnDownloadStatus = 1;
+                return DownloadStatus::NotDownloaded;
+            } else if (checkProcessed >= 1) {
+                if (checkProcessedOnDownloadStatus == 1) checkProcessedOnDownloadStatus = 2;
+                return DownloadStatus::Downloaded;
+            }
+        });
+
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 1;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 1;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        REQUIRE( checkProcessed == 3 ); //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessedOnDownload );
+        REQUIRE( checkProcessedOnDownloadStatus == 2 );
+    }
+
+    SECTION("Installation phase only") {
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installing") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        bool checkProcessedOnInstall = false;
+
+        fwService->setOnInstall([&checkProcessedOnInstall] (const char *location) {
+            checkProcessedOnInstall = true;
+            REQUIRE( !strcmp(location, FTP_URL) );
+            return true;
+        });
+
+        int checkProcessedOnInstallStatus = 0;
+
+        fwService->setInstallationStatusInput([&checkProcessed, &checkProcessedOnInstallStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnInstallStatus == 0) checkProcessedOnInstallStatus = 1;
+                return InstallationStatus::NotInstalled;
+            } else if (checkProcessed >= 1) {
+                if (checkProcessedOnInstallStatus == 1) checkProcessedOnInstallStatus = 2;
+                return InstallationStatus::Installed;
+            }
+        });
+        
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 1;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 1;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        REQUIRE( checkProcessed == 2 ); //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessedOnInstall );
+        REQUIRE( checkProcessedOnInstallStatus == 2 );
+    }
+
+    SECTION("Download and install") {
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloading") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloaded") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 2) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installing") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 3) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        bool checkProcessedOnDownload = false;
+        fwService->setOnDownload([&checkProcessedOnDownload] (const char *location) {
+            checkProcessedOnDownload = true;
+            return true;
+        });
+
+        int checkProcessedOnDownloadStatus = 0;
+        fwService->setDownloadStatusInput([&checkProcessed, &checkProcessedOnDownloadStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnDownloadStatus == 0) checkProcessedOnDownloadStatus = 1;
+                return DownloadStatus::NotDownloaded;
+            } else if (checkProcessed >= 1) {
+                if (checkProcessedOnDownloadStatus == 1) checkProcessedOnDownloadStatus = 2;
+                return DownloadStatus::Downloaded;
+            }
+        });
+        
+        bool checkProcessedOnInstall = false;
+        fwService->setOnInstall([&checkProcessedOnInstall] (const char *location) {
+            checkProcessedOnInstall = true;
+            return true;
+        });
+
+        int checkProcessedOnInstallStatus = 0;
+        fwService->setInstallationStatusInput([&checkProcessed, &checkProcessedOnInstallStatus] () {
+            if (checkProcessed <= 2) {
+                if (checkProcessedOnInstallStatus == 0) checkProcessedOnInstallStatus = 1;
+                return InstallationStatus::NotInstalled;
+            } else if (checkProcessed >= 3) {
+                if (checkProcessedOnInstallStatus == 1) checkProcessedOnInstallStatus = 2;
+                return InstallationStatus::Installed;
+            }
+        });
+        
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 1;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 1;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        REQUIRE( checkProcessed == 4 ); //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessedOnDownload );
+        REQUIRE( checkProcessedOnDownloadStatus == 2 );
+        REQUIRE( checkProcessedOnInstall );
+        REQUIRE( checkProcessedOnInstallStatus == 2 );
+    }
+
+    SECTION("Download failure (try 2 times)") {
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloading") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "DownloadFailed") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 2) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloading") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 3) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "DownloadFailed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+
+        int checkProcessedOnDownload = 0;
+        fwService->setOnDownload([&checkProcessedOnDownload] (const char *location) {
+            checkProcessedOnDownload++;
+            return true;
+        });
+
+        int checkProcessedOnDownloadStatus = 0;
+        fwService->setDownloadStatusInput([&checkProcessed, &checkProcessedOnDownloadStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnDownloadStatus == 0) checkProcessedOnDownloadStatus = 1;
+                return DownloadStatus::NotDownloaded;
+            } else if (checkProcessed == 1) {
+                if (checkProcessedOnDownloadStatus == 1) checkProcessedOnDownloadStatus = 2;
+                return DownloadStatus::DownloadFailed;
+            } else if (checkProcessed == 2) {
+                if (checkProcessedOnDownloadStatus == 2) checkProcessedOnDownloadStatus = 3;
+                return DownloadStatus::NotDownloaded;
+            } else if (checkProcessed >= 3) {
+                if (checkProcessedOnDownloadStatus == 3) checkProcessedOnDownloadStatus = 4;
+                return DownloadStatus::DownloadFailed;
+            }
+        });
+
+        bool checkProcessedOnInstall = false; // must not be executed
+        fwService->setOnInstall([&checkProcessedOnInstall] (const char *location) {
+            checkProcessedOnInstall = true;
+            return true;
+        });
+
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 2;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 10;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 20; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        REQUIRE( checkProcessed == 4 ); //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessedOnDownload == 2 );
+        REQUIRE( checkProcessedOnDownloadStatus == 4 );
+        REQUIRE( !checkProcessedOnInstall );
+    }
+
+    SECTION("Installation failure (try 2 times)") {
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installing") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "InstallationFailed") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 2) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installing") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 3) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "InstallationFailed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        int checkProcessedOnInstall = 0;
+
+        fwService->setOnInstall([&checkProcessedOnInstall] (const char *location) {
+            checkProcessedOnInstall++;
+            return true;
+        });
+
+        int checkProcessedOnInstallStatus = 0;
+
+        fwService->setInstallationStatusInput([&checkProcessed, &checkProcessedOnInstallStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnInstallStatus == 0) checkProcessedOnInstallStatus = 1;
+                return InstallationStatus::NotInstalled;
+            } else if (checkProcessed == 1) {
+                if (checkProcessedOnInstallStatus == 1) checkProcessedOnInstallStatus = 2;
+                return InstallationStatus::InstallationFailed;
+            } else if (checkProcessed == 2) {
+                if (checkProcessedOnInstallStatus == 2) checkProcessedOnInstallStatus = 3;
+                return InstallationStatus::NotInstalled;
+            } else if (checkProcessed >= 3) {
+                if (checkProcessedOnInstallStatus == 3) checkProcessedOnInstallStatus = 4;
+                return InstallationStatus::InstallationFailed;
+            }
+        });
+        
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 2;
+                    payload["retrieveDate"] = BASE_TIME;
+                    payload["retryInterval"] = 10;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        REQUIRE( checkProcessed == 4 ); //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessedOnInstall == 2 );
+        REQUIRE( checkProcessedOnInstallStatus == 4 );
+    }
+
+    SECTION("Wait for retreiveDate and charging sessions end") {
+
+        beginTransaction("mIdTag");
+
+        int checkProcessed = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("FirmwareStatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("FirmwareStatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        if (checkProcessed == 0) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloading") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 1) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Downloaded") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 2) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installing") );
+                            checkProcessed++;
+                        } else if (checkProcessed == 3) {
+                            REQUIRE( !strcmp(payload["status"] | "_Undefined", "Installed") );
+                            checkProcessed++;
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        bool checkProcessedOnDownload = false;
+        fwService->setOnDownload([&checkProcessedOnDownload] (const char *location) {
+            checkProcessedOnDownload = true;
+            return true;
+        });
+
+        int checkProcessedOnDownloadStatus = 0;
+        fwService->setDownloadStatusInput([&checkProcessed, &checkProcessedOnDownloadStatus] () {
+            if (checkProcessed == 0) {
+                if (checkProcessedOnDownloadStatus == 0) checkProcessedOnDownloadStatus = 1;
+                return DownloadStatus::NotDownloaded;
+            } else if (checkProcessed >= 1) {
+                if (checkProcessedOnDownloadStatus == 1) checkProcessedOnDownloadStatus = 2;
+                return DownloadStatus::Downloaded;
+            }
+        });
+        
+        bool checkProcessedOnInstall = false;
+        fwService->setOnInstall([&checkProcessedOnInstall] (const char *location) {
+            checkProcessedOnInstall = true;
+            return true;
+        });
+
+        int checkProcessedOnInstallStatus = 0;
+        fwService->setInstallationStatusInput([&checkProcessed, &checkProcessedOnInstallStatus] () {
+            if (checkProcessed <= 2) {
+                if (checkProcessedOnInstallStatus == 0) checkProcessedOnInstallStatus = 1;
+                return InstallationStatus::NotInstalled;
+            } else if (checkProcessed >= 3) {
+                if (checkProcessedOnInstallStatus == 1) checkProcessedOnInstallStatus = 2;
+                return InstallationStatus::Installed;
+            }
+        });
+        
+        getOcppContext()->initiateRequest(makeRequest(new Ocpp16::CustomOperation(
+                "UpdateFirmware",
+                [] () {
+                    //create req
+                    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(4)));
+                    auto payload = doc->to<JsonObject>();
+                    payload["location"] = FTP_URL;
+                    payload["retries"] = 1;
+                    payload["retrieveDate"] = BASE_TIME_1H;
+                    payload["retryInterval"] = 1;
+                    return doc;},
+                [] (JsonObject) { } //ignore conf
+        )));
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        //retreiveDate not reached yet
+        REQUIRE( checkProcessed == 0 );
+        REQUIRE( !checkProcessedOnDownload );
+        REQUIRE( checkProcessedOnDownloadStatus == 0 );
+        REQUIRE( !checkProcessedOnInstall );
+        REQUIRE( checkProcessedOnInstallStatus == 0 );
+
+        getOcppContext()->getModel().getClock().setTime(BASE_TIME_1H);
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        //download-related FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessed == 2 );
+        REQUIRE( checkProcessedOnDownload );
+        REQUIRE( checkProcessedOnDownloadStatus == 2 );
+        REQUIRE( !checkProcessedOnInstall );
+        REQUIRE( checkProcessedOnInstallStatus == 0 );
+
+        endTransaction();
+
+        for (unsigned int i = 0; i < 10; i++) {
+            loop();
+            mtime += 5000;
+        }
+
+        //all FirmwareStatusNotification messages have been received
+        REQUIRE( checkProcessed == 4 );
+        REQUIRE( checkProcessedOnDownload );
+        REQUIRE( checkProcessedOnDownloadStatus == 2 );
+        REQUIRE( checkProcessedOnInstall );
+        REQUIRE( checkProcessedOnInstallStatus == 2 );
+    }
+
+    mocpp_deinitialize();
+
+}

--- a/tests/helpers/testHelper.cpp
+++ b/tests/helpers/testHelper.cpp
@@ -2,14 +2,9 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#include <iostream>
 #include <MicroOcpp.h>
 
 using namespace MicroOcpp;
-
-void cpp_console_out(const char *msg) {
-    std::cout << msg;
-}
 
 unsigned long mtime = 10000;
 unsigned long custom_timer_cb() {

--- a/tests/helpers/testHelper.h
+++ b/tests/helpers/testHelper.h
@@ -2,15 +2,8 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#ifndef MO_CPP_CONSOLE_OUT
-#define MO_CPP_CONSOLE_OUT
-
-/**
-* Prints a string to the c standart console
-*
-* @param msg pointer to the string
-*/
-void cpp_console_out(const char *msg);   
+#ifndef MO_TESTHELPER_H
+#define MO_TESTHELPER_H
 
 extern unsigned long mtime;
 unsigned long custom_timer_cb();

--- a/tests/ocppEngineLifecycle.cpp
+++ b/tests/ocppEngineLifecycle.cpp
@@ -10,9 +10,6 @@
 TEST_CASE( "Context lifecycle" ) {
     printf("\nRun %s\n",  "Context lifecycle");
 
-    //set console output to the cpp console to display outputs
-    //mocpp_set_console_out(cpp_console_out);
-
     //initialize Context with dummy socket
     MicroOcpp::LoopbackConnection loopback;
     mocpp_initialize(loopback);


### PR DESCRIPTION
Provide a default FTP firmware updater.

The UpdateFirmware handler now triggers an FTP download which which can be set up to store all data on flash. This PR includes a full default OTA implementation for the ESP32 on Arduino (using the [Update](https://github.com/espressif/arduino-esp32/tree/3.0.1/libraries/Update) library) as a reference on how to store the FTP traffic on flash.

Furthermore, this PR contains unit tests for the FirmwareService and cleans up the existing OTA procedure a bit.

The OTA reference on the ESP32 replaces the previous HTTP-based reference.