### PR TITLE
Support for AuthorizeRemoteTxRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Heap profiler and custom allocator support ([#350](https://github.com/matth-x/MicroOcpp/pull/350))
 - Migration of persistent storage ([#355](https://github.com/matth-x/MicroOcpp/pull/355))
 - Benchmarks pipeline ([#369](https://github.com/matth-x/MicroOcpp/pull/369))
+- Support for AuthorizeRemoteTxRequests
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Heap profiler and custom allocator support ([#350](https://github.com/matth-x/MicroOcpp/pull/350))
 - Migration of persistent storage ([#355](https://github.com/matth-x/MicroOcpp/pull/355))
 - Benchmarks pipeline ([#369](https://github.com/matth-x/MicroOcpp/pull/369))
-- Support for AuthorizeRemoteTxRequests
+- Support for AuthorizeRemoteTxRequests ([#373](https://github.com/matth-x/MicroOcpp/pull/373))
 
 ### Removed
 

--- a/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/ConnectorsCommon.cpp
@@ -35,7 +35,7 @@ ConnectorsCommon::ConnectorsCommon(Context& context, unsigned int numConn, std::
     /*
      * Further configuration keys which correspond to the Core profile
      */
-    declareConfiguration<bool>("AuthorizeRemoteTxRequests", false, CONFIGURATION_VOLATILE, true);
+    declareConfiguration<bool>("AuthorizeRemoteTxRequests", false);
     declareConfiguration<int>("GetConfigurationMaxKeys", 30, CONFIGURATION_VOLATILE, true);
     
     context.getOperationRegistry().registerOperation("ChangeAvailability", [&context] () {

--- a/src/MicroOcpp/Operations/RemoteStartTransaction.cpp
+++ b/src/MicroOcpp/Operations/RemoteStartTransaction.cpp
@@ -4,6 +4,7 @@
 
 
 #include <MicroOcpp/Operations/RemoteStartTransaction.h>
+#include <MicroOcpp/Core/Configuration.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/ConnectorBase/Connector.h>
 #include <MicroOcpp/Model/SmartCharging/SmartChargingService.h>
@@ -98,7 +99,13 @@ void RemoteStartTransaction::processReq(JsonObject payload) {
         }
 
         if (success) {
-            auto tx = selectConnector->beginTransaction_authorized(idTag);
+            std::shared_ptr<MicroOcpp::Transaction> tx;
+            auto authorizeRemoteTxRequests = declareConfiguration<bool>("AuthorizeRemoteTxRequests", false);
+            if (authorizeRemoteTxRequests && authorizeRemoteTxRequests->getBool()) {
+                tx = selectConnector->beginTransaction(idTag);
+            } else {
+                tx = selectConnector->beginTransaction_authorized(idTag);
+            }
             selectConnector->updateTxNotification(TxNotification::RemoteStart);
             if (tx) {
                 if (chargingProfileId >= 0) {


### PR DESCRIPTION
This PR implements the behavior for AuthorizeRemoteTxRequests. Before, the configuration was declared as read-only with value false and couldn't be changed to true.