### PR TITLE
Fix MeterValues tx-related message order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Don't change into Unavailable upon Reset ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - Reject DataTransfer by default ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
 - UnlockConnector NotSupported if connectorId invalid ([#344](https://github.com/matth-x/MicroOcpp/pull/344))
-- Fix regression bug of [#345](https://github.com/matth-x/MicroOcpp/pull/345) ([#353](https://github.com/matth-x/MicroOcpp/pull/353))
+- Fix regression bug of [#345](https://github.com/matth-x/MicroOcpp/pull/345) ([#353](https://github.com/matth-x/MicroOcpp/pull/353), [#356](https://github.com/matth-x/MicroOcpp/pull/356))
 - Correct MeterValue PreBoot timestamp ([#354](https://github.com/matth-x/MicroOcpp/pull/354))
 
 ## [1.1.0] - 2024-05-21

--- a/src/MicroOcpp/Core/Request.cpp
+++ b/src/MicroOcpp/Core/Request.cpp
@@ -29,7 +29,7 @@ namespace MicroOcpp {
 
 using namespace MicroOcpp;
 
-Request::Request(std::unique_ptr<Operation> msg, const char *memory_tag) : MemoryManaged(memory_tag), messageID(makeString(getMemoryTag())), operation(std::move(msg)) {
+Request::Request(std::unique_ptr<Operation> msg) : MemoryManaged("Request.", msg->getOperationType()), messageID(makeString(getMemoryTag())), operation(std::move(msg)) {
     timeout_start = mocpp_tick_ms();
     debugRequest_start = mocpp_tick_ms();
 }
@@ -289,19 +289,15 @@ bool Request::isRequestSent() {
 
 namespace MicroOcpp {
 
-std::unique_ptr<Request> makeRequest(std::unique_ptr<Operation> operation, const char *memoryTag){
+std::unique_ptr<Request> makeRequest(std::unique_ptr<Operation> operation){
     if (operation == nullptr) {
         return nullptr;
     }
-    return std::unique_ptr<Request>(new Request(std::move(operation), memoryTag));
+    return std::unique_ptr<Request>(new Request(std::move(operation)));
 }
 
 std::unique_ptr<Request> makeRequest(Operation *operation) {
     return makeRequest(std::unique_ptr<Operation>(operation));
-}
-
-std::unique_ptr<Request> makeRequest(const char *memoryTag, Operation *operation) {
-    return makeRequest(std::unique_ptr<Operation>(operation), memoryTag);
 }
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/Request.h
+++ b/src/MicroOcpp/Core/Request.h
@@ -41,7 +41,7 @@ private:
     bool requestSent = false;
 public:
 
-    Request(std::unique_ptr<Operation> msg, const char *memory_tag = "Request");
+    Request(std::unique_ptr<Operation> msg);
 
     ~Request();
 
@@ -121,9 +121,8 @@ public:
 /*
  * Simple factory functions
  */
-std::unique_ptr<Request> makeRequest(std::unique_ptr<Operation> op, const char *memoryTag = "Request");
+std::unique_ptr<Request> makeRequest(std::unique_ptr<Operation> op);
 std::unique_ptr<Request> makeRequest(Operation *op); //takes ownership of op
-std::unique_ptr<Request> makeRequest(const char *memoryTag, Operation *op); //takes ownership of op
 
 } //end namespace MicroOcpp
 

--- a/src/MicroOcpp/Core/RequestQueue.h
+++ b/src/MicroOcpp/Core/RequestQueue.h
@@ -18,7 +18,7 @@
 #endif
 
 #ifndef MO_NUM_REQUEST_QUEUES
-#define MO_NUM_REQUEST_QUEUES 5
+#define MO_NUM_REQUEST_QUEUES 10
 #endif
 
 namespace MicroOcpp {

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -1166,7 +1166,7 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
             }
 
             Timestamp nextAttempt = transactionFront->getStartSync().getAttemptTime() +
-                                    transactionFront->getStartSync().getAttemptNr() * transactionMessageRetryIntervalInt->getInt();
+                                    transactionFront->getStartSync().getAttemptNr() * std::max(0, transactionMessageRetryIntervalInt->getInt());
 
             if (nextAttempt > model.getClock().now()) {
                 return nullptr;
@@ -1223,7 +1223,7 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
             }
 
             Timestamp nextAttempt = transactionFront->getStopSync().getAttemptTime() +
-                                    transactionFront->getStopSync().getAttemptNr() * transactionMessageRetryIntervalInt->getInt();
+                                    transactionFront->getStopSync().getAttemptNr() * std::max(0, transactionMessageRetryIntervalInt->getInt());
 
             if (nextAttempt > model.getClock().now()) {
                 return nullptr;

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -95,7 +95,7 @@ private:
 
     unsigned int txNrBegin = 0; //oldest (historical) transaction on flash. Has no function, but is useful for error diagnosis
     unsigned int txNrFront = 0; //oldest transaction which is still queued to be sent to the server
-    unsigned int txNrBack = 0; //one position behind newest transaction
+    unsigned int txNrEnd = 0; //one position behind newest transaction
 
     std::shared_ptr<Transaction> transactionFront;
 public:
@@ -157,6 +157,10 @@ public:
 
     unsigned int getFrontRequestOpNr() override;
     std::unique_ptr<Request> fetchFrontRequest() override;
+
+    unsigned int getTxNrBeginHistory(); //if getTxNrBeginHistory() != getTxNrFront(), then return value is the txNr of the oldest tx history entry. If equal to getTxNrFront(), then the history is empty
+    unsigned int getTxNrFront(); //if getTxNrEnd() != getTxNrFront(), then return value is the txNr of the oldest transaction queued to be sent to the server. If equal to getTxNrEnd(), then there is no tx to be sent to the server
+    unsigned int getTxNrEnd(); //upper limit for the range of valid txNrs
 };
 
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.cpp
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.cpp
@@ -19,8 +19,9 @@
 #include <MicroOcpp/Version.h> //for MO_ENABLE_V201
 #include <MicroOcpp/Model/ConnectorBase/UnlockConnectorResult.h> //for MO_ENABLE_CONNECTOR_LOCK
 
-using namespace MicroOcpp;
-using Ocpp16::DiagnosticsStatus;
+using MicroOcpp::DiagnosticsService;
+using MicroOcpp::Ocpp16::DiagnosticsStatus;
+using MicroOcpp::Request;
 
 DiagnosticsService::DiagnosticsService(Context& context) : MemoryManaged("v16.Diagnostics.DiagnosticsService"), context(context), location(makeString(getMemoryTag())), diagFileList(makeVector<String>(getMemoryTag())) {
 

--- a/src/MicroOcpp/Model/Metering/MeterValue.cpp
+++ b/src/MicroOcpp/Model/Metering/MeterValue.cpp
@@ -2,6 +2,8 @@
 // Copyright Matthias Akstaller 2019 - 2024
 // MIT License
 
+#include <limits>
+
 #include <MicroOcpp/Model/Metering/MeterValue.h>
 #include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Debug.h>
@@ -67,12 +69,40 @@ ReadingContext MeterValue::getReadingContext() {
     return ReadingContext::NOT_SET;
 }
 
+void MeterValue::setTxNr(unsigned int txNr) {
+    if (txNr > (unsigned int)std::numeric_limits<int>::max()) {
+        MO_DBG_ERR("invalid arg");
+        return;
+    }
+    this->txNr = (int)txNr;
+}
+
+int MeterValue::getTxNr() {
+    return txNr;
+}
+
 void MeterValue::setOpNr(unsigned int opNr) {
     this->opNr = opNr;
 }
 
 unsigned int MeterValue::getOpNr() {
     return opNr;
+}
+
+void MeterValue::advanceAttemptNr() {
+    attemptNr++;
+}
+
+unsigned int MeterValue::getAttemptNr() {
+    return attemptNr;
+}
+
+unsigned long MeterValue::getAttemptTime() {
+    return attemptTime;
+}
+
+void MeterValue::setAttemptTime(unsigned long timestamp) {
+    this->attemptTime = timestamp;
 }
 
 MeterValueBuilder::MeterValueBuilder(const Vector<std::unique_ptr<SampledValueSampler>> &samplers,

--- a/src/MicroOcpp/Model/Metering/MeterValue.cpp
+++ b/src/MicroOcpp/Model/Metering/MeterValue.cpp
@@ -67,6 +67,14 @@ ReadingContext MeterValue::getReadingContext() {
     return ReadingContext::NOT_SET;
 }
 
+void MeterValue::setOpNr(unsigned int opNr) {
+    this->opNr = opNr;
+}
+
+unsigned int MeterValue::getOpNr() {
+    return opNr;
+}
+
 MeterValueBuilder::MeterValueBuilder(const Vector<std::unique_ptr<SampledValueSampler>> &samplers,
             std::shared_ptr<Configuration> samplersSelectStr) :
             MemoryManaged("v16.Metering.MeterValueBuilder"),

--- a/src/MicroOcpp/Model/Metering/MeterValue.h
+++ b/src/MicroOcpp/Model/Metering/MeterValue.h
@@ -19,7 +19,10 @@ private:
     Timestamp timestamp;
     Vector<std::unique_ptr<SampledValue>> sampledValue;
 
+    int txNr = -1;
     unsigned int opNr = 1;
+    unsigned int attemptNr = 0;
+    unsigned long attemptTime = 0;
 public:
     MeterValue(const Timestamp& timestamp);
     MeterValue(const MeterValue& other) = delete;
@@ -33,8 +36,17 @@ public:
 
     ReadingContext getReadingContext();
 
+    void setTxNr(unsigned int txNr);
+    int getTxNr();
+
     void setOpNr(unsigned int opNr);
     unsigned int getOpNr();
+
+    void advanceAttemptNr();
+    unsigned int getAttemptNr();
+
+    unsigned long getAttemptTime();
+    void setAttemptTime(unsigned long timestamp);
 };
 
 class MeterValueBuilder : public MemoryManaged {

--- a/src/MicroOcpp/Model/Metering/MeterValue.h
+++ b/src/MicroOcpp/Model/Metering/MeterValue.h
@@ -18,6 +18,8 @@ class MeterValue : public MemoryManaged {
 private:
     Timestamp timestamp;
     Vector<std::unique_ptr<SampledValue>> sampledValue;
+
+    unsigned int opNr = 1;
 public:
     MeterValue(const Timestamp& timestamp);
     MeterValue(const MeterValue& other) = delete;
@@ -30,6 +32,9 @@ public:
     void setTimestamp(Timestamp timestamp);
 
     ReadingContext getReadingContext();
+
+    void setOpNr(unsigned int opNr);
+    unsigned int getOpNr();
 };
 
 class MeterValueBuilder : public MemoryManaged {

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
@@ -6,7 +6,9 @@
 #include <MicroOcpp/Model/Metering/MeterStore.h>
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Model/Model.h>
+#include <MicroOcpp/Core/Context.h>
 #include <MicroOcpp/Core/Configuration.h>
+#include <MicroOcpp/Core/Request.h>
 #include <MicroOcpp/Operations/MeterValues.h>
 #include <MicroOcpp/Platform.h>
 #include <MicroOcpp/Debug.h>
@@ -17,12 +19,13 @@
 using namespace MicroOcpp;
 using namespace MicroOcpp::Ocpp16;
 
-MeteringConnector::MeteringConnector(Model& model, int connectorId, MeterStore& meterStore)
-        : MemoryManaged("v16.Metering.MeteringConnector"), model(model), connectorId{connectorId}, meterStore(meterStore), meterData(makeVector<std::unique_ptr<MeterValue>>(getMemoryTag())), samplers(makeVector<std::unique_ptr<SampledValueSampler>>(getMemoryTag())) {
+MeteringConnector::MeteringConnector(Context& context, int connectorId, MeterStore& meterStore)
+        : MemoryManaged("v16.Metering.MeteringConnector"), context(context), model(context.getModel()), connectorId{connectorId}, meterStore(meterStore), meterData(makeVector<std::unique_ptr<MeterValues>>(getMemoryTag())), samplers(makeVector<std::unique_ptr<SampledValueSampler>>(getMemoryTag())) {
+
+    context.getRequestQueue().addSendQueue(this);
 
     auto meterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData", "");
     declareConfiguration<int>("MeterValuesSampledDataMaxLength", 8, CONFIGURATION_VOLATILE, true);
-    meterValueCacheSizeInt = declareConfiguration<int>(MO_CONFIG_EXT_PREFIX "MeterValueCacheSize", 1);
     meterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval", 60);
 
     auto stopTxnSampledDataString = declareConfiguration<const char*>("StopTxnSampledData", "");
@@ -43,7 +46,7 @@ MeteringConnector::MeteringConnector(Model& model, int connectorId, MeterStore& 
     stopTxnAlignedDataBuilder = std::unique_ptr<MeterValueBuilder>(new MeterValueBuilder(samplers, stopTxnAlignedDataString));
 }
 
-std::unique_ptr<Operation> MeteringConnector::loop() {
+void MeteringConnector::loop() {
 
     bool txBreak = false;
     if (model.getConnector(connectorId)) {
@@ -54,12 +57,6 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
 
     if (txBreak) {
         lastSampleTime = mocpp_tick_ms();
-    }
-
-    if ((txBreak || meterData.size() >= (size_t) meterValueCacheSizeInt->getInt()) && !meterData.empty()) {
-        auto meterValues = std::unique_ptr<MeterValues>(new MeterValues(model, std::move(meterData), connectorId, transaction));
-        meterData = makeVector<std::unique_ptr<MeterValue>>(getMemoryTag());
-        return std::move(meterValues); //std::move is required for some compilers even if it's not mandated by standard C++
     }
 
     if (model.getConnector(connectorId)) {
@@ -80,8 +77,7 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
 
             if (connectorId != 0 && meterValuesInTxOnlyBool->getBool()) {
                 //don't take any MeterValues outside of transactions on connectorIds other than 0
-                meterData.clear();
-                return nullptr;
+                return;
             }
         }
     }
@@ -97,9 +93,14 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
                 abs(dt) <= 60 ?
                 "in time (tolerance <= 60s)" : "off, e.g. because of first run. Ignore");
             if (abs(dt) <= 60) { //is measurement still "clock-aligned"?
-                auto alignedMeterValues = alignedDataBuilder->takeSample(model.getClock().now(), ReadingContext::SampleClock);
-                if (alignedMeterValues) {
-                    meterData.push_back(std::move(alignedMeterValues));
+
+                if (auto alignedMeterValue = alignedDataBuilder->takeSample(model.getClock().now(), ReadingContext::SampleClock)) {
+                    if (meterData.size() >= MO_METERVALUES_CACHE_MAXSIZE) {
+                        MO_DBG_INFO("MeterValue cache full. Drop oldest MV");
+                        meterData.erase(meterData.begin());
+                    }
+                    alignedMeterValue->setOpNr(context.getRequestQueue().getNextOpNr());
+                    meterData.push_back(std::unique_ptr<MeterValues>(new MeterValues(model, std::move(alignedMeterValue), connectorId, transaction)));
                 }
 
                 if (stopTxnData) {
@@ -130,9 +131,13 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
         //record periodic tx data
 
         if (mocpp_tick_ms() - lastSampleTime >= (unsigned long) (meterValueSampleIntervalInt->getInt() * 1000)) {
-            auto sampleMeterValues = sampledDataBuilder->takeSample(model.getClock().now(), ReadingContext::SamplePeriodic);
-            if (sampleMeterValues) {
-                meterData.push_back(std::move(sampleMeterValues));
+            if (auto sampledMeterValue = sampledDataBuilder->takeSample(model.getClock().now(), ReadingContext::SamplePeriodic)) {
+                if (meterData.size() >= MO_METERVALUES_CACHE_MAXSIZE) {
+                    MO_DBG_INFO("MeterValue cache full. Drop oldest MV");
+                    meterData.erase(meterData.begin());
+                }
+                sampledMeterValue->setOpNr(context.getRequestQueue().getNextOpNr());
+                meterData.push_back(std::unique_ptr<MeterValues>(new MeterValues(model, std::move(sampledMeterValue), connectorId, transaction)));
             }
 
             if (stopTxnData && stopTxnDataCapturePeriodicBool->getBool()) {
@@ -144,12 +149,6 @@ std::unique_ptr<Operation> MeteringConnector::loop() {
             lastSampleTime = mocpp_tick_ms();
         }
     }
-
-    if (clockAlignedDataIntervalInt->getInt() < 1 && meterValueSampleIntervalInt->getInt() < 1) {
-        meterData.clear();
-    }
-
-    return nullptr; //successful method completition. Currently there is no reason to send a MeterValues Msg.
 }
 
 std::unique_ptr<Operation> MeteringConnector::takeTriggeredMeterValues() {
@@ -160,15 +159,12 @@ std::unique_ptr<Operation> MeteringConnector::takeTriggeredMeterValues() {
         return nullptr;
     }
 
-    decltype(meterData) mv_now;
-    mv_now.push_back(std::move(sample));
-
     std::shared_ptr<Transaction> transaction = nullptr;
     if (model.getConnector(connectorId)) {
         transaction = model.getConnector(connectorId)->getTransaction();
     }
 
-    return std::unique_ptr<MeterValues>(new MeterValues(model, std::move(mv_now), connectorId, transaction));
+    return std::unique_ptr<MeterValues>(new MeterValues(model, std::move(sample), connectorId, transaction));
 }
 
 void MeteringConnector::addMeterValueSampler(std::unique_ptr<SampledValueSampler> meterValueSampler) {
@@ -239,4 +235,30 @@ bool MeteringConnector::existsSampler(const char *measurand, size_t len) {
     }
 
     return false;
+}
+
+unsigned int MeteringConnector::getFrontRequestOpNr() {
+    if (!meterData.empty()) {
+        return meterData.front()->getOpNr();
+    }
+    return NoOperation;
+}
+
+std::unique_ptr<Request> MeteringConnector::fetchFrontRequest() {
+
+    auto mv_front = meterData.begin();
+    if (mv_front == meterData.end()) {
+        return nullptr;
+    }
+
+    std::unique_ptr<MeterValues> meterValue = std::move(*mv_front);
+    meterData.erase(mv_front);
+
+    //discard MV if it belongs to silent tx
+    if (meterValue->getTransaction() && meterValue->getTransaction()->isSilent()) {
+        MO_DBG_DEBUG("Drop MeterValue belonging to silent tx");
+        return nullptr;
+    }
+
+    return makeRequest(std::move(meterValue));
 }

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.h
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.h
@@ -14,7 +14,6 @@
 #include <MicroOcpp/Core/ConfigurationKeyValue.h>
 #include <MicroOcpp/Core/RequestQueue.h>
 #include <MicroOcpp/Core/Memory.h>
-#include <MicroOcpp/Operations/MeterValues.h>
 
 #ifndef MO_METERVALUES_CACHE_MAXSIZE
 #define MO_METERVALUES_CACHE_MAXSIZE MO_REQUEST_CACHE_MAXSIZE
@@ -25,7 +24,6 @@ namespace MicroOcpp {
 class Context;
 class Model;
 class Operation;
-class Transaction;
 class MeterStore;
 
 class MeteringConnector : public MemoryManaged, public RequestEmitter {
@@ -35,7 +33,8 @@ private:
     const int connectorId;
     MeterStore& meterStore;
     
-    Vector<std::unique_ptr<Ocpp16::MeterValues>> meterData;
+    Vector<std::unique_ptr<MeterValue>> meterData;
+    std::unique_ptr<MeterValue> meterDataFront;
     std::shared_ptr<TransactionMeterData> stopTxnData;
 
     std::unique_ptr<MeterValueBuilder> sampledDataBuilder;
@@ -62,6 +61,9 @@ private:
 
     std::shared_ptr<Configuration> meterValuesInTxOnlyBool;
     std::shared_ptr<Configuration> stopTxnDataCapturePeriodicBool;
+
+    std::shared_ptr<Configuration> transactionMessageAttemptsInt;
+    std::shared_ptr<Configuration> transactionMessageRetryIntervalInt;
 public:
     MeteringConnector(Context& context, int connectorId, MeterStore& meterStore);
 

--- a/src/MicroOcpp/Model/Metering/MeteringService.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringService.cpp
@@ -22,8 +22,9 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
     declareConfiguration<const char*>("MeterValuesAlignedData", "Energy.Active.Import.Register,Power.Active.Import");
     declareConfiguration<const char*>("StopTxnAlignedData", "");
     
+    connectors.reserve(numConn);
     for (int i = 0; i < numConn; i++) {
-        connectors.emplace_back(new MeteringConnector(context.getModel(), i, meterStore));
+        connectors.emplace_back(new MeteringConnector(context, i, meterStore));
     }
 
     std::function<bool(const char*)> validateSelectString = [this] (const char *csl) {
@@ -83,14 +84,8 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
 }
 
 void MeteringService::loop(){
-
     for (unsigned int i = 0; i < connectors.size(); i++){
-        auto meterValuesMsg = connectors[i]->loop();
-        if (meterValuesMsg != nullptr) {
-            auto meterValues = makeRequest(std::move(meterValuesMsg));
-            meterValues->setTimeout(120000);
-            context.initiateRequest(std::move(meterValues));
-        }
+        connectors[i]->loop();
     }
 }
 

--- a/src/MicroOcpp/Operations/MeterValues.cpp
+++ b/src/MicroOcpp/Operations/MeterValues.cpp
@@ -10,16 +10,20 @@
 
 using MicroOcpp::Ocpp16::MeterValues;
 using MicroOcpp::JsonDoc;
-using MicroOcpp::Transaction;
 
 //can only be used for echo server debugging
 MeterValues::MeterValues(Model& model) : MemoryManaged("v16.Operation.", "MeterValues"), model(model) {
     
 }
 
-MeterValues::MeterValues(Model& model, std::unique_ptr<MeterValue> meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction) 
-      : MemoryManaged("v16.Operation.", "MeterValues"), model(model), meterValue{std::move(meterValue)}, connectorId{connectorId}, transaction{transaction} {
+MeterValues::MeterValues(Model& model, MeterValue *meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction) 
+      : MemoryManaged("v16.Operation.", "MeterValues"), model(model), meterValue{meterValue}, connectorId{connectorId}, transaction{transaction} {
     
+}
+
+MeterValues::MeterValues(Model& model, std::unique_ptr<MeterValue> meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction)
+      : MeterValues(model, meterValue.get(), connectorId, transaction) {
+    this->meterValueOwnership = std::move(meterValue);
 }
 
 MeterValues::~MeterValues(){
@@ -73,17 +77,6 @@ std::unique_ptr<JsonDoc> MeterValues::createReq() {
 
 void MeterValues::processConf(JsonObject payload) {
     MO_DBG_DEBUG("Request has been confirmed");
-}
-
-std::shared_ptr<Transaction>& MeterValues::getTransaction() {
-    return transaction;
-}
-
-unsigned int MeterValues::getOpNr() {
-    if (!meterValue) {
-        return 1;
-    }
-    return meterValue->getOpNr();
 }
 
 

--- a/src/MicroOcpp/Operations/MeterValues.h
+++ b/src/MicroOcpp/Operations/MeterValues.h
@@ -20,14 +20,14 @@ namespace Ocpp16 {
 class MeterValues : public Operation, public MemoryManaged {
 private:
     Model& model; //for adjusting the timestamp if MeterValue has been created before BootNotification
-    Vector<std::unique_ptr<MeterValue>> meterValue;
+    std::unique_ptr<MeterValue> meterValue;
 
     unsigned int connectorId = 0;
 
     std::shared_ptr<Transaction> transaction;
 
 public:
-    MeterValues(Model& model, Vector<std::unique_ptr<MeterValue>>&& meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
+    MeterValues(Model& model, std::unique_ptr<MeterValue> meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
 
     MeterValues(Model& model); //for debugging only. Make this for the server pendant
 
@@ -38,6 +38,9 @@ public:
     std::unique_ptr<JsonDoc> createReq() override;
 
     void processConf(JsonObject payload) override;
+
+    std::shared_ptr<Transaction>& getTransaction();
+    unsigned int getOpNr();
 
     void processReq(JsonObject payload) override;
 

--- a/src/MicroOcpp/Operations/MeterValues.h
+++ b/src/MicroOcpp/Operations/MeterValues.h
@@ -20,13 +20,15 @@ namespace Ocpp16 {
 class MeterValues : public Operation, public MemoryManaged {
 private:
     Model& model; //for adjusting the timestamp if MeterValue has been created before BootNotification
-    std::unique_ptr<MeterValue> meterValue;
+    MeterValue *meterValue = nullptr;
+    std::unique_ptr<MeterValue> meterValueOwnership;
 
     unsigned int connectorId = 0;
 
     std::shared_ptr<Transaction> transaction;
 
 public:
+    MeterValues(Model& model, MeterValue *meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
     MeterValues(Model& model, std::unique_ptr<MeterValue> meterValue, unsigned int connectorId, std::shared_ptr<Transaction> transaction = nullptr);
 
     MeterValues(Model& model); //for debugging only. Make this for the server pendant
@@ -38,9 +40,6 @@ public:
     std::unique_ptr<JsonDoc> createReq() override;
 
     void processConf(JsonObject payload) override;
-
-    std::shared_ptr<Transaction>& getTransaction();
-    unsigned int getOpNr();
 
     void processReq(JsonObject payload) override;
 

--- a/src/MicroOcpp/Operations/TriggerMessage.cpp
+++ b/src/MicroOcpp/Operations/TriggerMessage.cpp
@@ -36,12 +36,16 @@ void TriggerMessage::processReq(JsonObject payload) {
             if (connectorId < 0) {
                 auto nConnectors = mService->getNumConnectors();
                 for (decltype(nConnectors) cId = 0; cId < nConnectors; cId++) {
-                    context.getRequestQueue().sendRequestPreBoot(mService->takeTriggeredMeterValues(cId));
-                    statusMessage = "Accepted";
+                    if (auto meterValues = mService->takeTriggeredMeterValues(cId)) {
+                        context.getRequestQueue().sendRequestPreBoot(std::move(meterValues));
+                        statusMessage = "Accepted";
+                    }
                 }
             } else if (connectorId < mService->getNumConnectors()) {
-                context.getRequestQueue().sendRequestPreBoot(mService->takeTriggeredMeterValues(connectorId));
-                statusMessage = "Accepted";
+                if (auto meterValues = mService->takeTriggeredMeterValues(connectorId)) {
+                    context.getRequestQueue().sendRequestPreBoot(std::move(meterValues));
+                    statusMessage = "Accepted";
+                }
             } else {
                 errorCode = "PropertyConstraintViolation";
             }


### PR DESCRIPTION
After the changes of #345, the message order of tx-related MeterValues didn't work anymore. This PR is the corresponding fix.