### PR TITLE
Generate heap benchmarks automatically

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -188,7 +188,7 @@ jobs:
     needs: [evaluate_firmware, measure_heap]
     name: Deploy docs
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: matth-x/MicroOcppSimulator
+        path: MicroOcppSimulator
         ref: feature/remote-api
         submodules: 'recursive'
     - name: Update MicroOcpp submodule to this commit

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,9 +36,13 @@ jobs:
         path: MicroOcppSimulator
         ref: feature/remote-api
         submodules: 'recursive'
-    - name: Update MicroOcpp submodule to this commit
+    - name: Clean MicroOcpp submodule
       run: |
-        git -C MicroOcppSimulator/lib/MicroOcpp checkout ${{ github.sha }}
+        rm -rf MicroOcppSimulator/lib/MicroOcpp
+    - name: Checkout MicroOcpp submodule
+      uses: actions/checkout@v3
+      with:
+        path: MicroOcppSimulator/lib/MicroOcpp
     - name: Generate CMake files
       run: cmake -S . -B ./build -DCMAKE_CXX_FLAGS="-DMO_OVERRIDE_ALLOCATION=1 -DMO_ENABLE_HEAP_PROFILER=1"
     - name: Compile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,11 +20,6 @@ jobs:
     - name: Check env vars
       run: |
         echo "show MO_SIM_CONFIG"
-        echo "${{ MO_SIM_CONFIG }}"
-        echo "end"
-    - name: Check env vars
-      run: |
-        echo "show MO_SIM_CONFIG"
         echo "$MO_SIM_CONFIG"
         echo "end"
       env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -82,7 +82,7 @@ jobs:
         echo "show MicroOcppSimulator/public"
         ls MicroOcppSimulator/public
         echo "show MO_SIM_CONFIG"
-        echo $(MO_SIM_CONFIG)
+        echo "$MO_SIM_CONFIG"
     - name: Measure heap and create reports
       run: python tests/benchmarks/scripts/measure_heap.py
     - name: Upload reports

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -168,9 +168,7 @@ jobs:
         if-no-files-found: error
 
   deploy:
-    needs: |
-      evaluate_firmware
-      measure_heap
+    needs: [evaluate_firmware, measure_heap]
     name: Deploy docs
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,7 +59,7 @@ jobs:
 
   measure_heap:
     needs: build_simulator
-    name: Execute heap measurements
+    name: Heap measurements
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
     - name: Upload reports
       uses: actions/upload-artifact@v4
       with:
-        name: Memory occupation reports CSV
+        name: Memory usage reports CSV
         path: docs/assets/tables
         if-no-files-found: error
 
@@ -188,7 +188,7 @@ jobs:
     needs: [evaluate_firmware, measure_heap]
     name: Deploy docs
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -208,7 +208,7 @@ jobs:
     - name: Get memory occupation reports
       uses: actions/download-artifact@v4
       with:
-        name: Memory occupation reports CSV
+        name: Memory usage reports CSV
         path: docs/assets/tables
     - name: Run mkdocs
       run: mkdocs gh-deploy --force

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Install Python dependencies
-      run: pip install pandas paramiko
+      run: pip install requests paramiko pandas
     - name: Get Simulator
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,13 +17,6 @@ jobs:
     name: Build Simulator
     runs-on: ubuntu-latest
     steps:
-    - name: Check env vars
-      run: |
-        echo "show MO_SIM_CONFIG"
-        echo "$MO_SIM_CONFIG"
-        echo "end"
-      env:
-        MO_SIM_CONFIG: ${{ secrets.MO_SIM_CONFIG }}
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -80,20 +73,19 @@ jobs:
       with:
         name: Simulator executable
         path: MicroOcppSimulator
-    - name: Check Simulator and env vars
-      run: |
-        echo "show MicroOcppSimulator"
-        ls MicroOcppSimulator
-        echo "show MicroOcppSimulator/build"
-        ls MicroOcppSimulator/build
-        echo "show MicroOcppSimulator/public"
-        ls MicroOcppSimulator/public
-        echo "show MO_SIM_CONFIG"
-        echo "$MO_SIM_CONFIG"
     - name: Measure heap and create reports
       run: python tests/benchmarks/scripts/measure_heap.py
       env:
+        TEST_DRIVER_URL: ${{ secrets.TEST_DRIVER_URL }}
+        TEST_DRIVER_CONFIG: ${{ secrets.TEST_DRIVER_CONFIG }}
+        TEST_DRIVER_KEY: ${{ secrets.TEST_DRIVER_KEY }}
         MO_SIM_CONFIG: ${{ secrets.MO_SIM_CONFIG }}
+        MO_SIM_OCPP_SERVER: ${{ secrets.MO_SIM_OCPP_SERVER }}
+        MO_SIM_API_CERT: ${{ secrets.MO_SIM_API_CERT }}
+        MO_SIM_API_KEY: ${{ secrets.MO_SIM_API_KEY }}
+        MO_SIM_API_CONFIG: ${{ secrets.MO_SIM_API_CONFIG }}
+        SSH_LOCAL_PRIV: ${{ secrets.SSH_LOCAL_PRIV }}
+        SSH_HOST_PUB: ${{ secrets.SSH_HOST_PUB }}
     - name: Upload reports
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -74,7 +74,9 @@ jobs:
         name: Simulator executable
         path: MicroOcppSimulator
     - name: Measure heap and create reports
-      run: python tests/benchmarks/scripts/measure_heap.py
+      run: |
+        mkdir -p docs/assets/tables
+        python tests/benchmarks/scripts/measure_heap.py
       env:
         TEST_DRIVER_URL: ${{ secrets.TEST_DRIVER_URL }}
         TEST_DRIVER_CONFIG: ${{ secrets.TEST_DRIVER_CONFIG }}
@@ -170,8 +172,7 @@ jobs:
         path: firmware
     - name: Run bloaty
       run: |
-        mkdir docs/assets
-        mkdir docs/assets/tables
+        mkdir -p docs/assets/tables
         tools/bloaty/build/bloaty firmware/firmware_v16.elf  -d compileunits --csv -n 0 > docs/assets/tables/bloaty_v16.csv
         tools/bloaty/build/bloaty firmware/firmware_v201.elf -d compileunits --csv -n 0 > docs/assets/tables/bloaty_v201.csv
     - name: Evaluate and create reports

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,9 +44,9 @@ jobs:
       with:
         path: MicroOcppSimulator/lib/MicroOcpp
     - name: Generate CMake files
-      run: cmake -S . -B ./build -DCMAKE_CXX_FLAGS="-DMO_OVERRIDE_ALLOCATION=1 -DMO_ENABLE_HEAP_PROFILER=1"
+      run: cmake -S ./MicroOcppSimulator -B ./MicroOcppSimulator/build -DCMAKE_CXX_FLAGS="-DMO_OVERRIDE_ALLOCATION=1 -DMO_ENABLE_HEAP_PROFILER=1"
     - name: Compile
-      run: cmake --build ./build -j 32 --target mo_simulator
+      run: cmake --build ./MicroOcppSimulator/build -j 32 --target mo_simulator
     - name: Upload Simulator executable
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,8 +20,15 @@ jobs:
     - name: Check env vars
       run: |
         echo "show MO_SIM_CONFIG"
+        echo "${{ MO_SIM_CONFIG }}"
+        echo "end"
+    - name: Check env vars
+      run: |
+        echo "show MO_SIM_CONFIG"
         echo "$MO_SIM_CONFIG"
         echo "end"
+      env:
+        MO_SIM_CONFIG: ${{ secrets.MO_SIM_CONFIG }}
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -90,6 +97,8 @@ jobs:
         echo "$MO_SIM_CONFIG"
     - name: Measure heap and create reports
       run: python tests/benchmarks/scripts/measure_heap.py
+      env:
+        MO_SIM_CONFIG: ${{ secrets.MO_SIM_CONFIG }}
     - name: Upload reports
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@
 # Copyright Matthias Akstaller 2019 - 2024
 # MIT License
 
-name: documentation 
+name: Documentation
 on:
   push:
     branches:
@@ -11,8 +11,74 @@ on:
 
 permissions:
   contents: write
+
 jobs:
+  build_simulator:
+    name: Build Simulator
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - uses: actions/cache@v2
+      with:
+        key: ${{ github.ref }}
+        path: .cache
+    - name: Get build tools
+      run: |
+        sudo apt update
+        sudo apt install cmake libssl-dev build-essential
+    - name: Checkout Simulator
+      uses: actions/checkout@v3
+      with:
+        repository: matth-x/MicroOcppSimulator
+        ref: feature/remote-api
+        submodules: 'recursive'
+    - name: Update MicroOcpp submodule to this commit
+      run: |
+        git -C MicroOcppSimulator/lib/MicroOcpp checkout ${{ github.sha }}
+    - name: Generate CMake files
+      run: cmake -S . -B ./build -DCMAKE_CXX_FLAGS="-DMO_OVERRIDE_ALLOCATION=1 -DMO_ENABLE_HEAP_PROFILER=1"
+    - name: Compile
+      run: cmake --build ./build -j 32 --target mo_simulator
+    - name: Upload Simulator executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: Simulator executable
+        path: |
+          MicroOcppSimulator/build/mo_simulator
+          MicroOcppSimulator/public/bundle.html.gz
+        if-no-files-found: error
+        retention-days: 1
+
+  measure_heap:
+    needs: build_simulator
+    name: Execute heap measurements
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - name: Install Python dependencies
+      run: pip install pandas paramiko
+    - name: Get Simulator
+      uses: actions/download-artifact@v4
+      with:
+        name: Simulator executable
+        path: MicroOcppSimulator
+    - name: Measure heap and create reports
+      run: python tests/benchmarks/scripts/measure_heap.py
+    - name: Upload reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: Memory occupation reports CSV
+        path: docs/assets/tables
+        if-no-files-found: error
+
   build_firmware_size:
+    name: Build firmware
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -51,6 +117,7 @@ jobs:
 
   evaluate_firmware:
     needs: build_firmware_size
+    name: Static firmware analysis
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -101,7 +168,10 @@ jobs:
         if-no-files-found: error
 
   deploy:
-    needs: evaluate_firmware
+    needs: |
+      evaluate_firmware
+      measure_heap
+    name: Deploy docs
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
@@ -119,6 +189,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firmware size reports CSV
+        path: docs/assets/tables
+    - name: Get memory occupation reports
+      uses: actions/download-artifact@v4
+      with:
+        name: Memory occupation reports CSV
         path: docs/assets/tables
     - name: Run mkdocs
       run: mkdocs gh-deploy --force

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,11 @@ jobs:
     name: Build Simulator
     runs-on: ubuntu-latest
     steps:
+    - name: Check env vars
+      run: |
+        echo "show MO_SIM_CONFIG"
+        echo "$MO_SIM_CONFIG"
+        echo "end"
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -73,6 +73,16 @@ jobs:
       with:
         name: Simulator executable
         path: MicroOcppSimulator
+    - name: Check Simulator and env vars
+      run: |
+        echo "show MicroOcppSimulator"
+        ls MicroOcppSimulator
+        echo "show MicroOcppSimulator/build"
+        ls MicroOcppSimulator/build
+        echo "show MicroOcppSimulator/public"
+        ls MicroOcppSimulator/public
+        echo "show MO_SIM_CONFIG"
+        echo $(MO_SIM_CONFIG)
     - name: Measure heap and create reports
       run: python tests/benchmarks/scripts/measure_heap.py
     - name: Upload reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Support for TransactionMessageAttempts/-RetryInterval ([#345](https://github.com/matth-x/MicroOcpp/pull/345))
 - Heap profiler and custom allocator support ([#350](https://github.com/matth-x/MicroOcpp/pull/350))
 - Migration of persistent storage ([#355](https://github.com/matth-x/MicroOcpp/pull/355))
-- Benchmarks pipeline ([#369](https://github.com/matth-x/MicroOcpp/pull/369))
+- Benchmarks pipeline ([#369](https://github.com/matth-x/MicroOcpp/pull/369), [#376](https://github.com/matth-x/MicroOcpp/pull/376))
 - MeterValues port for OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - UnlockConnector port for OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - More APIs ported to OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -45,3 +45,7 @@ This section contains the raw data which is the basis for the evaluations above.
 **Table 4: All compilation units for OCPP 2.0.1 firmware**
 
 {{ read_csv('compile_units_v201.csv') }}
+
+## Heap memory (preview)
+
+{{ read_csv('heap_v201.csv') }}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -34,18 +34,26 @@ The following table shows the cumulated size of the objects files per module. Th
 
 {{ read_csv('modules_v201.csv') }}
 
+## Memory usage
+
+MicroOCPP uses the heap memory to process incoming messages, maintain the device model and create outgoing OCPP messages. The total heap usage should remain low enough to not risk a heap depletion which would not only affect the OCPP module, but the whole controller, because heap memory is typically shared on microcontrollers. To assess the heap usage of MicroOCPP, a test suite runs a variety of simulated charger use cases and measures the maximum occupied memory. Then, the maximum observed value is considered as the memory requirement of MicroOCPP.
+
+Another important figure is the base level which is much closer to the average heap usage. The total heap usage consists of a base level and a dynamic part. Some memory objects are only initialized once during startup or as the device model is populated (e.g. Charging Schedules) and therefore belong to the base which changes only slowly over time. In contrast, objects for the JSON parsing and serialization and the internal execution of the operations are highly dynamic as they are instantiated for one operation and freed again after completion of the action. If the firmware contains multiple components besides MicroOCPP with this usage pattern, then the average total memory occupation of the device RAM is even closer to the base levels of the individual components.
+
+The following table shows the dynamic heap usage for a variety of test cases, followed by the base level and resulting maximum memory occupation of MicroOCPP. At the time being, the measurements are limited to only OCPP 2.0.1 and a narrow set of test cases. They will be gradually extended over time.
+
+**Table 3: Memory usage per use case and total**
+
+{{ read_csv('heap_v201.csv') }}
+
 ## Full data sets
 
 This section contains the raw data which is the basis for the evaluations above.
 
-**Table 3: All compilation units for OCPP 1.6 firmware**
+**Table 4: All compilation units for OCPP 1.6 firmware**
 
 {{ read_csv('compile_units_v16.csv') }}
 
-**Table 4: All compilation units for OCPP 2.0.1 firmware**
+**Table 5: All compilation units for OCPP 2.0.1 firmware**
 
 {{ read_csv('compile_units_v201.csv') }}
-
-## Heap memory (preview)
-
-{{ read_csv('heap_v201.csv') }}

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -248,7 +248,7 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
-    print(f'Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV']-2)]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end')
+    print(f'Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-2]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end')
 
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -1,0 +1,200 @@
+import os
+import requests
+import paramiko
+import base64
+import io
+import json
+import time
+
+
+testcase_name_list = ['TC_B_06_CS', 'TC_C_02_CS']
+
+requests.packages.urllib3.disable_warnings() # avoid the URL to be printed to console
+
+def connect_ssh():
+
+    if not os.path.isfile(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519')):
+        file = open(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), 'w')
+        file.write(os.environ['SSH_LOCAL_PRIV'])
+        file.close()
+
+    client = paramiko.SSHClient()
+    client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
+    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'))
+    return client
+
+def close_ssh(client: paramiko.SSHClient):
+
+    client.close()
+
+def deploy_simulator():
+
+    print('Deploy Simulator')
+
+    client = connect_ssh()
+
+    print('   - stop Simulator, if still running')
+    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+
+    print('   - clean previous deployment')
+    stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator'))
+
+    print('   - init folder structure')
+    sftp = client.open_sftp()
+    sftp.mkdir(os.path.join('MicroOcppSimulator'))
+    sftp.mkdir(os.path.join('MicroOcppSimulator', 'build'))
+    sftp.mkdir(os.path.join('MicroOcppSimulator', 'public'))
+    sftp.mkdir(os.path.join('MicroOcppSimulator', 'mo_store'))
+
+    print('   - upload files')
+    sftp.put(  os.path.join('MicroOcppSimulator', 'build', 'mo_simulator'),
+               os.path.join('MicroOcppSimulator', 'build', 'mo_simulator'))
+    sftp.chmod(os.path.join('MicroOcppSimulator', 'build', 'mo_simulator'), 0O777)
+    sftp.put(  os.path.join('MicroOcppSimulator', 'public', 'bundle.html.gz'),
+               os.path.join('MicroOcppSimulator', 'public', 'bundle.html.gz'))
+    sftp.close()
+    close_ssh(client)
+    print('   - done')
+
+def cleanup_simulator():
+
+    print('Clean up Simulator')
+
+    client = connect_ssh()
+
+    print('   - stop Simulator, if still running')
+    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+
+    print('   - clean deployment')
+    stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator'))
+
+    close_ssh(client)
+    print('   - done')
+
+def setup_simulator():
+
+    print('Setup Simulator')
+
+    client = connect_ssh()
+
+    print('   - stop Simulator, if still running')
+    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+
+    print('   - clean state')
+    stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator', 'mo_store', '*'))
+
+    print('   - upload credentials')
+    sftp = client.open_sftp()
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_CONFIG']),     os.path.join('MicroOcppSimulator', 'mo_store', 'simulator.jsn'))
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_OCPP_SERVER']),os.path.join('MicroOcppSimulator', 'mo_store', 'ws-conn.jsn'))
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_API_CERT']),   os.path.join('MicroOcppSimulator', 'mo_store', 'api_cert.pem'))
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_API_KEY']),    os.path.join('MicroOcppSimulator', 'mo_store', 'api_key.pem'))
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_API_CONFIG']), os.path.join('MicroOcppSimulator', 'mo_store', 'api.jsn'))
+    sftp.close()
+
+    print('   - start Simulator')
+
+    stdin, stdout, stderr = client.exec_command('cd ' + os.path.join('MicroOcppSimulator') + ' && ./build/mo_simulator')
+    close_ssh(client)
+
+    print('   - done')
+
+def run_measurements():
+
+    if (    'TEST_DRIVER_URL'    not in os.environ or
+            'TEST_DRIVER_CONFIG' not in os.environ or
+            'TEST_DRIVER_KEY'    not in os.environ or
+            'MO_SIM_CONFIG'      not in os.environ or
+            'MO_SIM_OCPP_SERVER' not in os.environ or
+            'MO_SIM_API_CERT'    not in os.environ or
+            'MO_SIM_API_KEY'     not in os.environ or
+            'MO_SIM_API_CONFIG'  not in os.environ or
+            'SSH_LOCAL_PRIV'     not in os.environ or
+            'SSH_HOST_PUB'       not in os.environ):
+        print('Could not read environment variables')
+        exit(1)
+    
+    print("Fetch TCs from Test Driver")
+
+    response = requests.get(os.environ['TEST_DRIVER_URL'] + '/ocpp2.0.1/CS/testcases/' + os.environ['TEST_DRIVER_CONFIG'], 
+                            headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                            verify=False)
+
+    testcases = []
+
+    for i in response.json()['data']['testcasesData']:
+        for j in i['data']:
+            is_core = False
+            for k in j['certification_profiles']:
+                if k == 'Core':
+                    is_core = True
+                    break
+
+            select = False
+            for k in testcase_name_list:
+                if j['testcase_name'] == k:
+                    select = True
+                    break
+
+            if select:
+                print(i['header'] + ' --- ' + j['functional_block'] + ' --- ' + j['description'])
+                testcases.append(j)
+
+    deploy_simulator()
+
+    ##
+    #print('Test RMT_API')
+    #setup_simulator()
+    #response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
+    #                         auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+    #                               json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+    #print(f'Status code {response.status_code}')
+    #print(response.text)
+    #print(json.dumps(response.json(), indent=4))
+    #cleanup_simulator()
+    #return
+
+    print("Start Test Driver")
+
+    response = requests.post(os.environ['TEST_DRIVER_URL'] + '/ocpp2.0.1/CS/session/start/' + os.environ['TEST_DRIVER_CONFIG'], 
+                             headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                             verify=False)
+    print(f'Status code {response.status_code}')
+    print(json.dumps(response.json(), indent=4))
+
+    for testcase in testcases:
+        print('\nRun ' + testcase['functional_block'] + ' > ' + testcase['description'] + ' (' + testcase['testcase_name'] + ')')
+
+        setup_simulator()
+        time.sleep(1)
+
+        # Check connection
+        for i in range(5):
+            response = requests.get(os.environ['TEST_DRIVER_URL'] + '/sut_connection_status', 
+                                    headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                                    verify=False)
+            print(f'Status code {response.status_code}')
+            print(json.dumps(response.json(), indent=4))
+            if response.json()['isConnected'] == True:
+                break
+            else:
+                print(f'Waiting for SUT to connect ({i}) ...')
+                time.sleep(3)
+        
+        response = requests.post(os.environ['TEST_DRIVER_URL'] + '/testcases/' + testcase['testcase_name'] + '/execute', 
+                                 headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                                 verify=False)
+        print(f'Status code {response.status_code}')
+        print(json.dumps(response.json(), indent=4))
+
+    print("Stop Test Driver")
+    
+    response = requests.post(os.environ['TEST_DRIVER_URL'] + '/session/stop', 
+                             headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                             verify=False)
+    print(f'Status code {response.status_code}')
+    print(json.dumps(response.json(), indent=4))
+
+    cleanup_simulator()
+
+run_measurements()

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -247,6 +247,9 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
+    print("Show MO_SIM_CONFIG")
+    print(os.environ['MO_SIM_CONFIG'])
+
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or
             'TEST_DRIVER_KEY'    not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -98,8 +98,6 @@ testcase_name_list = [
     'TC_J_10_CS',
 ]
 
-testcase_name_list = ['TC_B_06_CS', 'TC_E_05_CS']
-
 # Result data set
 df = pd.DataFrame(columns=['FN_BLOCK', 'Testcase', 'Pass', 'Heap usage (Bytes)'])
 df.index.names = ['TC_ID']

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -223,8 +223,7 @@ def run_measurements():
     # Add some meta information
     max_memory = 0
     for index, row in df.iterrows():
-        if int(row[3]) > max_memory:
-            max_memory = int(row[3])
+        max_memory = max(max_memory, int(row[3]))
 
     functional_blocks = set()
     for index, row in df.iterrows():
@@ -238,7 +237,7 @@ def run_measurements():
     df.loc['|MO_SIM_000'] = ['-', '**Simulator stats**', ' ', ' ']
     df.loc['|MO_SIM_010'] = ['-', 'Base memory occupation', ' ', str(base_memory_level)]
     df.loc['|MO_SIM_020'] = ['-', 'Test case maximum', ' ', str(max_memory)]
-    df.loc['|MO_SIM_030'] = ['-', 'Base + test case maximum', ' ', str(base_memory_level + max_memory)]
+    df.loc['|MO_SIM_030'] = ['-', 'Total memory maximum', ' ', str(base_memory_level + max_memory)]
 
     df.sort_index(inplace=True)
     

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -1,13 +1,21 @@
 import os
+import sys
 import requests
 import paramiko
 import base64
 import io
 import json
 import time
+import pandas as pd
 
 
-testcase_name_list = ['TC_B_06_CS', 'TC_C_02_CS']
+# Test case selection
+testcase_name_list = ['TC_B_06_CS', 'TC_B_07_CS', 'TC_C_02_CS']
+#testcase_name_list = ['TC_B_06_CS']
+
+# Result data set
+df = pd.DataFrame(columns=['FN_BLOCK', 'Testcase', 'Pass', 'Heap usage (Bytes)'])
+df.index.names = ['TC_ID']
 
 requests.packages.urllib3.disable_warnings() # avoid the URL to be printed to console
 
@@ -100,25 +108,14 @@ def setup_simulator():
     print('   - done')
 
 def run_measurements():
-
-    if (    'TEST_DRIVER_URL'    not in os.environ or
-            'TEST_DRIVER_CONFIG' not in os.environ or
-            'TEST_DRIVER_KEY'    not in os.environ or
-            'MO_SIM_CONFIG'      not in os.environ or
-            'MO_SIM_OCPP_SERVER' not in os.environ or
-            'MO_SIM_API_CERT'    not in os.environ or
-            'MO_SIM_API_KEY'     not in os.environ or
-            'MO_SIM_API_CONFIG'  not in os.environ or
-            'SSH_LOCAL_PRIV'     not in os.environ or
-            'SSH_HOST_PUB'       not in os.environ):
-        print('Could not read environment variables')
-        exit(1)
     
     print("Fetch TCs from Test Driver")
 
     response = requests.get(os.environ['TEST_DRIVER_URL'] + '/ocpp2.0.1/CS/testcases/' + os.environ['TEST_DRIVER_CONFIG'], 
                             headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                             verify=False)
+
+    print(json.dumps(response.json(), indent=4))
 
     testcases = []
 
@@ -142,21 +139,19 @@ def run_measurements():
 
     deploy_simulator()
 
-    ##
-    print('Test Simulator Rmt API')
+    print('Get Simulator base memory data')
     setup_simulator()
-    response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
-                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
-                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
-    print(f'Status code {response.status_code}, current heap={response.json()["total_current"]}, max heap={response.json()["total_max"]}')
 
     response = requests.post('https://cicd.micro-ocpp.com:8443/api/memory/reset', 
                              auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
                                    json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
     print(f'Status code {response.status_code}')
 
-    #cleanup_simulator()
-    #return
+    response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
+                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+    print(f'Status code {response.status_code}, current heap={response.json()["total_current"]}, max heap={response.json()["total_max"]}')
+    base_memory_level = response.json()["total_max"]
 
     print("Start Test Driver")
 
@@ -169,10 +164,15 @@ def run_measurements():
     for testcase in testcases:
         print('\nRun ' + testcase['functional_block'] + ' > ' + testcase['description'] + ' (' + testcase['testcase_name'] + ')')
 
+        if testcase['testcase_name'] in df.index:
+            print('Test case already executed - skip')
+            continue
+
         setup_simulator()
         time.sleep(1)
 
         # Check connection
+        simulator_connected = False
         for i in range(5):
             response = requests.get(os.environ['TEST_DRIVER_URL'] + '/sut_connection_status', 
                                     headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
@@ -180,26 +180,33 @@ def run_measurements():
             print(f'Status code {response.status_code}')
             print(json.dumps(response.json(), indent=4))
             if response.status_code == 200:
+                simulator_connected = True
                 break
             else:
                 print(f'Waiting for the Simulator to connect ({i}) ...')
                 time.sleep(3)
+        
+        if not simulator_connected:
+            print('Simulator could not connect to Test Driver')
+            raise Exception()
         
         response = requests.post('https://cicd.micro-ocpp.com:8443/api/memory/reset', 
                              auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
                                    json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
         print(f'Status code {response.status_code}')
         
-        response = requests.post(os.environ['TEST_DRIVER_URL'] + '/testcases/' + testcase['testcase_name'] + '/execute', 
+        test_response = requests.post(os.environ['TEST_DRIVER_URL'] + '/testcases/' + testcase['testcase_name'] + '/execute', 
                                  headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                                  verify=False)
-        print(f'Status code {response.status_code}')
-        print(json.dumps(response.json(), indent=4))
+        print(f'Status code {test_response.status_code}')
+        print(json.dumps(test_response.json(), indent=4))
 
-        response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
+        mo_sim_response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
                              auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
                                    json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
-        print(f'Status code {response.status_code}, current heap={response.json()["total_current"]}, max heap={response.json()["total_max"]}')
+        print(f'Status code {mo_sim_response.status_code}, current heap={mo_sim_response.json()["total_current"]}, max heap={mo_sim_response.json()["total_max"]}')
+
+        df.loc[testcase['testcase_name']] = [testcase['functional_block'], testcase['description'], 'x' if test_response.json()['data'][0]['verdict'] == "pass" else '-', str(mo_sim_response.json()["total_max"] - base_memory_level)]
 
     print("Stop Test Driver")
     
@@ -211,4 +218,72 @@ def run_measurements():
 
     cleanup_simulator()
 
-run_measurements()
+    print('Store test results')
+
+    # Add some meta information
+    max_memory = 0
+    for index, row in df.iterrows():
+        if int(row[3]) > max_memory:
+            max_memory = int(row[3])
+
+    functional_blocks = set()
+    for index, row in df.iterrows():
+        functional_blocks.add(row[0])
+    
+    print(functional_blocks)
+
+    for i in functional_blocks:
+        df.loc[f'TC_{i[0]}'] = [i, f'**{i}**', ' ', ' ']
+
+    df.loc['|MO_SIM_000'] = ['-', '**Simulator stats**', ' ', ' ']
+    df.loc['|MO_SIM_010'] = ['-', 'Base memory occupation', ' ', str(base_memory_level)]
+    df.loc['|MO_SIM_020'] = ['-', 'Test case maximum', ' ', str(max_memory)]
+    df.loc['|MO_SIM_030'] = ['-', 'Base + test case maximum', ' ', str(base_memory_level + max_memory)]
+
+    df.sort_index(inplace=True)
+    
+    print(df)
+
+    df.to_csv('docs/assets/tables/heap_v201.csv',index=False,columns=['Testcase','Pass','Heap usage (Bytes)'])
+
+def run_measurements_and_retry():
+
+    if (    'TEST_DRIVER_URL'    not in os.environ or
+            'TEST_DRIVER_CONFIG' not in os.environ or
+            'TEST_DRIVER_KEY'    not in os.environ or
+            'MO_SIM_CONFIG'      not in os.environ or
+            'MO_SIM_OCPP_SERVER' not in os.environ or
+            'MO_SIM_API_CERT'    not in os.environ or
+            'MO_SIM_API_KEY'     not in os.environ or
+            'MO_SIM_API_CONFIG'  not in os.environ or
+            'SSH_LOCAL_PRIV'     not in os.environ or
+            'SSH_HOST_PUB'       not in os.environ):
+        sys.exit('\nCould not read environment variables')
+
+    n_tries = 3
+
+    for i in range(n_tries):
+
+        try:
+            run_measurements()
+            print('\n **Test cases executed successfully**')
+            break
+        except:
+            print(f'Error detected ({i+1})')
+
+            print("Stop Test Driver")    
+            response = requests.post(os.environ['TEST_DRIVER_URL'] + '/session/stop', 
+                                    headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
+                                    verify=False)
+            print(f'Status code {response.status_code}')
+            print(json.dumps(response.json(), indent=4))
+
+            cleanup_simulator()
+
+            if i + 1 < n_tries:
+                print('Retry test cases')
+            else:
+                print('\n **Test case execution aborted**')
+                sys.exit('\nError running test cases')
+
+run_measurements_and_retry()

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -25,6 +25,7 @@ def connect_ssh():
         file = open(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), 'w')
         file.write(os.environ['SSH_LOCAL_PRIV'])
         file.close()
+        print('SSH ID written to file')
 
     client = paramiko.SSHClient()
     client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
@@ -115,7 +116,7 @@ def run_measurements():
                             headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                             verify=False)
 
-    print(json.dumps(response.json(), indent=4))
+    #print(json.dumps(response.json(), indent=4))
 
     testcases = []
 
@@ -159,7 +160,7 @@ def run_measurements():
                              headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                              verify=False)
     print(f'Status code {response.status_code}')
-    print(json.dumps(response.json(), indent=4))
+    #print(json.dumps(response.json(), indent=4))
 
     for testcase in testcases:
         print('\nRun ' + testcase['functional_block'] + ' > ' + testcase['description'] + ' (' + testcase['testcase_name'] + ')')
@@ -178,7 +179,7 @@ def run_measurements():
                                     headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                                     verify=False)
             print(f'Status code {response.status_code}')
-            print(json.dumps(response.json(), indent=4))
+            #print(json.dumps(response.json(), indent=4))
             if response.status_code == 200:
                 simulator_connected = True
                 break
@@ -199,7 +200,7 @@ def run_measurements():
                                  headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                                  verify=False)
         print(f'Status code {test_response.status_code}')
-        print(json.dumps(test_response.json(), indent=4))
+        #print(json.dumps(test_response.json(), indent=4))
 
         mo_sim_response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
                              auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
@@ -214,7 +215,7 @@ def run_measurements():
                              headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                              verify=False)
     print(f'Status code {response.status_code}')
-    print(json.dumps(response.json(), indent=4))
+    #print(json.dumps(response.json(), indent=4))
 
     cleanup_simulator()
 
@@ -247,6 +248,8 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
+    print(f'Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV']-2)]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end')
+
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or
             'TEST_DRIVER_KEY'    not in os.environ or
@@ -275,7 +278,7 @@ def run_measurements_and_retry():
                                     headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                                     verify=False)
             print(f'Status code {response.status_code}')
-            print(json.dumps(response.json(), indent=4))
+            #print(json.dumps(response.json(), indent=4))
 
             cleanup_simulator()
 

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -34,7 +34,7 @@ def deploy_simulator():
     client = connect_ssh()
 
     print('   - stop Simulator, if still running')
-    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+    stdin, stdout, stderr = client.exec_command('killall -s SIGINT mo_simulator')
 
     print('   - clean previous deployment')
     stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator'))
@@ -63,7 +63,7 @@ def cleanup_simulator():
     client = connect_ssh()
 
     print('   - stop Simulator, if still running')
-    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+    stdin, stdout, stderr = client.exec_command('killall -s SIGINT mo_simulator')
 
     print('   - clean deployment')
     stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator'))
@@ -78,7 +78,7 @@ def setup_simulator():
     client = connect_ssh()
 
     print('   - stop Simulator, if still running')
-    stdin, stdout, stderr = client.exec_command('killall mo_simulator')
+    stdin, stdout, stderr = client.exec_command('killall -s SIGINT mo_simulator')
 
     print('   - clean state')
     stdin, stdout, stderr = client.exec_command('rm -rf ' + os.path.join('MicroOcppSimulator', 'mo_store', '*'))
@@ -94,7 +94,7 @@ def setup_simulator():
 
     print('   - start Simulator')
 
-    stdin, stdout, stderr = client.exec_command('cd ' + os.path.join('MicroOcppSimulator') + ' && ./build/mo_simulator')
+    stdin, stdout, stderr = client.exec_command('mkdir -p logs && cd ' + os.path.join('MicroOcppSimulator') + ' && ./build/mo_simulator > ~/logs/sim_"$(date +%Y-%m-%d_%H-%M-%S.log)"')
     close_ssh(client)
 
     print('   - done')
@@ -175,10 +175,10 @@ def run_measurements():
                                     verify=False)
             print(f'Status code {response.status_code}')
             print(json.dumps(response.json(), indent=4))
-            if response.json()['isConnected'] == True:
+            if response.status_code == 200:
                 break
             else:
-                print(f'Waiting for SUT to connect ({i}) ...')
+                print(f'Waiting for the Simulator to connect ({i}) ...')
                 time.sleep(3)
         
         response = requests.post(os.environ['TEST_DRIVER_URL'] + '/testcases/' + testcase['testcase_name'] + '/execute', 

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -247,8 +247,7 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
-    print("Show MO_SIM_CONFIG")
-    print(os.environ['MO_SIM_CONFIG'])
+    print(f"Show MO_SIM_CONFIG: {len(os.environ['MO_SIM_CONFIG'])}")
 
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -21,15 +21,15 @@ requests.packages.urllib3.disable_warnings() # avoid the URL to be printed to co
 
 def connect_ssh():
 
-    if not os.path.isfile(os.path.join('id_ed25519')):
-        file = open(os.path.join('id_ed25519'), 'w')
+    if not os.path.isfile(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519')):
+        file = open(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), 'w')
         file.write(os.environ['SSH_LOCAL_PRIV'])
         file.close()
         print('SSH ID written to file')
 
     client = paramiko.SSHClient()
     client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
-    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('id_ed25519'))
+    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), look_for_keys=False)
     return client
 
 def close_ssh(client: paramiko.SSHClient):
@@ -245,6 +245,8 @@ def run_measurements():
     print(df)
 
     df.to_csv('docs/assets/tables/heap_v201.csv',index=False,columns=['Testcase','Pass','Heap usage (Bytes)'])
+
+run_measurements()
 
 def run_measurements_and_retry():
 

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -247,8 +247,6 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
-    print(f"Show MO_SIM_CONFIG: {len(os.environ['MO_SIM_CONFIG'])}")
-
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or
             'TEST_DRIVER_KEY'    not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -29,7 +29,7 @@ def connect_ssh():
 
     client = paramiko.SSHClient()
     client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
-    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), look_for_keys=False, disabled_algorithms={'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']})
+    client.connect('cicd.micro-ocpp.com', username='ocpp', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), look_for_keys=False)
     return client
 
 def close_ssh(client: paramiko.SSHClient):

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -143,14 +143,18 @@ def run_measurements():
     deploy_simulator()
 
     ##
-    #print('Test RMT_API')
-    #setup_simulator()
-    #response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
-    #                         auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
-    #                               json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
-    #print(f'Status code {response.status_code}')
-    #print(response.text)
-    #print(json.dumps(response.json(), indent=4))
+    print('Test Simulator Rmt API')
+    setup_simulator()
+    response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
+                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+    print(f'Status code {response.status_code}, current heap={response.json()["total_current"]}, max heap={response.json()["total_max"]}')
+
+    response = requests.post('https://cicd.micro-ocpp.com:8443/api/memory/reset', 
+                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+    print(f'Status code {response.status_code}')
+
     #cleanup_simulator()
     #return
 
@@ -181,11 +185,21 @@ def run_measurements():
                 print(f'Waiting for the Simulator to connect ({i}) ...')
                 time.sleep(3)
         
+        response = requests.post('https://cicd.micro-ocpp.com:8443/api/memory/reset', 
+                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+        print(f'Status code {response.status_code}')
+        
         response = requests.post(os.environ['TEST_DRIVER_URL'] + '/testcases/' + testcase['testcase_name'] + '/execute', 
                                  headers={'Authorization': 'Bearer ' + os.environ['TEST_DRIVER_KEY']},
                                  verify=False)
         print(f'Status code {response.status_code}')
         print(json.dumps(response.json(), indent=4))
+
+        response = requests.get('https://cicd.micro-ocpp.com:8443/api/memory/info', 
+                             auth=(json.loads(os.environ['MO_SIM_API_CONFIG'])['user'],
+                                   json.loads(os.environ['MO_SIM_API_CONFIG'])['pass']))
+        print(f'Status code {response.status_code}, current heap={response.json()["total_current"]}, max heap={response.json()["total_max"]}')
 
     print("Stop Test Driver")
     

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -21,15 +21,15 @@ requests.packages.urllib3.disable_warnings() # avoid the URL to be printed to co
 
 def connect_ssh():
 
-    if not os.path.isfile(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519')):
-        file = open(os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), 'w')
+    if not os.path.isfile(os.path.join('id_ed25519')):
+        file = open(os.path.join('id_ed25519'), 'w')
         file.write(os.environ['SSH_LOCAL_PRIV'])
         file.close()
         print('SSH ID written to file')
 
     client = paramiko.SSHClient()
     client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
-    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'))
+    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('id_ed25519'))
     return client
 
 def close_ssh(client: paramiko.SSHClient):

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -248,7 +248,7 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
-    print(f'Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-2]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end')
+    print(f"Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-2]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end")
 
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -248,8 +248,6 @@ def run_measurements():
 
 def run_measurements_and_retry():
 
-    print(f"Show {os.environ['SSH_LOCAL_PRIV'][0]}, {os.environ['SSH_LOCAL_PRIV'][1]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-2]}, {os.environ['SSH_LOCAL_PRIV'][len(os.environ['SSH_LOCAL_PRIV'])-1]} end")
-
     if (    'TEST_DRIVER_URL'    not in os.environ or
             'TEST_DRIVER_CONFIG' not in os.environ or
             'TEST_DRIVER_KEY'    not in os.environ or

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -29,7 +29,7 @@ def connect_ssh():
 
     client = paramiko.SSHClient()
     client.get_host_keys().add('cicd.micro-ocpp.com', 'ssh-ed25519', paramiko.pkey.PKey.from_type_string('ssh-ed25519', base64.b64decode(os.environ['SSH_HOST_PUB'])))
-    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), look_for_keys=False)
+    client.connect('cicd.micro-ocpp.com', key_filename=os.path.join('tests', 'benchmarks', 'scripts', 'id_ed25519'), look_for_keys=False, disabled_algorithms={'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']})
     return client
 
 def close_ssh(client: paramiko.SSHClient):


### PR DESCRIPTION
Adds a GitHub Action which measures the heap occupation of various test cases of an external test driver. The test driver needs to trigger some state changes on MicroOcpp to check for the expected results. For this purpose, this setup incorporates the MicroOcppSimulator which runs the OCPP-side communication to the test driver while handling its HTTP requests.

The heap measurement results are published to the [Benchmarks](https://matth-x.github.io/MicroOcpp/benchmarks/) page of the Docs. This is a follow up PR of #369