### PR TITLE
Remove int to bool conversion in ChangeConfiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix regression bug of [#345](https://github.com/matth-x/MicroOcpp/pull/345) ([#353](https://github.com/matth-x/MicroOcpp/pull/353), [#356](https://github.com/matth-x/MicroOcpp/pull/356))
 - Correct MeterValue PreBoot timestamp ([#354](https://github.com/matth-x/MicroOcpp/pull/354))
 - Send errorCode in triggered StatusNotif ([#359](https://github.com/matth-x/MicroOcpp/pull/359))
+- Remove int to bool conversion in ChangeConfig ([#362](https://github.com/matth-x/MicroOcpp/pull/362))
 
 ## [1.1.0] - 2024-05-21
 

--- a/src/MicroOcpp/Operations/ChangeConfiguration.cpp
+++ b/src/MicroOcpp/Operations/ChangeConfiguration.cpp
@@ -101,8 +101,6 @@ void ChangeConfiguration::processReq(JsonObject payload) {
         numBool = true;
     } else if (tolower(value[0]) == 'f' && tolower(value[1]) == 'a' && tolower(value[2]) == 'l' && tolower(value[3]) == 's' && tolower(value[4]) == 'e' && !value[5]) {
         numBool = false;
-    } else if (convertibleInt) {
-        numBool = numInt != 0;
     } else {
         convertibleBool = false;
     }


### PR DESCRIPTION
When ChangeConfiguation tried to update a boolean config with an integer value, then the integer was converted to bool following the C convention (i.e. `0` is `false` and all other numbers mean `true`). That behavior is misleading and removed in this PR.