### PR TITLE
Fix MeterValues PreBoot year 1970 timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Reject DataTransfer by default ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - UnlockConnector NotSupported if connectorId invalid ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - Fix regression bug of [#345](https://github.com/matth-x/MicroOcpp/pull/345) ([#353](https://github.com/matth-x/MicroOcpp/pull/353))
+- Correct MeterValue PreBoot timestamp
 
 ## [1.1.0] - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Reject DataTransfer by default ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - UnlockConnector NotSupported if connectorId invalid ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - Fix regression bug of [#345](https://github.com/matth-x/MicroOcpp/pull/345) ([#353](https://github.com/matth-x/MicroOcpp/pull/353))
-- Correct MeterValue PreBoot timestamp
+- Correct MeterValue PreBoot timestamp ([#354](https://github.com/matth-x/MicroOcpp/pull/354))
 
 ## [1.1.0] - 2024-05-21
 

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
     }
 
     if ((txBreak || meterData.size() >= (size_t) meterValueCacheSizeInt->getInt()) && !meterData.empty()) {
-        auto meterValues = std::unique_ptr<MeterValues>(new MeterValues(std::move(meterData), connectorId, transaction));
+        auto meterValues = std::unique_ptr<MeterValues>(new MeterValues(model, std::move(meterData), connectorId, transaction));
         meterData = makeVector<std::unique_ptr<MeterValue>>(getMemoryTag());
         return std::move(meterValues); //std::move is required for some compilers even if it's not mandated by standard C++
     }
@@ -168,7 +168,7 @@ std::unique_ptr<Operation> MeteringConnector::takeTriggeredMeterValues() {
         transaction = model.getConnector(connectorId)->getTransaction();
     }
 
-    return std::unique_ptr<MeterValues>(new MeterValues(std::move(mv_now), connectorId, transaction));
+    return std::unique_ptr<MeterValues>(new MeterValues(model, std::move(mv_now), connectorId, transaction));
 }
 
 void MeteringConnector::addMeterValueSampler(std::unique_ptr<SampledValueSampler> meterValueSampler) {

--- a/src/MicroOcpp/Model/Metering/MeteringService.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringService.cpp
@@ -78,8 +78,8 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
      * is connected with a WebSocket echo server, let it reply to its own requests.
      * Mocking an OCPP Server on the same device makes running (unit) tests easier.
      */
-    context.getOperationRegistry().registerOperation("MeterValues", [] () {
-        return new Ocpp16::MeterValues();});
+    context.getOperationRegistry().registerOperation("MeterValues", [this] () {
+        return new Ocpp16::MeterValues(this->context.getModel());});
 }
 
 void MeteringService::loop(){

--- a/src/MicroOcpp/Operations/MeterValues.cpp
+++ b/src/MicroOcpp/Operations/MeterValues.cpp
@@ -14,12 +14,12 @@ using MicroOcpp::JsonDoc;
 #define ENERGY_METER_TIMEOUT_MS 30 * 1000  //after waiting for 30s, send MeterValues without missing readings
 
 //can only be used for echo server debugging
-MeterValues::MeterValues() : MemoryManaged("v16.Operation.", "MeterValues") {
+MeterValues::MeterValues(Model& model) : MemoryManaged("v16.Operation.", "MeterValues"), model(model) {
     
 }
 
-MeterValues::MeterValues(Vector<std::unique_ptr<MeterValue>>&& meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction) 
-      : MemoryManaged("v16.Operation.", "MeterValues"), meterValue{std::move(meterValue)}, connectorId{connectorId}, transaction{transaction} {
+MeterValues::MeterValues(Model& model, Vector<std::unique_ptr<MeterValue>>&& meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction) 
+      : MemoryManaged("v16.Operation.", "MeterValues"), model(model), meterValue{std::move(meterValue)}, connectorId{connectorId}, transaction{transaction} {
     
 }
 
@@ -36,8 +36,15 @@ std::unique_ptr<JsonDoc> MeterValues::createReq() {
     size_t capacity = 0;
     
     auto entries = makeVector<std::unique_ptr<JsonDoc>>(getMemoryTag());
-    for (auto value = meterValue.begin(); value != meterValue.end(); value++) {
-        auto entry = (*value)->toJson();
+    for (auto mv = meterValue.begin(); mv != meterValue.end(); mv++) {
+
+        if ((*mv)->getTimestamp() < MIN_TIME) {
+            MO_DBG_DEBUG("adjust preboot MeterValue timestamp");
+            Timestamp adjusted = model.getClock().adjustPrebootTimestamp((*mv)->getTimestamp());
+            (*mv)->setTimestamp(adjusted);
+        }
+
+        auto entry = (*mv)->toJson();
         if (entry) {
             capacity += entry->capacity();
             entries.push_back(std::move(entry));

--- a/src/MicroOcpp/Operations/MeterValues.h
+++ b/src/MicroOcpp/Operations/MeterValues.h
@@ -11,6 +11,7 @@
 
 namespace MicroOcpp {
 
+class Model;
 class MeterValue;
 class Transaction;
 
@@ -18,6 +19,7 @@ namespace Ocpp16 {
 
 class MeterValues : public Operation, public MemoryManaged {
 private:
+    Model& model; //for adjusting the timestamp if MeterValue has been created before BootNotification
     Vector<std::unique_ptr<MeterValue>> meterValue;
 
     unsigned int connectorId = 0;
@@ -25,9 +27,9 @@ private:
     std::shared_ptr<Transaction> transaction;
 
 public:
-    MeterValues(Vector<std::unique_ptr<MeterValue>>&& meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
+    MeterValues(Model& model, Vector<std::unique_ptr<MeterValue>>&& meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
 
-    MeterValues(); //for debugging only. Make this for the server pendant
+    MeterValues(Model& model); //for debugging only. Make this for the server pendant
 
     ~MeterValues();
 


### PR DESCRIPTION
When a charger is running a transaction while it doesn't have the OCPP timestamp from the BootNotification response yet (possible in PreBoot mode), then any initiated MeterValues request had a 1970-01-01... timestamp. That timestamp is adjusted now after receiving the BootNotification so that the time is displayed correctly in the backend system.