### PR TITLE
Fix OCTT test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Built-in Diagnostics over FTP ([#313](https://github.com/matth-x/MicroOcpp/pull/313))
 - Error `severity` mechanism ([#331](https://github.com/matth-x/MicroOcpp/pull/331))
 - Build flag `MO_REPORT_NOERROR` to report error recovery ([#331](https://github.com/matth-x/MicroOcpp/pull/331))
+- Support for `parentIdTag` ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
+- Input validation for unsigned int Configs ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 
 ### Removed
 
@@ -26,6 +28,10 @@
 - Hold back error StatusNotifs when time not set ([#311](https://github.com/matth-x/MicroOcpp/issues/311))
 - Don't send Available when tx occupies connector ([#315](https://github.com/matth-x/MicroOcpp/issues/315))
 - Make ChargingScheduleAllowedChargingRateUnit read-only ([#328](https://github.com/matth-x/MicroOcpp/issues/328))
+- Don't send StatusNotifs while offline ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
+- Don't change into Unavailable upon Reset ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
+- Reject DataTransfer by default ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
+- UnlockConnector NotSupported if connectorId invalid ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 
 ## [1.1.0] - 2024-05-21
 

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -464,25 +464,44 @@ bool endTransaction(const char *idTag, const char *reason, unsigned int connecto
         if (!idTag || !strcmp(idTag, getTransactionIdTag(connectorId))) {
             res = endTransaction_authorized(idTag, reason, connectorId);
         } else {
-            auto& tx = getTransaction(connectorId);
+            auto tx = getTransaction(connectorId);
             const char *parentIdTag = tx->getParentIdTag();
             if (strlen(parentIdTag) > 0)
             {
                 // We have a parent ID tag, so we need to check if this new card also has one
                 auto authorize = makeRequest(new Ocpp16::Authorize(context->getModel(), idTag));
-                // authorize->setTimeout(authorizationTimeoutInt && authorizationTimeoutInt->getInt() > 0 ? authorizationTimeoutInt->getInt() * 1000UL : 20UL * 1000UL);
-                authorize->setOnReceiveConfListener([idTag, parentIdTag, connectorId, reason] (JsonObject response) {
+                std::string idTag_capture = idTag;
+                std::string reason_capture = reason ? reason : "";
+                authorize->setOnReceiveConfListener([idTag_capture, reason_capture, connectorId, tx] (JsonObject response) {
                     JsonObject idTagInfo = response["idTagInfo"];
 
                     if (strcmp("Accepted", idTagInfo["status"] | "UNDEFINED")) {
                         //Authorization rejected, do nothing
+                        MO_DBG_DEBUG("Authorize rejected (%s), continue transaction", idTag_capture.c_str());
+                        auto connector = context->getModel().getConnector(connectorId);
+                        if (connector) {
+                            connector->updateTxNotification(TxNotification::AuthorizationRejected);
+                        }
                         return;
                     }
-                    if (idTagInfo.containsKey("parentIdTag") && strcmp(idTagInfo["parenIdTag"], parentIdTag))
+                    if (idTagInfo.containsKey("parentIdTag") && !strcmp(idTagInfo["parenIdTag"], tx->getParentIdTag()))
                     {
-                        endTransaction_authorized(idTag, reason, connectorId);
+                        endTransaction_authorized(idTag_capture.c_str(), reason_capture.empty() ? (const char*)nullptr : reason_capture.c_str(), connectorId);
                     }
                 });
+
+                authorize->setOnTimeoutListener([idTag_capture, connectorId] () {
+                    //Authorization timed out, do nothing
+                    MO_DBG_DEBUG("Authorization timeout (%s), continue transaction", idTag_capture.c_str());
+                    auto connector = context->getModel().getConnector(connectorId);
+                    if (connector) {
+                        connector->updateTxNotification(TxNotification::AuthorizationTimeout);
+                    }
+                });
+
+                auto authorizationTimeoutInt = declareConfiguration<int>(MO_CONFIG_EXT_PREFIX "AuthorizationTimeout", 20);
+                authorize->setTimeout(authorizationTimeoutInt && authorizationTimeoutInt->getInt() > 0 ? authorizationTimeoutInt->getInt() * 1000UL : 20UL * 1000UL);
+
                 context->initiateRequest(std::move(authorize));
                 res = true;
             } else {

--- a/src/MicroOcpp/Core/Request.cpp
+++ b/src/MicroOcpp/Core/Request.cpp
@@ -34,6 +34,10 @@ void Request::setOperation(std::unique_ptr<Operation> msg){
     operation = std::move(msg);
 }
 
+std::unique_ptr<Operation>& Request::getOperation(){
+    return operation;
+}
+
 void Request::setTimeout(unsigned long timeout) {
     this->timeout_period = timeout;
 }

--- a/src/MicroOcpp/Core/Request.cpp
+++ b/src/MicroOcpp/Core/Request.cpp
@@ -34,8 +34,8 @@ void Request::setOperation(std::unique_ptr<Operation> msg){
     operation = std::move(msg);
 }
 
-std::unique_ptr<Operation>& Request::getOperation(){
-    return operation;
+Operation *Request::getOperation(){
+    return operation.get();
 }
 
 void Request::setTimeout(unsigned long timeout) {

--- a/src/MicroOcpp/Core/Request.h
+++ b/src/MicroOcpp/Core/Request.h
@@ -49,7 +49,7 @@ public:
     ~Request();
 
     void setOperation(std::unique_ptr<Operation> msg);
-    std::unique_ptr<Operation>& getOperation();
+    Operation *getOperation();
 
     void setTimeout(unsigned long timeout); //0 = disable timeout
     bool isTimeoutExceeded();

--- a/src/MicroOcpp/Core/Request.h
+++ b/src/MicroOcpp/Core/Request.h
@@ -49,6 +49,7 @@ public:
     ~Request();
 
     void setOperation(std::unique_ptr<Operation> msg);
+    std::unique_ptr<Operation>& getOperation();
 
     void setTimeout(unsigned long timeout); //0 = disable timeout
     bool isTimeoutExceeded();

--- a/src/MicroOcpp/Core/RequestQueue.cpp
+++ b/src/MicroOcpp/Core/RequestQueue.cpp
@@ -134,13 +134,13 @@ void RequestQueue::sendRequest(std::unique_ptr<Request> op){
     // Don't queue up multiple StatusNotification messages for the same connectorId
     if (strcmp(op->getOperationType(), "StatusNotification") == 0)
     {
-        auto new_status_notification = static_cast<Ocpp16::StatusNotification*>(op->getOperation().get());
+        auto new_status_notification = static_cast<Ocpp16::StatusNotification*>(op->getOperation());
         initiatedRequests->drop_if([&new_status_notification] (const std::unique_ptr<Request>& operation) {
             if (strcmp(operation->getOperationType(), "StatusNotification")!= 0)
             {
                 return false;
             }
-            auto old_status_notification = static_cast<Ocpp16::StatusNotification*>(operation->getOperation().get());
+            auto old_status_notification = static_cast<Ocpp16::StatusNotification*>(operation->getOperation());
             return old_status_notification->getConnectorId() == new_status_notification->getConnectorId();
         });
     }

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -686,8 +686,6 @@ std::shared_ptr<Transaction> Connector::beginTransaction(const char *idTag) {
             }
         }
     }
-    #else
-    (void)parentIdTag;
     #endif //MO_ENABLE_RESERVATION
 
     transaction = allocateTransaction();
@@ -702,6 +700,10 @@ std::shared_ptr<Transaction> Connector::beginTransaction(const char *idTag) {
         transaction->setIdTag("");
     } else {
         transaction->setIdTag(idTag);
+    }
+
+    if (parentIdTag) {
+        transaction->setParentIdTag(parentIdTag);
     }
 
     transaction->setBeginTimestamp(model.getClock().now());
@@ -765,6 +767,10 @@ std::shared_ptr<Transaction> Connector::beginTransaction(const char *idTag) {
             }
         }
         #endif //MO_ENABLE_RESERVATION
+
+        if (idTagInfo.containsKey("parentIdTag")) {
+            tx->setParentIdTag(idTagInfo["parentIdTag"] | "");
+        }
 
         MO_DBG_DEBUG("Authorized transaction process (%s)", tx->getIdTag());
         tx->setAuthorized();
@@ -851,6 +857,10 @@ std::shared_ptr<Transaction> Connector::beginTransaction_authorized(const char *
         transaction->setIdTag("");
     } else {
         transaction->setIdTag(idTag);
+    }
+
+    if (parentIdTag) {
+        transaction->setParentIdTag(parentIdTag);
     }
 
     transaction->setBeginTimestamp(model.getClock().now());

--- a/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
@@ -2,7 +2,6 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#include "DataTransfer.h"
 #include <string>
 
 #include <MicroOcpp/Model/ConnectorBase/ConnectorsCommon.h>
@@ -11,6 +10,7 @@
 #include <MicroOcpp/Operations/ChangeAvailability.h>
 #include <MicroOcpp/Operations/ChangeConfiguration.h>
 #include <MicroOcpp/Operations/ClearCache.h>
+#include <MicroOcpp/Operations/DataTransfer.h>
 #include <MicroOcpp/Operations/GetConfiguration.h>
 #include <MicroOcpp/Operations/RemoteStartTransaction.h>
 #include <MicroOcpp/Operations/RemoteStopTransaction.h>

--- a/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
@@ -2,6 +2,7 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include "DataTransfer.h"
 #include <string>
 
 #include <MicroOcpp/Model/ConnectorBase/ConnectorsCommon.h>
@@ -45,6 +46,8 @@ ConnectorsCommon::ConnectorsCommon(Context& context, unsigned int numConn, std::
         return new Ocpp16::ChangeConfiguration();});
     context.getOperationRegistry().registerOperation("ClearCache", [filesystem] () {
         return new Ocpp16::ClearCache(filesystem);});
+    context.getOperationRegistry().registerOperation("DataTransfer", [] () {
+        return new Ocpp16::DataTransfer();});
     context.getOperationRegistry().registerOperation("GetConfiguration", [] () {
         return new Ocpp16::GetConfiguration();});
     context.getOperationRegistry().registerOperation("RemoteStartTransaction", [&context] () {

--- a/src/MicroOcpp/Model/Metering/MeteringService.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringService.cpp
@@ -55,10 +55,23 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
         }
         return isValid;
     };
+
+    std::function<bool(const char*)> validateUnsignedIntString = [] (const char *value) {
+        for(size_t i = 0; value[i] != '\0'; i++)
+        {
+            if (value[i] < '0' || value[i] > '9') {
+                return false;
+            }
+        }
+        return true;
+    };
+
     registerConfigurationValidator("MeterValuesSampledData", validateSelectString);
     registerConfigurationValidator("StopTxnSampledData", validateSelectString);
     registerConfigurationValidator("MeterValuesAlignedData", validateSelectString);
     registerConfigurationValidator("StopTxnAlignedData", validateSelectString);
+    registerConfigurationValidator("MeterValueSampleInterval", validateUnsignedIntString);
+    registerConfigurationValidator("ClockAlignedDataInterval", validateUnsignedIntString);
 
     /*
      * Register further message handlers to support echo mode: when this library

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -53,10 +53,6 @@ void ResetService::loop() {
         MO_DBG_ERR("Reset device failure. %s", outstandingResetRetries == 0 ? "Abort" : "Retry");
 
         if (outstandingResetRetries <= 0) {
-            for (unsigned int cId = 0; cId < context.getModel().getNumConnectors(); cId++) {
-                auto connector = context.getModel().getConnector(cId);
-                connector->setAvailabilityVolatile(true);
-            }
 
             ChargePointStatus cpStatus = ChargePointStatus_UNDEFINED;
             if (context.getModel().getNumConnectors() > 0) {

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -96,11 +96,6 @@ void ResetService::initiateReset(bool isHard) {
         outstandingResetRetries = 5;
     }
     t_resetRetry = mocpp_tick_ms();
-
-    for (unsigned int cId = 0; cId < context.getModel().getNumConnectors(); cId++) {
-        auto connector = context.getModel().getConnector(cId);
-        connector->setAvailabilityVolatile(false);
-    }
 }
 
 #if MO_PLATFORM == MO_PLATFORM_ARDUINO && (defined(ESP32) || defined(ESP8266))

--- a/src/MicroOcpp/Model/Transactions/Transaction.cpp
+++ b/src/MicroOcpp/Model/Transactions/Transaction.cpp
@@ -12,6 +12,11 @@ bool Transaction::setIdTag(const char *idTag) {
     return ret >= 0 && ret < IDTAG_LEN_MAX + 1;
 }
 
+bool Transaction::setParentIdTag(const char *idTag) {
+    auto ret = snprintf(this->parentIdTag, IDTAG_LEN_MAX + 1, "%s", idTag);
+    return ret >= 0 && ret < IDTAG_LEN_MAX + 1;
+}
+
 bool Transaction::setStopIdTag(const char *idTag) {
     auto ret = snprintf(stop_idTag, IDTAG_LEN_MAX + 1, "%s", idTag);
     return ret >= 0 && ret < IDTAG_LEN_MAX + 1;

--- a/src/MicroOcpp/Model/Transactions/Transaction.h
+++ b/src/MicroOcpp/Model/Transactions/Transaction.h
@@ -57,6 +57,7 @@ private:
     Timestamp start_timestamp = MIN_TIME;      //timestamp of StartTx; can be set before actually initiating
     uint16_t start_bootNr = 0;
     int transactionId = -1; //only valid if confirmed = true
+    char parentIdTag [IDTAG_LEN_MAX + 1] = {'\0'};
 
     /*
      * Attributes of StopTransaction
@@ -136,6 +137,9 @@ public:
     uint16_t getStartBootNr() {return start_bootNr;}
 
     void setTransactionId(int transactionId) {this->transactionId = transactionId;}
+
+    bool setParentIdTag(const char *idTag);
+    const char *getParentIdTag() {return parentIdTag;}
 
     SendStatus& getStopSync() {return stop_sync;}
 

--- a/src/MicroOcpp/Model/Transactions/Transaction.h
+++ b/src/MicroOcpp/Model/Transactions/Transaction.h
@@ -43,6 +43,7 @@ private:
      * Attributes existing before StartTransaction
      */
     char idTag [IDTAG_LEN_MAX + 1] = {'\0'};
+    char parentIdTag [IDTAG_LEN_MAX + 1] = {'\0'};
     bool authorized = false;    //if the given idTag was authorized
     bool deauthorized = false;  //if the server revoked a local authorization
     Timestamp begin_timestamp = MIN_TIME;
@@ -57,7 +58,6 @@ private:
     Timestamp start_timestamp = MIN_TIME;      //timestamp of StartTx; can be set before actually initiating
     uint16_t start_bootNr = 0;
     int transactionId = -1; //only valid if confirmed = true
-    char parentIdTag [IDTAG_LEN_MAX + 1] = {'\0'};
 
     /*
      * Attributes of StopTransaction
@@ -112,6 +112,9 @@ public:
     bool setIdTag(const char *idTag);
     const char *getIdTag() {return idTag;}
 
+    bool setParentIdTag(const char *idTag);
+    const char *getParentIdTag() {return parentIdTag;}
+
     void setAuthorized() {authorized = true;}
     void setIdTagDeauthorized() {deauthorized = true;}
 
@@ -137,9 +140,6 @@ public:
     uint16_t getStartBootNr() {return start_bootNr;}
 
     void setTransactionId(int transactionId) {this->transactionId = transactionId;}
-
-    bool setParentIdTag(const char *idTag);
-    const char *getParentIdTag() {return parentIdTag;}
 
     SendStatus& getStopSync() {return stop_sync;}
 

--- a/src/MicroOcpp/Model/Transactions/TransactionDeserialize.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionDeserialize.cpp
@@ -40,6 +40,9 @@ bool serializeTransaction(Transaction& tx, DynamicJsonDocument& out) {
     if (tx.getIdTag()[0] != '\0') {
         sessionState["idTag"] = tx.getIdTag();
     }
+    if (tx.getParentIdTag()[0] != '\0') {
+        sessionState["parentIdTag"] = tx.getParentIdTag();
+    }
     if (tx.isAuthorized()) {
         sessionState["authorized"] = true;
     }
@@ -124,6 +127,13 @@ bool deserializeTransaction(Transaction& tx, JsonObject state) {
 
     if (sessionState.containsKey("idTag")) {
         if (!tx.setIdTag(sessionState["idTag"] | "")) {
+            MO_DBG_ERR("read err");
+            return false;
+        }
+    }
+
+    if (sessionState.containsKey("parentIdTag")) {
+        if (!tx.setParentIdTag(sessionState["parentIdTag"] | "")) {
             MO_DBG_ERR("read err");
             return false;
         }

--- a/src/MicroOcpp/Operations/DataTransfer.cpp
+++ b/src/MicroOcpp/Operations/DataTransfer.cpp
@@ -32,3 +32,14 @@ void DataTransfer::processConf(JsonObject payload){
         MO_DBG_INFO("Request has been denied");
     }
 }
+
+void DataTransfer::processReq(JsonObject payload) {
+    // Do nothing - we're just required to reject these DataTransfer requests
+}
+
+std::unique_ptr<DynamicJsonDocument> DataTransfer::createConf(){
+    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
+    JsonObject payload = doc->to<JsonObject>();
+    payload["status"] = "Rejected";
+    return doc;
+}

--- a/src/MicroOcpp/Operations/DataTransfer.h
+++ b/src/MicroOcpp/Operations/DataTransfer.h
@@ -14,6 +14,7 @@ class DataTransfer : public Operation {
 private:
     std::string msg {};
 public:
+    DataTransfer() {};
     DataTransfer(const std::string &msg);
 
     const char* getOperationType() override;
@@ -21,6 +22,10 @@ public:
     std::unique_ptr<DynamicJsonDocument> createReq() override;
 
     void processConf(JsonObject payload) override;
+
+    void processReq(JsonObject payload) override;
+
+    std::unique_ptr<DynamicJsonDocument> createConf() override;
     
 };
 

--- a/src/MicroOcpp/Operations/GetLocalListVersion.cpp
+++ b/src/MicroOcpp/Operations/GetLocalListVersion.cpp
@@ -28,7 +28,6 @@ void GetLocalListVersion::processReq(JsonObject payload) {
 std::unique_ptr<DynamicJsonDocument> GetLocalListVersion::createConf(){
     auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
     JsonObject payload = doc->to<JsonObject>();
-    auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
 
     if (auto authService = model.getAuthorizationService()) {
         payload["listVersion"] = authService->getLocalListVersion();

--- a/src/MicroOcpp/Operations/GetLocalListVersion.cpp
+++ b/src/MicroOcpp/Operations/GetLocalListVersion.cpp
@@ -2,6 +2,7 @@
 // Copyright Matthias Akstaller 2019 - 2023
 // MIT License
 
+#include "Configuration.h"
 #include <MicroOcpp/Operations/GetLocalListVersion.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Authorization/AuthorizationService.h>
@@ -24,7 +25,11 @@ void GetLocalListVersion::processReq(JsonObject payload) {
 std::unique_ptr<DynamicJsonDocument> GetLocalListVersion::createConf(){
     auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
     JsonObject payload = doc->to<JsonObject>();
-    if (auto authService = model.getAuthorizationService()) {
+    auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
+
+    if (strstr(supported_feature_profiles->getString(), "LocalAuthListManagement") == NULL) {
+        payload["listVersion"] = -1;
+    } else if (auto authService = model.getAuthorizationService()) {
         payload["listVersion"] = authService->getLocalListVersion();
     } else {
         payload["listVersion"] = -1;

--- a/src/MicroOcpp/Operations/GetLocalListVersion.cpp
+++ b/src/MicroOcpp/Operations/GetLocalListVersion.cpp
@@ -2,7 +2,6 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#include "Configuration.h"
 #include <MicroOcpp/Version.h>
 
 #if MO_ENABLE_LOCAL_AUTH
@@ -31,9 +30,7 @@ std::unique_ptr<DynamicJsonDocument> GetLocalListVersion::createConf(){
     JsonObject payload = doc->to<JsonObject>();
     auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
 
-    if (strstr(supported_feature_profiles->getString(), "LocalAuthListManagement") == NULL) {
-        payload["listVersion"] = -1;
-    } else if (auto authService = model.getAuthorizationService()) {
+    if (auto authService = model.getAuthorizationService()) {
         payload["listVersion"] = authService->getLocalListVersion();
     } else {
         payload["listVersion"] = -1;

--- a/src/MicroOcpp/Operations/SendLocalList.cpp
+++ b/src/MicroOcpp/Operations/SendLocalList.cpp
@@ -58,7 +58,6 @@ void SendLocalList::processReq(JsonObject payload) {
 std::unique_ptr<DynamicJsonDocument> SendLocalList::createConf(){
     auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
     JsonObject payload = doc->to<JsonObject>();
-    auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
 
     if (versionMismatch) {
         payload["status"] = "VersionMismatch";

--- a/src/MicroOcpp/Operations/SendLocalList.cpp
+++ b/src/MicroOcpp/Operations/SendLocalList.cpp
@@ -2,7 +2,6 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
-#include "Configuration.h"
 #include <MicroOcpp/Version.h>
 
 #if MO_ENABLE_LOCAL_AUTH
@@ -26,10 +25,6 @@ const char* SendLocalList::getOperationType(){
 }
 
 void SendLocalList::processReq(JsonObject payload) {
-    auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
-    if (strstr(supported_feature_profiles->getString(), "LocalAuthListManagement") == NULL) {
-        return;
-    }
 
     if (!payload.containsKey("listVersion") || !payload.containsKey("updateType")) {
         errorCode = "FormationViolation";
@@ -65,9 +60,7 @@ std::unique_ptr<DynamicJsonDocument> SendLocalList::createConf(){
     JsonObject payload = doc->to<JsonObject>();
     auto supported_feature_profiles = declareConfiguration<const char*>("SupportedFeatureProfiles", "");
 
-    if (strstr(supported_feature_profiles->getString(), "LocalAuthListManagement") == NULL) {
-        payload["status"] = "NotSupported";
-    } else if (versionMismatch) {
+    if (versionMismatch) {
         payload["status"] = "VersionMismatch";
     } else if (updateFailure) {
         payload["status"] = "Failed";

--- a/src/MicroOcpp/Operations/StartTransaction.cpp
+++ b/src/MicroOcpp/Operations/StartTransaction.cpp
@@ -148,6 +148,11 @@ void StartTransaction::processConf(JsonObject payload) {
     int transactionId = payload["transactionId"] | -1;
     transaction->setTransactionId(transactionId);
 
+    if (payload["idTagInfo"].containsKey("parentIdTag"))
+    {
+        transaction->setParentIdTag(payload["idTagInfo"]["parentIdTag"]);
+    }
+
     transaction->getStartSync().confirm();
     transaction->commit();
 

--- a/src/MicroOcpp/Operations/StatusNotification.h
+++ b/src/MicroOcpp/Operations/StatusNotification.h
@@ -35,6 +35,10 @@ public:
     void processReq(JsonObject payload) override;
 
     std::unique_ptr<DynamicJsonDocument> createConf() override;
+
+    int getConnectorId() {
+        return connectorId;
+    }
 };
 
 } // namespace Ocpp16

--- a/src/MicroOcpp/Operations/UnlockConnector.cpp
+++ b/src/MicroOcpp/Operations/UnlockConnector.cpp
@@ -20,10 +20,10 @@ void UnlockConnector::processReq(JsonObject payload) {
     
     auto connectorId = payload["connectorId"] | -1;
 
-    auto connector = model.getConnector(connectorId);
+    connector = model.getConnector(connectorId);
 
     if (!connector) {
-        errorCode = "PropertyConstraintViolation";
+        // NotSupported
         return;
     }
 
@@ -43,6 +43,15 @@ void UnlockConnector::processReq(JsonObject payload) {
 }
 
 std::unique_ptr<DynamicJsonDocument> UnlockConnector::createConf() {
+    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
+    JsonObject payload = doc->to<JsonObject>();
+
+    if (connector == nullptr) {
+        // NotSupported
+        payload["status"] = "NotSupported";
+        return doc;
+    }
+
     if (unlockConnector && mocpp_tick_ms() - timerStart < MO_UNLOCK_TIMEOUT) {
         //do poll and if more time is needed, delay creation of conf msg
 
@@ -54,8 +63,6 @@ std::unique_ptr<DynamicJsonDocument> UnlockConnector::createConf() {
         }
     }
 
-    auto doc = std::unique_ptr<DynamicJsonDocument>(new DynamicJsonDocument(JSON_OBJECT_SIZE(1)));
-    JsonObject payload = doc->to<JsonObject>();
     if (!unlockConnector) {
         payload["status"] = "NotSupported";
     } else if (cbUnlockResult == UnlockConnectorResult_Unlocked) {

--- a/src/MicroOcpp/Operations/UnlockConnector.h
+++ b/src/MicroOcpp/Operations/UnlockConnector.h
@@ -6,6 +6,7 @@
 #define UNLOCKCONNECTOR_H
 
 #include <MicroOcpp/Core/Operation.h>
+#include <MicroOcpp/Model/ConnectorBase/Connector.h>
 #include <MicroOcpp/Model/ConnectorBase/UnlockConnectorResult.h>
 #include <functional>
 
@@ -19,6 +20,7 @@ class UnlockConnector : public Operation {
 private:
     Model& model;
     std::function<UnlockConnectorResult ()> unlockConnector;
+    Connector *connector = nullptr;
     UnlockConnectorResult cbUnlockResult;
     unsigned long timerStart = 0; //for timeout
 

--- a/src/MicroOcpp/Operations/UnlockConnector.h
+++ b/src/MicroOcpp/Operations/UnlockConnector.h
@@ -6,7 +6,6 @@
 #define UNLOCKCONNECTOR_H
 
 #include <MicroOcpp/Core/Operation.h>
-#include <MicroOcpp/Model/ConnectorBase/Connector.h>
 #include <MicroOcpp/Model/ConnectorBase/UnlockConnectorResult.h>
 #include <functional>
 


### PR DESCRIPTION
This PR contains fixes for passing the OCTT test cases. A big shout out to @heakins who contributed back the patches to MicroOCPP!

For more information on the fixed issues, see the detailed commit messages.

The fixes addressing the rejection of SendLocalList, GetLocalListVersion and UnlockConnector have already been superseded on main. To disable Local Authorization Lists, set the build flag `MO_ENABLE_LOCAL_AUTH=0`. The connector lock support is already disabled by default.