### PR TITLE
Migrate persistent storage from previous MO versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Input validation for unsigned int Configs ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - Support for TransactionMessageAttempts/-RetryInterval ([#345](https://github.com/matth-x/MicroOcpp/pull/345))
 - Heap profiler and custom allocator support ([#350](https://github.com/matth-x/MicroOcpp/pull/350))
+- Migration of persistent storage ([#355](https://github.com/matth-x/MicroOcpp/pull/355))
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ target_compile_definitions(mo_unit_tests PUBLIC
     MO_PLATFORM=MO_PLATFORM_UNIX
     MO_NUMCONNECTORS=3
     MO_CUSTOM_TIMER
-    MO_DBG_LEVEL=MO_DL_DEBUG
+    MO_DBG_LEVEL=MO_DL_INFO
     MO_TRAFFIC_OUT
     MO_FILENAME_PREFIX="./mo_store/"
     MO_LocalAuthListMaxLength=8

--- a/src/MicroOcpp/Core/Configuration.cpp
+++ b/src/MicroOcpp/Core/Configuration.cpp
@@ -239,4 +239,11 @@ bool configuration_save() {
     return success;
 }
 
+bool configuration_clean_unused() {
+    for (auto& container : configurationContainers) {
+        container->removeUnused();
+    }
+    configuration_save();
+}
+
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/Configuration.cpp
+++ b/src/MicroOcpp/Core/Configuration.cpp
@@ -243,7 +243,7 @@ bool configuration_clean_unused() {
     for (auto& container : configurationContainers) {
         container->removeUnused();
     }
-    configuration_save();
+    return configuration_save();
 }
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -36,5 +36,7 @@ bool configuration_load(const char *filename = nullptr);
 
 bool configuration_save();
 
+bool configuration_clean_unused(); //remove configs which haven't been accessed
+
 } //end namespace MicroOcpp
 #endif

--- a/src/MicroOcpp/Core/ConfigurationContainer.h
+++ b/src/MicroOcpp/Core/ConfigurationContainer.h
@@ -35,6 +35,8 @@ public:
     virtual std::shared_ptr<Configuration> getConfiguration(const char *key) = 0;
 
     virtual void loadStaticKey(Configuration& config, const char *key) { } //possible optimization: can replace internal key with passed static key
+
+    virtual void removeUnused() { } //remove configs which haven't been accessed (optional and only if known)
 };
 
 class ConfigurationContainerVolatile : public ConfigurationContainer, public MemoryManaged {

--- a/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
+++ b/src/MicroOcpp/Core/ConfigurationContainerFlash.cpp
@@ -334,6 +334,25 @@ public:
         config.setKey(key);
         clearKeyPool(key);
     }
+
+    void removeUnused() override {
+        //if a config's key is still in the keyPool, we know it's unused because it has never been declared in FW (originates from an older FW version)
+
+        auto key = keyPool.begin();
+        while (key != keyPool.end()) {
+
+            for (auto config = configurations.begin(); config != configurations.end(); ++config) {
+                if ((*config)->getKey() == *key) {
+                    MO_DBG_DEBUG("remove unused config %s", (*config)->getKey());
+                    configurations.erase(config);
+                    break;
+                }
+            }
+
+            MO_FREE(*key);
+            key = keyPool.erase(key);
+        }
+    }
 };
 
 std::unique_ptr<ConfigurationContainer> makeConfigurationContainerFlash(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename, bool accessible) {

--- a/src/MicroOcpp/Model/Boot/BootService.cpp
+++ b/src/MicroOcpp/Model/Boot/BootService.cpp
@@ -230,7 +230,6 @@ bool BootService::recover(std::shared_ptr<FilesystemAdapter> filesystem, BootSta
     bool success = FilesystemUtils::remove_if(filesystem, [] (const char *fname) -> bool {
         return !strncmp(fname, "sd", strlen("sd")) ||
                 !strncmp(fname, "tx", strlen("tx")) ||
-                !strncmp(fname, "op", strlen("op")) ||
                 !strncmp(fname, "sc-", strlen("sc-")) ||
                 !strncmp(fname, "reservation", strlen("reservation")) ||
                 !strncmp(fname, "client-state", strlen("client-state"));
@@ -254,7 +253,7 @@ bool BootService::migrate(std::shared_ptr<FilesystemAdapter> filesystem, BootSta
                     !strncmp(fname, "tx", strlen("tx")) ||
                     !strncmp(fname, "op", strlen("op")) ||
                     !strncmp(fname, "sc-", strlen("sc-")) ||
-                    !strncmp(fname, "client-state", strlen("client-state")) ||
+                    !strcmp(fname, "client-state.cnf") ||
                     !strcmp(fname, "arduino-ocpp.cnf") ||
                     !strcmp(fname, "ocpp-creds.jsn");
         });

--- a/src/MicroOcpp/Model/Boot/BootService.h
+++ b/src/MicroOcpp/Model/Boot/BootService.h
@@ -13,7 +13,13 @@
 
 #define MO_BOOT_INTERVAL_DEFAULT 60
 
+#ifndef MO_BOOTSTATS_LONGTIME_MS
+#define MO_BOOTSTATS_LONGTIME_MS 180 * 1000
+#endif
+
 namespace MicroOcpp {
+
+#define MO_BOOTSTATS_VERSION_SIZE 10
 
 struct BootStats {
     uint16_t bootNr = 0;
@@ -22,6 +28,8 @@ struct BootStats {
     uint16_t getBootFailureCount() {
         return bootNr - lastBootSuccess;
     }
+
+    char microOcppVersion [MO_BOOTSTATS_VERSION_SIZE] = {'\0'};
 };
 
 enum class RegistrationStatus {
@@ -79,8 +87,12 @@ public:
     void notifyRegistrationStatus(RegistrationStatus status);
     void setRetryInterval(unsigned long interval);
 
-    static bool loadBootStats(std::shared_ptr<FilesystemAdapter> filesystem, BootStats& out);
-    static bool storeBootStats(std::shared_ptr<FilesystemAdapter> filesystem, BootStats bstats);
+    static bool loadBootStats(std::shared_ptr<FilesystemAdapter> filesystem, BootStats& bstats);
+    static bool storeBootStats(std::shared_ptr<FilesystemAdapter> filesystem, BootStats& bstats);
+
+    static bool recover(std::shared_ptr<FilesystemAdapter> filesystem, BootStats& bstats); //delete all persistent files which could lead to a crash
+
+    static bool migrate(std::shared_ptr<FilesystemAdapter> filesystem, BootStats& bstats); //migrate persistent storage if running on a new MO version
 };
 
 }


### PR DESCRIPTION
Automatically migrate the persistent storage of MO on the controller if it originates from a previous MO version.

The persistent storage is extended and optimized in some new releases of MO, making the storage layout backwards-incompatible. To allow existing deployments to be continuously updated, it's necessary to handle the storage changes. The built-in migration is guaranteed to work from v1.2.0 onward. There could be some storage artifacts from before v1.2.0 which are not fully handled.

Examples includes:
- The transaction store has been refactored in #345. The migration function clears existing tx store files (if a FW update happened, then it is very likely that the charger was online and all transactions have been fully uploaded, so no data loss)
- In v0.3, the name of the main configurations file was "arduino-ocpp.cnf" which was later renamed into "ocpp-config.jsn". That file is removed without transferring its contents which is an example of the migration being limited to fully work only from this version on. However, if migrating from v1.0 or v1.1, then there are no known limitations.