### PR TITLE
StatusNotification error severity mechanism & report resolved errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Provide ChargePointStatus in API ([#309](https://github.com/matth-x/MicroOcpp/pull/309))
 - Built-in OTA over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
 - Built-in Diagnostics over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
+- Error `severity` mechanism ([#331](https://github.com/matth-x/MicroOcpp/pull/331))
+- Build flag `MO_REPORT_NOERROR` to report error recovery ([#331](https://github.com/matth-x/MicroOcpp/pull/331))
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(MO_SRC_UNIT
     tests/Transactions.cpp
     tests/Certificates.cpp
     tests/FirmwareManagement.cpp
+    tests/ChargePointError.cpp
 )
 
 add_executable(mo_unit_tests
@@ -191,6 +192,7 @@ target_compile_definitions(mo_unit_tests PUBLIC
     MO_MaxChargingProfilesInstalled=3
     MO_ENABLE_CERT_MGMT=1
     MO_ENABLE_CONNECTOR_LOCK=1
+    MO_REPORT_NOERROR=1
 )
 
 target_compile_options(mo_unit_tests PUBLIC

--- a/src/MicroOcpp/Model/ConnectorBase/ChargePointErrorData.h
+++ b/src/MicroOcpp/Model/ConnectorBase/ChargePointErrorData.h
@@ -5,11 +5,14 @@
 #ifndef MO_CHARGEPOINTERRORCODE_H
 #define MO_CHARGEPOINTERRORCODE_H
 
+#include <stdint.h>
+
 namespace MicroOcpp {
 
 struct ErrorData {
     bool isError = false; //if any error information is set
     bool isFaulted = false; //if this is a severe error and the EVSE should go into the faulted state
+    uint8_t severity = 1; //severity: don't send less severe errors during highly severe error condition
     const char *errorCode = nullptr; //see ChargePointErrorCode (p. 76/77) for possible values
     const char *info = nullptr; //Additional free format information related to the error
     const char *vendorId = nullptr; //vendor-specific implementation identifier

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -446,8 +446,8 @@ void Connector::loop() {
         #if MO_REPORT_NOERROR
         if (hasResolvedError) {
             bool hasErrors = false;
-            for (size_t i = 0; i < trackErrorDataInputs.size(); i++) {
-                if (trackErrorDataInputs[i]) {
+            for (size_t i = 0; i < std::min(errorDataInputs.size(), trackErrorDataInputs.size()); i++) {
+                if (errorDataInputs[i].operator()().isError || trackErrorDataInputs[i]) {
                     hasErrors = true;
                     break;
                 }

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -31,6 +31,10 @@
 #define MO_TX_CLEAN_ABORTED 1
 #endif
 
+#ifndef MO_REPORT_NOERROR
+#define MO_REPORT_NOERROR 0
+#endif
+
 using namespace MicroOcpp;
 
 Connector::Connector(Context& context, int connectorId)

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -16,6 +16,10 @@
 #include <functional>
 #include <memory>
 
+#ifndef MO_REPORT_NOERROR
+#define MO_REPORT_NOERROR 0
+#endif
+
 namespace MicroOcpp {
 
 class Context;
@@ -41,6 +45,7 @@ private:
     std::function<bool()> evseReadyInput;
     std::vector<std::function<ErrorData ()>> errorDataInputs;
     std::vector<bool> trackErrorDataInputs;
+    uint8_t currentErrorSeverity = 0;
     bool isFaulted();
     const char *getErrorCode();
 

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -45,7 +45,7 @@ private:
     std::function<bool()> evseReadyInput;
     std::vector<std::function<ErrorData ()>> errorDataInputs;
     std::vector<bool> trackErrorDataInputs;
-    uint8_t currentErrorSeverity = 0;
+    int reportedErrorIndex = -1; //last reported error
     bool isFaulted();
     const char *getErrorCode();
 

--- a/tests/ChargePointError.cpp
+++ b/tests/ChargePointError.cpp
@@ -1,0 +1,278 @@
+// matth-x/MicroOcpp
+// Copyright Matthias Akstaller 2019 - 2024
+// MIT License
+
+#include <MicroOcpp.h>
+#include <MicroOcpp/Core/Connection.h>
+#include "./catch2/catch.hpp"
+#include "./helpers/testHelper.h"
+
+#include <MicroOcpp/Core/Context.h>
+#include <MicroOcpp/Operations/CustomOperation.h>
+#include <MicroOcpp/Core/SimpleRequestFactory.h>
+
+#include <MicroOcpp/Core/FilesystemAdapter.h>
+#include <MicroOcpp/Core/FilesystemUtils.h>
+#include <MicroOcpp/Core/Configuration.h>
+
+#include <MicroOcpp/Model/ConnectorBase/Connector.h>
+#include <MicroOcpp/Model/FirmwareManagement/FirmwareService.h>
+
+#define BASE_TIME     "2023-01-01T00:00:00.000Z"
+#define BASE_TIME_1H  "2023-01-01T01:00:00.000Z"
+#define FTP_URL       "ftps://localhost/firmware.bin"
+
+#define ERROR_INFO_EXAMPLE "error description"
+#define ERROR_INFO_LOW_1   "low severity 1"
+#define ERROR_INFO_LOW_2   "low severity 2"
+#define ERROR_INFO_HIGH    "high severity"
+
+#define ERROR_VENDOR_ID    "mVendorId"
+#define ERROR_VENDOR_CODE  "mVendorErrorCode"
+
+using namespace MicroOcpp;
+
+TEST_CASE( "ChargePointError" ) {
+    printf("\nRun %s\n",  "ChargePointError");
+
+    //clean state
+    auto filesystem = makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail);
+    FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
+
+    //initialize Context with dummy socket
+    LoopbackConnection loopback;
+
+    mocpp_set_timer(custom_timer_cb);
+
+    mocpp_initialize(loopback, ChargerCredentials("test-runner"));
+    auto& model = getOcppContext()->getModel();
+    auto fwService = getFirmwareService();
+    SECTION("FirmwareService initialized") {
+        REQUIRE(fwService != nullptr);
+    }
+
+    model.getClock().setTime(BASE_TIME);
+
+    loop();
+
+    SECTION("Err and resolve (soft error)") {
+
+        bool errorCondition = false;
+
+        addErrorDataInput([&errorCondition] () -> ErrorData {
+            if (errorCondition) {
+                ErrorData error = "OtherError";
+                error.isFaulted = false;
+                error.info = ERROR_INFO_EXAMPLE;
+                error.vendorId = ERROR_VENDOR_ID;
+                error.vendorErrorCode = ERROR_VENDOR_CODE;
+                return error;
+            }
+            return nullptr;
+        });
+
+        //test error condition during transaction to check if status remains unchanged
+
+        beginTransaction("mIdTag");
+
+        loop();
+
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Charging );
+        REQUIRE( isOperative() );
+
+        bool checkProcessed = false;
+
+        getOcppContext()->getOperationRegistry().registerOperation("StatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("StatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        checkProcessed = true;
+                        REQUIRE( !strcmp(payload["errorCode"] | "_Undefined", "OtherError") );
+                        REQUIRE( !strcmp(payload["info"] | "_Undefined", ERROR_INFO_EXAMPLE) );
+                        REQUIRE( !strcmp(payload["status"] | "_Undefined", "Charging") );
+                        REQUIRE( !strcmp(payload["vendorId"] | "_Undefined", ERROR_VENDOR_ID) );
+                        REQUIRE( !strcmp(payload["vendorErrorCode"] | "_Undefined", ERROR_VENDOR_CODE) );
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+
+        errorCondition = true;
+
+        loop();
+
+        REQUIRE( checkProcessed );
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Charging );
+        REQUIRE( isOperative() );
+
+#if MO_REPORT_NOERROR
+        checkProcessed = false;
+        getOcppContext()->getOperationRegistry().registerOperation("StatusNotification",
+            [&checkProcessed] () {
+                return new Ocpp16::CustomOperation("StatusNotification",
+                    [ &checkProcessed] (JsonObject payload) {
+                        //process req
+                        checkProcessed = true;
+                        REQUIRE( !strcmp(payload["errorCode"] | "_Undefined", "NoError") );
+                        REQUIRE( !payload.containsKey("info") );
+                        REQUIRE( !strcmp(payload["status"] | "_Undefined", "Charging") );
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+#else
+        checkProcessed = true;
+#endif //MO_REPORT_NOERROR
+
+        errorCondition = false;
+
+        loop();
+
+        REQUIRE( checkProcessed );
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Charging );
+        REQUIRE( isOperative() );
+
+    }
+
+    SECTION("Err and resolve (fatal)") {
+
+        bool errorCondition = false;
+
+        addErrorCodeInput([&errorCondition] () {
+            return errorCondition ? "OtherError" : nullptr;
+        });
+
+        loop();
+
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Available );
+        REQUIRE( isOperative() );
+
+        errorCondition = true;
+
+        loop();
+
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Faulted );
+        REQUIRE( !isOperative() );
+
+        errorCondition = false;
+
+        loop();
+
+        REQUIRE( getChargePointStatus() == ChargePointStatus_Available );
+        REQUIRE( isOperative() );
+    }
+
+    SECTION("Error severity") {
+
+        bool errorConditionLow1 = false;
+        bool errorConditionLow2 = false;
+        bool errorConditionHigh = false;
+
+        addErrorDataInput([&errorConditionLow1] () -> ErrorData {
+            if (errorConditionLow1) {
+                ErrorData error = "OtherError";
+                error.severity = 1;
+                error.info = ERROR_INFO_LOW_1;
+                return error;
+            }
+            return nullptr;
+        });
+
+        addErrorDataInput([&errorConditionLow2] () -> ErrorData {
+            if (errorConditionLow2) {
+                ErrorData error = "OtherError";
+                error.severity = 1;
+                error.info = ERROR_INFO_LOW_2;
+                return error;
+            }
+            return nullptr;
+        });
+
+        addErrorDataInput([&errorConditionHigh] () -> ErrorData {
+            if (errorConditionHigh) {
+                ErrorData error = "OtherError";
+                error.severity = 2;
+                error.info = ERROR_INFO_HIGH;
+                return error;
+            }
+            return nullptr;
+        });
+
+        bool checkProcessed = false;
+        const char *errorLabel = "";
+
+        getOcppContext()->getOperationRegistry().registerOperation("StatusNotification",
+            [&checkProcessed, &errorLabel] () {
+                return new Ocpp16::CustomOperation("StatusNotification",
+                    [&checkProcessed, &errorLabel] (JsonObject payload) {
+                        //process req
+                        if (payload.containsKey("info")) {
+                            checkProcessed = true;
+                            REQUIRE( !strcmp(payload["info"] | "_Undefined", errorLabel) );
+                        }
+                    },
+                    [] () {
+                        //create conf
+                        return createEmptyDocument();
+                    });
+            });
+        
+        //sequence: low-level error 1, low-level error 2, then severe error  -- all errors should go through
+
+        errorConditionLow1 = true;
+        errorLabel = ERROR_INFO_LOW_1;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+        
+        errorConditionLow2 = true;
+        errorLabel = ERROR_INFO_LOW_2;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+        
+        errorConditionHigh = true;
+        errorLabel = ERROR_INFO_HIGH;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+
+        errorConditionLow1 = false;
+        errorConditionLow2 = false;
+        errorConditionHigh = false;
+        loop();
+        
+        //sequence: low-level error 1, severe error, then low-level error 2 -- last error gets muted until severe error is resolved
+
+        errorConditionLow1 = true;
+        errorLabel = ERROR_INFO_LOW_1;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+        
+        errorConditionHigh = true;
+        errorLabel = ERROR_INFO_HIGH;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+        
+        errorConditionLow2 = true;
+        errorLabel = ERROR_INFO_LOW_2;
+        loop();
+        REQUIRE( !checkProcessed );
+
+        errorConditionHigh = false;
+        loop();
+        REQUIRE( checkProcessed );
+        checkProcessed = false;
+    }
+
+    endTransaction();
+    mocpp_deinitialize();
+
+}


### PR DESCRIPTION
This adds the error severity field to the MO error reporting mechanism. The severity can be used to avoid that less important errors are being reported to the server while still being in a highly severe error condition. If the most severe error is resolved, then MO reports the next most severe error. This behavior is useful for some backend systems.

See this example for changing the severity:

```cpp
addErrorDataInput([] () -> ErrorData {
    if (/* error condition */) {
        ErrorData error = "OtherError";
        error.severity = 2; //increase severity to `2` (default is `1`)
        return error;
    }
    return nullptr;
});
```

The new build option `MO_REPORT_NOERROR=1` applies to errors which don't lead to the Faulted status, i.e. where `error.isFaulted == false` (for example, the charger reports the WeakSignal error while remaining Available). If all of these errors are resolved, then MO sends a further StatusNotification message with the error code NoError.