### PR TITLE
Make ISO 8601 Timestamp milliseconds support optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Connector lock disabled by default per `MO_ENABLE_CONNECTOR_LOCK` ([#312](https://github.com/matth-x/MicroOcpp/pull/312))
 - Relaxed temporal order of non-tx-related operations ([#345](https://github.com/matth-x/MicroOcpp/pull/345))
 - Use pseudo-GUIDs as messageId ([#345](https://github.com/matth-x/MicroOcpp/pull/345))
+- ISO 8601 milliseconds omitted by default ([352](https://github.com/matth-x/MicroOcpp/pull/352))
 
 ### Added
 

--- a/src/MicroOcpp/Core/Time.h
+++ b/src/MicroOcpp/Core/Time.h
@@ -11,7 +11,15 @@
 
 #include <MicroOcpp/Platform.h>
 
+#ifndef MO_ENABLE_TIMESTAMP_MILLISECONDS
+#define MO_ENABLE_TIMESTAMP_MILLISECONDS 0
+#endif
+
+#if MO_ENABLE_TIMESTAMP_MILLISECONDS
 #define JSONDATE_LENGTH 24   //max. ISO 8601 date length, excluding the terminating zero
+#else
+#define JSONDATE_LENGTH 20   //ISO 8601 date length, excluding the terminating zero
+#endif //MO_ENABLE_TIMESTAMP_MILLISECONDS
 
 namespace MicroOcpp {
 
@@ -27,7 +35,9 @@ private:
     int32_t hour = 0;
     int32_t minute = 0;
     int32_t second = 0;
+#if MO_ENABLE_TIMESTAMP_MILLISECONDS
     int32_t ms = 0;
+#endif //MO_ENABLE_TIMESTAMP_MILLISECONDS
 
 public:
 
@@ -35,8 +45,11 @@ public:
 
     Timestamp(const Timestamp& other);
 
-    Timestamp(int16_t year, int16_t month, int16_t day, int32_t hour, int32_t minute, int32_t second, int32_t ms = 0) :
-                year(year), month(month), day(day), hour(hour), minute(minute), second(second), ms(ms) { };
+#if MO_ENABLE_TIMESTAMP_MILLISECONDS
+    Timestamp(int16_t year, int16_t month, int16_t day, int32_t hour, int32_t minute, int32_t second, int32_t ms = 0);
+#else 
+    Timestamp(int16_t year, int16_t month, int16_t day, int32_t hour, int32_t minute, int32_t second);
+#endif //MO_ENABLE_TIMESTAMP_MILLISECONDS
 
     /**
      * Expects a date string like
@@ -57,7 +70,9 @@ public:
 
     Timestamp &operator=(const Timestamp &rhs);
 
+#if MO_ENABLE_TIMESTAMP_MILLISECONDS
     Timestamp &addMilliseconds(int ms);
+#endif //MO_ENABLE_TIMESTAMP_MILLISECONDS
 
     /*
      * Time periods are given in seconds for all of the following arithmetic operations


### PR DESCRIPTION
Adds a build switch `MO_ENABLE_TIMESTAMP_MILLISECONDS` to enable / disable the millisecond support of the Timestamp class.

To enable, set `MO_ENABLE_TIMESTAMP_MILLISECONDS=1` (disabled by default). To keep the old behavior, disable the switch explicitly in the build settings.

If disabled, the milliseconds fraction of incoming ISO 8601 timestamps will be ignored. Outgoing ISO 8601 strings will omit the milliseconds.

This change saves a few bytes per Timestamp, with the class size being slightly reduced from 24B to 20B. While this ~17% saving is not too significant, it nevertheless fits the design philosophy of microcontroller optimization.