### PR TITLE
OCPP 2.0.1 persistent Variable and Transactions store

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         repository: matth-x/MicroOcppSimulator
         path: MicroOcppSimulator
-        ref: feature/remote-api
+        ref: 20e8da7b76a3f5f3e50facab018a457ecdbcca59
         submodules: 'recursive'
     - name: Clean MicroOcpp submodule
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - UnlockConnector port for OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - More APIs ported to OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - Support for AuthorizeRemoteTxRequests ([#373](https://github.com/matth-x/MicroOcpp/pull/373))
+- Persistent Variable and Tx store for OCPP 2.0.1
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - UnlockConnector port for OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - More APIs ported to OCPP 2.0.1 ([#371](https://github.com/matth-x/MicroOcpp/pull/371))
 - Support for AuthorizeRemoteTxRequests ([#373](https://github.com/matth-x/MicroOcpp/pull/373))
-- Persistent Variable and Tx store for OCPP 2.0.1
+- Persistent Variable and Tx store for OCPP 2.0.1 ([#379](https://github.com/matth-x/MicroOcpp/pull/379))
 
 ### Removed
 

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -290,7 +290,7 @@ void mocpp_initialize(Connection& connection, const char *bootNotificationCreden
         model.setVariableService(std::unique_ptr<VariableService>(
             new VariableService(*context, filesystem)));
         model.setTransactionService(std::unique_ptr<TransactionService>(
-            new TransactionService(*context)));
+            new TransactionService(*context, filesystem, MO_NUM_EVSEID)));
         model.setRemoteControlService(std::unique_ptr<RemoteControlService>(
             new RemoteControlService(*context, MO_NUM_EVSEID)));
     } else
@@ -852,6 +852,7 @@ void setEvReadyInput(std::function<bool()> evReadyInput, unsigned int connectorI
                 evse->setEvReadyInput(evReadyInput);
             }
         }
+        return;
     }
 #endif
     auto connector = context->getModel().getConnector(connectorId);

--- a/src/MicroOcpp/Model/Authorization/IdToken.cpp
+++ b/src/MicroOcpp/Model/Authorization/IdToken.cpp
@@ -22,6 +22,8 @@ IdToken::IdToken(const char *token, Type type, const char *memoryTag) : MemoryMa
             MO_DBG_ERR("invalid token");
             *idToken = '\0';
         }
+    } else {
+        *idToken = '\0';
     }
 }
 
@@ -63,11 +65,11 @@ bool IdToken::parseCstr(const char *token, const char *typeCstr) {
 }
 
 const char *IdToken::get() const {
-    return *idToken ? idToken : nullptr;;
+    return idToken;
 }
 
 const char *IdToken::getTypeCstr() const {
-    const char *res = nullptr;
+    const char *res = "";
     switch (type) {
         case Type::UNDEFINED:
             MO_DBG_ERR("internal error");
@@ -98,7 +100,7 @@ const char *IdToken::getTypeCstr() const {
             break;
     }
 
-    return res ? res : "";
+    return res;
 }
 
 bool IdToken::equals(const IdToken& other) {

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -22,8 +22,6 @@
 #define MO_TXRECORD_SIZE 4 //no. of tx to hold on flash storage
 #endif
 
-#define MAX_TX_CNT 100000U //upper limit of txNr (internal usage). Must be at least 2*MO_TXRECORD_SIZE+1
-
 #ifndef MO_REPORT_NOERROR
 #define MO_REPORT_NOERROR 0
 #endif

--- a/src/MicroOcpp/Model/RemoteControl/RemoteControlService.h
+++ b/src/MicroOcpp/Model/RemoteControl/RemoteControlService.h
@@ -53,7 +53,7 @@ public:
 
     RemoteControlServiceEvse *getEvse(unsigned int evseId);
 
-    RequestStartStopStatus requestStartTransaction(unsigned int evseId, unsigned int remoteStartId, IdToken idToken, std::shared_ptr<Ocpp201::Transaction>& transactionOut); //ChargingProfile, GroupIdToken not supported yet
+    RequestStartStopStatus requestStartTransaction(unsigned int evseId, unsigned int remoteStartId, IdToken idToken, char *transactionIdOut, size_t transactionIdBufSize); //ChargingProfile, GroupIdToken not supported yet
 
     RequestStartStopStatus requestStopTransaction(const char *transactionId);
 };

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -125,7 +125,7 @@ ResetService::~ResetService() {
 
 ResetService::Evse::Evse(Context& context, ResetService& resetService, unsigned int evseId) : context(context), resetService(resetService), evseId(evseId) {
     auto varService = context.getModel().getVariableService();
-    varService->declareVariable<bool>(ComponentId("EVSE", evseId >= 1 ? evseId : -1), "AllowReset", true, MO_VARIABLE_FN, Variable::Mutability::ReadOnly);
+    varService->declareVariable<bool>(ComponentId("EVSE", evseId >= 1 ? evseId : -1), "AllowReset", true, Variable::Mutability::ReadOnly, false);
 }
 
 void ResetService::Evse::loop() {

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -303,7 +303,7 @@ ResetStatus ResetService::initiateReset(ResetType type, unsigned int evseId) {
             if (tx->active) {
                 //Tx in progress. Check behavior
                 if (type == ResetType_Immediate) {
-                    txService->getEvse(eId)->abortTransaction(Transaction::StopReason::ImmediateReset, TransactionEventTriggerReason::ResetCommand);
+                    txService->getEvse(eId)->abortTransaction(Transaction::StoppedReason::ImmediateReset, TransactionEventTriggerReason::ResetCommand);
                 } else {
                     scheduled = true;
                     break;

--- a/src/MicroOcpp/Model/Transactions/Transaction.cpp
+++ b/src/MicroOcpp/Model/Transactions/Transaction.cpp
@@ -255,7 +255,9 @@ const char *serializeTransactionEventTriggerReason(TransactionEventTriggerReason
     return triggerReasonCstr;
 }
 bool deserializeTransactionEventTriggerReason(const char *triggerReasonCstr, TransactionEventTriggerReason& triggerReasonOut) {
-    if (!strcmp(triggerReasonCstr, "Authorized")) {
+    if (!triggerReasonCstr || !*triggerReasonCstr) {
+        triggerReasonOut = TransactionEventTriggerReason::UNDEFINED;
+    } else if (!strcmp(triggerReasonCstr, "Authorized")) {
         triggerReasonOut = TransactionEventTriggerReason::Authorized;
     } else if (!strcmp(triggerReasonCstr, "CablePluggedIn")) {
         triggerReasonOut = TransactionEventTriggerReason::CablePluggedIn;

--- a/src/MicroOcpp/Model/Transactions/Transaction.cpp
+++ b/src/MicroOcpp/Model/Transactions/Transaction.cpp
@@ -4,6 +4,7 @@
 
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Model/Transactions/TransactionStore.h>
+#include <MicroOcpp/Debug.h>
 
 using namespace MicroOcpp;
 
@@ -30,6 +31,327 @@ bool Transaction::setStopReason(const char *reason) {
 bool Transaction::commit() {
     return context.commit(this);
 }
+
+#if MO_ENABLE_V201
+
+namespace MicroOcpp {
+namespace Ocpp201 {
+
+const char *serializeTransactionStoppedReason(Transaction::StoppedReason stoppedReason) {
+    const char *stoppedReasonCstr = nullptr;
+    switch (stoppedReason) {
+        case Transaction::StoppedReason::UNDEFINED:
+            // optional, okay
+            break;
+        case Transaction::StoppedReason::Local:
+            stoppedReasonCstr = "Local";
+            break;
+        case Transaction::StoppedReason::DeAuthorized:
+            stoppedReasonCstr = "DeAuthorized";
+            break;
+        case Transaction::StoppedReason::EmergencyStop:
+            stoppedReasonCstr = "EmergencyStop";
+            break;
+        case Transaction::StoppedReason::EnergyLimitReached:
+            stoppedReasonCstr = "EnergyLimitReached";
+            break;
+        case Transaction::StoppedReason::EVDisconnected:
+            stoppedReasonCstr = "EVDisconnected";
+            break;
+        case Transaction::StoppedReason::GroundFault:
+            stoppedReasonCstr = "GroundFault";
+            break;
+        case Transaction::StoppedReason::ImmediateReset:
+            stoppedReasonCstr = "ImmediateReset";
+            break;
+        case Transaction::StoppedReason::LocalOutOfCredit:
+            stoppedReasonCstr = "LocalOutOfCredit";
+            break;
+        case Transaction::StoppedReason::MasterPass:
+            stoppedReasonCstr = "MasterPass";
+            break;
+        case Transaction::StoppedReason::Other:
+            stoppedReasonCstr = "Other";
+            break;
+        case Transaction::StoppedReason::OvercurrentFault:
+            stoppedReasonCstr = "OvercurrentFault";
+            break;
+        case Transaction::StoppedReason::PowerLoss:
+            stoppedReasonCstr = "PowerLoss";
+            break;
+        case Transaction::StoppedReason::PowerQuality:
+            stoppedReasonCstr = "PowerQuality";
+            break;
+        case Transaction::StoppedReason::Reboot:
+            stoppedReasonCstr = "Reboot";
+            break;
+        case Transaction::StoppedReason::Remote:
+            stoppedReasonCstr = "Remote";
+            break;
+        case Transaction::StoppedReason::SOCLimitReached:
+            stoppedReasonCstr = "SOCLimitReached";
+            break;
+        case Transaction::StoppedReason::StoppedByEV:
+            stoppedReasonCstr = "StoppedByEV";
+            break;
+        case Transaction::StoppedReason::TimeLimitReached:
+            stoppedReasonCstr = "TimeLimitReached";
+            break;
+        case Transaction::StoppedReason::Timeout:
+            stoppedReasonCstr = "Timeout";
+            break;
+    }
+
+    return stoppedReasonCstr;
+}
+bool deserializeTransactionStoppedReason(const char *stoppedReasonCstr, Transaction::StoppedReason& stoppedReasonOut) {
+    if (!stoppedReasonCstr || !*stoppedReasonCstr) {
+        stoppedReasonOut = Transaction::StoppedReason::UNDEFINED;
+    } else if (!strcmp(stoppedReasonCstr, "DeAuthorized")) {
+        stoppedReasonOut = Transaction::StoppedReason::DeAuthorized;
+    } else if (!strcmp(stoppedReasonCstr, "EmergencyStop")) {
+        stoppedReasonOut = Transaction::StoppedReason::EmergencyStop;
+    } else if (!strcmp(stoppedReasonCstr, "EnergyLimitReached")) {
+        stoppedReasonOut = Transaction::StoppedReason::EnergyLimitReached;
+    } else if (!strcmp(stoppedReasonCstr, "EVDisconnected")) {
+        stoppedReasonOut = Transaction::StoppedReason::EVDisconnected;
+    } else if (!strcmp(stoppedReasonCstr, "GroundFault")) {
+        stoppedReasonOut = Transaction::StoppedReason::GroundFault;
+    } else if (!strcmp(stoppedReasonCstr, "ImmediateReset")) {
+        stoppedReasonOut = Transaction::StoppedReason::ImmediateReset;
+    } else if (!strcmp(stoppedReasonCstr, "Local")) {
+        stoppedReasonOut = Transaction::StoppedReason::Local;
+    } else if (!strcmp(stoppedReasonCstr, "LocalOutOfCredit")) {
+        stoppedReasonOut = Transaction::StoppedReason::LocalOutOfCredit;
+    } else if (!strcmp(stoppedReasonCstr, "MasterPass")) {
+        stoppedReasonOut = Transaction::StoppedReason::MasterPass;
+    } else if (!strcmp(stoppedReasonCstr, "Other")) {
+        stoppedReasonOut = Transaction::StoppedReason::Other;
+    } else if (!strcmp(stoppedReasonCstr, "OvercurrentFault")) {
+        stoppedReasonOut = Transaction::StoppedReason::OvercurrentFault;
+    } else if (!strcmp(stoppedReasonCstr, "PowerLoss")) {
+        stoppedReasonOut = Transaction::StoppedReason::PowerLoss;
+    } else if (!strcmp(stoppedReasonCstr, "PowerQuality")) {
+        stoppedReasonOut = Transaction::StoppedReason::PowerQuality;
+    } else if (!strcmp(stoppedReasonCstr, "Reboot")) {
+        stoppedReasonOut = Transaction::StoppedReason::Reboot;
+    } else if (!strcmp(stoppedReasonCstr, "Remote")) {
+        stoppedReasonOut = Transaction::StoppedReason::Remote;
+    } else if (!strcmp(stoppedReasonCstr, "SOCLimitReached")) {
+        stoppedReasonOut = Transaction::StoppedReason::SOCLimitReached;
+    } else if (!strcmp(stoppedReasonCstr, "StoppedByEV")) {
+        stoppedReasonOut = Transaction::StoppedReason::StoppedByEV;
+    } else if (!strcmp(stoppedReasonCstr, "TimeLimitReached")) {
+        stoppedReasonOut = Transaction::StoppedReason::TimeLimitReached;
+    } else if (!strcmp(stoppedReasonCstr, "Timeout")) {
+        stoppedReasonOut = Transaction::StoppedReason::Timeout;
+    } else {
+        MO_DBG_ERR("deserialization error");
+        return false;
+    }
+    return true;
+}
+
+const char *serializeTransactionEventType(TransactionEventData::Type type) {
+    const char *typeCstr = "";
+    switch (type) {
+        case TransactionEventData::Type::Ended:
+            typeCstr = "Ended";
+            break;
+        case TransactionEventData::Type::Started:
+            typeCstr = "Started";
+            break;
+        case TransactionEventData::Type::Updated:
+            typeCstr = "Updated";
+            break;
+    }
+    return typeCstr;
+}
+bool deserializeTransactionEventType(const char *typeCstr, TransactionEventData::Type& typeOut) {
+    if (!strcmp(typeCstr, "Ended")) {
+        typeOut = TransactionEventData::Type::Ended;
+    } else if (!strcmp(typeCstr, "Started")) {
+        typeOut = TransactionEventData::Type::Started;
+    } else if (!strcmp(typeCstr, "Updated")) {
+        typeOut = TransactionEventData::Type::Updated;
+    } else {
+        MO_DBG_ERR("deserialization error");
+        return false;
+    }
+    return true;
+}
+
+const char *serializeTransactionEventTriggerReason(TransactionEventTriggerReason triggerReason) {
+
+    const char *triggerReasonCstr = nullptr;
+    switch(triggerReason) {
+        case TransactionEventTriggerReason::UNDEFINED:
+            break;
+        case TransactionEventTriggerReason::Authorized:
+            triggerReasonCstr = "Authorized";
+            break;
+        case TransactionEventTriggerReason::CablePluggedIn:
+            triggerReasonCstr = "CablePluggedIn";
+            break;
+        case TransactionEventTriggerReason::ChargingRateChanged:
+            triggerReasonCstr = "ChargingRateChanged";
+            break;
+        case TransactionEventTriggerReason::ChargingStateChanged:
+            triggerReasonCstr = "ChargingStateChanged";
+            break;
+        case TransactionEventTriggerReason::Deauthorized:
+            triggerReasonCstr = "Deauthorized";
+            break;
+        case TransactionEventTriggerReason::EnergyLimitReached:
+            triggerReasonCstr = "EnergyLimitReached";
+            break;
+        case TransactionEventTriggerReason::EVCommunicationLost:
+            triggerReasonCstr = "EVCommunicationLost";
+            break;
+        case TransactionEventTriggerReason::EVConnectTimeout:
+            triggerReasonCstr = "EVConnectTimeout";
+            break;
+        case TransactionEventTriggerReason::MeterValueClock:
+            triggerReasonCstr = "MeterValueClock";
+            break;
+        case TransactionEventTriggerReason::MeterValuePeriodic:
+            triggerReasonCstr = "MeterValuePeriodic";
+            break;
+        case TransactionEventTriggerReason::TimeLimitReached:
+            triggerReasonCstr = "TimeLimitReached";
+            break;
+        case TransactionEventTriggerReason::Trigger:
+            triggerReasonCstr = "Trigger";
+            break;
+        case TransactionEventTriggerReason::UnlockCommand:
+            triggerReasonCstr = "UnlockCommand";
+            break;
+        case TransactionEventTriggerReason::StopAuthorized:
+            triggerReasonCstr = "StopAuthorized";
+            break;
+        case TransactionEventTriggerReason::EVDeparted:
+            triggerReasonCstr = "EVDeparted";
+            break;
+        case TransactionEventTriggerReason::EVDetected:
+            triggerReasonCstr = "EVDetected";
+            break;
+        case TransactionEventTriggerReason::RemoteStop:
+            triggerReasonCstr = "RemoteStop";
+            break;
+        case TransactionEventTriggerReason::RemoteStart:
+            triggerReasonCstr = "RemoteStart";
+            break;
+        case TransactionEventTriggerReason::AbnormalCondition:
+            triggerReasonCstr = "AbnormalCondition";
+            break;
+        case TransactionEventTriggerReason::SignedDataReceived:
+            triggerReasonCstr = "SignedDataReceived";
+            break;
+        case TransactionEventTriggerReason::ResetCommand:
+            triggerReasonCstr = "ResetCommand";
+            break;
+    }
+
+    return triggerReasonCstr;
+}
+bool deserializeTransactionEventTriggerReason(const char *triggerReasonCstr, TransactionEventTriggerReason& triggerReasonOut) {
+    if (!strcmp(triggerReasonCstr, "Authorized")) {
+        triggerReasonOut = TransactionEventTriggerReason::Authorized;
+    } else if (!strcmp(triggerReasonCstr, "CablePluggedIn")) {
+        triggerReasonOut = TransactionEventTriggerReason::CablePluggedIn;
+    } else if (!strcmp(triggerReasonCstr, "ChargingRateChanged")) {
+        triggerReasonOut = TransactionEventTriggerReason::ChargingRateChanged;
+    } else if (!strcmp(triggerReasonCstr, "ChargingStateChanged")) {
+        triggerReasonOut = TransactionEventTriggerReason::ChargingStateChanged;
+    } else if (!strcmp(triggerReasonCstr, "Deauthorized")) {
+        triggerReasonOut = TransactionEventTriggerReason::Deauthorized;
+    } else if (!strcmp(triggerReasonCstr, "EnergyLimitReached")) {
+        triggerReasonOut = TransactionEventTriggerReason::EnergyLimitReached;
+    } else if (!strcmp(triggerReasonCstr, "EVCommunicationLost")) {
+        triggerReasonOut = TransactionEventTriggerReason::EVCommunicationLost;
+    } else if (!strcmp(triggerReasonCstr, "EVConnectTimeout")) {
+        triggerReasonOut = TransactionEventTriggerReason::EVConnectTimeout;
+    } else if (!strcmp(triggerReasonCstr, "MeterValueClock")) {
+        triggerReasonOut = TransactionEventTriggerReason::MeterValueClock;
+    } else if (!strcmp(triggerReasonCstr, "MeterValuePeriodic")) {
+        triggerReasonOut = TransactionEventTriggerReason::MeterValuePeriodic;
+    } else if (!strcmp(triggerReasonCstr, "TimeLimitReached")) {
+        triggerReasonOut = TransactionEventTriggerReason::TimeLimitReached;
+    } else if (!strcmp(triggerReasonCstr, "Trigger")) {
+        triggerReasonOut = TransactionEventTriggerReason::Trigger;
+    } else if (!strcmp(triggerReasonCstr, "UnlockCommand")) {
+        triggerReasonOut = TransactionEventTriggerReason::UnlockCommand;
+    } else if (!strcmp(triggerReasonCstr, "StopAuthorized")) {
+        triggerReasonOut = TransactionEventTriggerReason::StopAuthorized;
+    } else if (!strcmp(triggerReasonCstr, "EVDeparted")) {
+        triggerReasonOut = TransactionEventTriggerReason::EVDeparted;
+    } else if (!strcmp(triggerReasonCstr, "EVDetected")) {
+        triggerReasonOut = TransactionEventTriggerReason::EVDetected;
+    } else if (!strcmp(triggerReasonCstr, "RemoteStop")) {
+        triggerReasonOut = TransactionEventTriggerReason::RemoteStop;
+    } else if (!strcmp(triggerReasonCstr, "RemoteStart")) {
+        triggerReasonOut = TransactionEventTriggerReason::RemoteStart;
+    } else if (!strcmp(triggerReasonCstr, "AbnormalCondition")) {
+        triggerReasonOut = TransactionEventTriggerReason::AbnormalCondition;
+    } else if (!strcmp(triggerReasonCstr, "SignedDataReceived")) {
+        triggerReasonOut = TransactionEventTriggerReason::SignedDataReceived;
+    } else if (!strcmp(triggerReasonCstr, "ResetCommand")) {
+        triggerReasonOut = TransactionEventTriggerReason::ResetCommand;
+    } else {
+        MO_DBG_ERR("deserialization error");
+        return false;
+    }
+    return true;
+}
+
+const char *serializeTransactionEventChargingState(TransactionEventData::ChargingState chargingState) {
+    const char *chargingStateCstr = nullptr;
+    switch (chargingState) {
+        case TransactionEventData::ChargingState::UNDEFINED:
+            // optional, okay
+            break;
+        case TransactionEventData::ChargingState::Charging:
+            chargingStateCstr = "Charging";
+            break;
+        case TransactionEventData::ChargingState::EVConnected:
+            chargingStateCstr = "EVConnected";
+            break;
+        case TransactionEventData::ChargingState::SuspendedEV:
+            chargingStateCstr = "SuspendedEV";
+            break;
+        case TransactionEventData::ChargingState::SuspendedEVSE:
+            chargingStateCstr = "SuspendedEVSE";
+            break;
+        case TransactionEventData::ChargingState::Idle:
+            chargingStateCstr = "Idle";
+            break;
+    }
+    return chargingStateCstr;
+}
+bool deserializeTransactionEventChargingState(const char *chargingStateCstr, TransactionEventData::ChargingState& chargingStateOut) {
+    if (!chargingStateCstr || !*chargingStateCstr) {
+        chargingStateOut = TransactionEventData::ChargingState::UNDEFINED;
+    } else if (!strcmp(chargingStateCstr, "Charging")) {
+        chargingStateOut = TransactionEventData::ChargingState::Charging;
+    } else if (!strcmp(chargingStateCstr, "EVConnected")) {
+        chargingStateOut = TransactionEventData::ChargingState::EVConnected;
+    } else if (!strcmp(chargingStateCstr, "SuspendedEV")) {
+        chargingStateOut = TransactionEventData::ChargingState::SuspendedEV;
+    } else if (!strcmp(chargingStateCstr, "SuspendedEVSE")) {
+        chargingStateOut = TransactionEventData::ChargingState::SuspendedEVSE;
+    } else if (!strcmp(chargingStateCstr, "Idle")) {
+        chargingStateOut = TransactionEventData::ChargingState::Idle;
+    } else {
+        MO_DBG_ERR("deserialization error");
+        return false;
+    }
+    return true;
+}
+
+} //namespace Ocpp201
+} //namespace MicroOcpp
+
+#endif //MO_ENABLE_V201
 
 int ocpp_tx_getTransactionId(OCPP_Transaction *tx) {
     return reinterpret_cast<MicroOcpp::Transaction*>(tx)->getTransactionId();

--- a/src/MicroOcpp/Model/Transactions/TransactionService.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.cpp
@@ -47,6 +47,10 @@ TransactionService::Evse::Evse(Context& context, TransactionService& txService, 
     transaction = txStore.loadTransaction(txNrLatest); //returns nullptr if txNrLatest does not exist on flash
 }
 
+TransactionService::Evse::~Evse() {
+    
+}
+
 bool TransactionService::Evse::beginTransaction() {
 
     if (transaction) {

--- a/src/MicroOcpp/Model/Transactions/TransactionService.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.cpp
@@ -1011,6 +1011,12 @@ TransactionService::TransactionService(Context& context, std::shared_ptr<Filesys
     }
 }
 
+TransactionService::~TransactionService() {
+    for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID && evses[evseId]; evseId++) {
+        delete evses[evseId];
+    }
+}
+
 void TransactionService::loop() {
     for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID && evses[evseId]; evseId++) {
         evses[evseId]->loop();

--- a/src/MicroOcpp/Model/Transactions/TransactionService.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.cpp
@@ -11,35 +11,52 @@
 #include <string.h>
 
 #include <MicroOcpp/Core/Context.h>
+#include <MicroOcpp/Core/FilesystemAdapter.h>
+#include <MicroOcpp/Core/FilesystemUtils.h>
 #include <MicroOcpp/Core/Request.h>
 #include <MicroOcpp/Model/Model.h>
 #include <MicroOcpp/Model/Variables/VariableService.h>
+#include <MicroOcpp/Model/Transactions/TransactionStore.h>
 #include <MicroOcpp/Operations/Authorize.h>
 #include <MicroOcpp/Operations/TransactionEvent.h>
 #include <MicroOcpp/Operations/RequestStartTransaction.h>
 #include <MicroOcpp/Operations/RequestStopTransaction.h>
 #include <MicroOcpp/Debug.h>
 
+#ifndef MO_TX_CLEAN_ABORTED
+#define MO_TX_CLEAN_ABORTED 1
+#endif
+
 using namespace MicroOcpp;
 using namespace MicroOcpp::Ocpp201;
 
-TransactionService::Evse::Evse(Context& context, TransactionService& txService, unsigned int evseId) :
+TransactionService::Evse::Evse(Context& context, TransactionService& txService, Ocpp201::TransactionStoreEvse& txStore, unsigned int evseId) :
         MemoryManaged("v201.Transactions.TransactionServiceEvse"),
         context(context),
         txService(txService),
+        txStore(txStore),
         evseId(evseId) {
 
+    context.getRequestQueue().addSendQueue(this); //register at RequestQueue as Request emitter
+
+    txStore.discoverStoredTx(txNrBegin, txNrEnd); //initializes txNrBegin and txNrEnd
+    txNrFront = txNrBegin;
+    MO_DBG_DEBUG("found %u transactions for evseId %u. Internal range from %u to %u (exclusive)", (txNrEnd + MAX_TX_CNT - txNrBegin) % MAX_TX_CNT, evseId, txNrBegin, txNrEnd);
+
+    unsigned int txNrLatest = (txNrEnd + MAX_TX_CNT - 1) % MAX_TX_CNT; //txNr of the most recent tx on flash
+    transaction = txStore.loadTransaction(txNrLatest); //returns nullptr if txNrLatest does not exist on flash
 }
 
-std::unique_ptr<Ocpp201::Transaction> TransactionService::Evse::allocateTransaction() {
-    auto tx =  std::unique_ptr<Ocpp201::Transaction>(new Ocpp201::Transaction());
-    if (!tx) {
-        // OOM
-        return nullptr;
+bool TransactionService::Evse::beginTransaction() {
+
+    if (transaction) {
+        MO_DBG_ERR("transaction still running");
+        return false;
     }
 
-    tx->evseId = evseId;
-    tx->txNr = txNrCounter;
+    std::unique_ptr<Ocpp201::Transaction> tx;
+
+    char txId [sizeof(Ocpp201::Transaction::transactionId)];
 
     //simple clock-based hash
     int v = context.getModel().getClock().now() - Timestamp(2020,0,0,0,0,0);
@@ -48,27 +65,178 @@ std::unique_ptr<Ocpp201::Transaction> TransactionService::Evse::allocateTransact
     h *= 749572633U;
     h %= 24593209U;
     for (size_t i = 0; i < sizeof(tx->transactionId) - 3; i += 2) {
-        snprintf(tx->transactionId + i, 3, "%02X", (uint8_t)h);
+        snprintf(txId + i, 3, "%02X", (uint8_t)h);
         h *= 749572633U;
         h %= 24593209U;
     }
 
+    //clean possible aborted tx
+    unsigned int txr = txNrEnd;
+    unsigned int txSize = (txNrEnd + MAX_TX_CNT - txNrBegin) % MAX_TX_CNT;
+    for (unsigned int i = 0; i < txSize; i++) {
+        txr = (txr + MAX_TX_CNT - 1) % MAX_TX_CNT; //decrement by 1
+
+        std::unique_ptr<Ocpp201::Transaction> intermediateTx;
+
+        Ocpp201::Transaction *txhist = nullptr;
+        if (transaction && transaction->txNr == txr) {
+            txhist = transaction.get();
+        } else if (txFront && txFront->txNr == txr) {
+            txhist = txFront;
+        } else {
+            intermediateTx = txStore.loadTransaction(txr);
+            txhist = intermediateTx.get();
+        }
+
+        //check if dangling silent tx, aborted tx, or corrupted entry (txhist == null)
+        if (!txhist || txhist->silent || (!txhist->active && !txhist->started && MO_TX_CLEAN_ABORTED)) {
+            //yes, remove
+            if (txStore.remove(txr)) {
+                if (txNrFront == txNrEnd) {
+                    txNrFront = txr;
+                }
+                txNrEnd = txr;
+                MO_DBG_WARN("deleted dangling silent or aborted tx for new transaction");
+            } else {
+                MO_DBG_ERR("memory corruption");
+                break;
+            }
+        } else {
+            //no, tx record trimmed, end
+            break;
+        }
+    }
+
+    txSize = (txNrEnd + MAX_TX_CNT - txNrBegin) % MAX_TX_CNT; //refresh after cleaning txs
+
+    //try to create new transaction
+    if (txSize < MO_TXRECORD_SIZE) {
+        tx = txStore.createTransaction(txNrEnd, txId);
+    }
+
+    if (!tx) {
+        //could not create transaction - now, try to replace tx history entry
+
+        unsigned int txl = txNrBegin;
+        txSize = (txNrEnd + MAX_TX_CNT - txNrBegin) % MAX_TX_CNT;
+
+        for (unsigned int i = 0; i < txSize; i++) {
+
+            if (tx) {
+                //success, finished here
+                break;
+            }
+
+            //no transaction allocated, delete history entry to make space
+            std::unique_ptr<Ocpp201::Transaction> intermediateTx;
+
+            Ocpp201::Transaction *txhist = nullptr;
+            if (transaction && transaction->txNr == txl) {
+                txhist = transaction.get();
+            } else if (txFront && txFront->txNr == txl) {
+                txhist = txFront;
+            } else {
+                intermediateTx = txStore.loadTransaction(txl);
+                txhist = intermediateTx.get();
+            }
+
+            //oldest entry, now check if it's history and can be removed or corrupted entry
+            if (!txhist || (txhist->stopped && txhist->seqNos.empty()) || (!txhist->active && !txhist->started) || (txhist->silent && txhist->stopped)) {
+                //yes, remove
+
+                if (txStore.remove(txl)) {
+                    txNrBegin = (txl + 1) % MAX_TX_CNT;
+                    if (txNrFront == txl) {
+                        txNrFront = txNrBegin;
+                    }
+                    MO_DBG_DEBUG("deleted tx history entry for new transaction");
+                    MO_DBG_VERBOSE("txNrBegin=%u, txNrFront=%u, txNrEnd=%u", txNrBegin, txNrFront, txNrEnd);
+
+                    tx = txStore.createTransaction(txNrEnd, txId);
+                } else {
+                    MO_DBG_ERR("memory corruption");
+                    break;
+                }
+            } else {
+                //no, end of history reached, don't delete further tx
+                MO_DBG_DEBUG("cannot delete more tx");
+                break;
+            }
+
+            txl++;
+            txl %= MAX_TX_CNT;
+        }
+    }
+
+    if (!tx) {
+        //couldn't create normal transaction -> check if to start charging without real transaction
+        if (txService.silentOfflineTransactionsBool && txService.silentOfflineTransactionsBool->getBool()) {
+            //try to handle charging session without sending StartTx or StopTx to the server
+            tx = txStore.createTransaction(txNrEnd, txId);
+
+            if (tx) {
+                tx->silent = true;
+                MO_DBG_DEBUG("created silent transaction");
+            }
+        }
+    }
+
+    if (!tx) {
+        MO_DBG_ERR("transaction queue full");
+        return false;
+    }
+
     tx->beginTimestamp = context.getModel().getClock().now();
 
-    MO_DBG_DEBUG("allocated tx %u-%s", evseId, tx->transactionId);
+    if (!txStore.commit(tx.get())) {
+        MO_DBG_ERR("fs error");
+        return false;
+    }
 
-    return tx;
+    transaction = std::move(tx);
+
+    txNrEnd = (txNrEnd + 1) % MAX_TX_CNT;
+    MO_DBG_DEBUG("advance txNrEnd %u-%u", evseId, txNrEnd);
+    MO_DBG_VERBOSE("txNrBegin=%u, txNrFront=%u, txNrEnd=%u", txNrBegin, txNrFront, txNrEnd);
+
+    return true;
+}
+
+bool TransactionService::Evse::endTransaction(Ocpp201::Transaction::StoppedReason stoppedReason = Ocpp201::Transaction::StoppedReason::Other, Ocpp201::TransactionEventTriggerReason stopTrigger = Ocpp201::TransactionEventTriggerReason::AbnormalCondition) {
+
+    if (!transaction || !transaction->active) {
+        //transaction already ended / not active anymore
+        return false;
+    }
+
+    MO_DBG_DEBUG("End transaction started by idTag %s",
+                            transaction->idToken.get());
+
+    transaction->active = false;
+    transaction->stopTrigger = stopTrigger;
+    transaction->stoppedReason = stoppedReason;
+    txStore.commit(transaction.get());
+
+    return true;
 }
 
 void TransactionService::Evse::loop() {
 
     if (transaction && !transaction->active && !transaction->started) {
         MO_DBG_DEBUG("collect aborted transaction %u-%s", evseId, transaction->transactionId);
+        if (txFront == transaction.get()) {
+            MO_DBG_DEBUG("pass ownership from tx to txFront");
+            txFrontCache = std::move(transaction);
+        }
         transaction = nullptr;
     }
 
     if (transaction && transaction->stopped) {
         MO_DBG_DEBUG("collect obsolete transaction %u-%s", evseId, transaction->transactionId);
+        if (txFront == transaction.get()) {
+            MO_DBG_DEBUG("pass ownership from tx to txFront");
+            txFrontCache = std::move(transaction);
+        }
         transaction = nullptr;
     }
 
@@ -88,9 +256,7 @@ void TransactionService::Evse::loop() {
                     context.getModel().getClock().now() - transaction->beginTimestamp >= txService.evConnectionTimeOutInt->getInt()) {
 
                 MO_DBG_INFO("Session mngt: timeout");
-                transaction->active = false;
-                transaction->stopTrigger = TransactionEventTriggerReason::EVConnectTimeout;
-                transaction->stopReason = Ocpp201::Transaction::StopReason::Timeout;
+                endTransaction(Ocpp201::Transaction::StoppedReason::Timeout, TransactionEventTriggerReason::EVConnectTimeout);
             }
 
             if (transaction->active &&
@@ -100,15 +266,12 @@ void TransactionService::Evse::loop() {
                      txService.isTxStopPoint(TxStartStopPoint::Authorized)  || txService.isTxStopPoint(TxStartStopPoint::PowerPathClosed))) {
                 
                 MO_DBG_INFO("Session mngt: Deauthorized before start");
-                transaction->active = false;
-                transaction->stopTrigger = TransactionEventTriggerReason::Deauthorized;
-                transaction->stopReason = Ocpp201::Transaction::StopReason::DeAuthorized;
+                endTransaction(Ocpp201::Transaction::StoppedReason::DeAuthorized, TransactionEventTriggerReason::Deauthorized);
             }
         }
     }
 
-
-    std::shared_ptr<TransactionEventData> txEvent;
+    std::unique_ptr<TransactionEventData> txEvent;
 
     bool txStopCondition = false;
 
@@ -116,55 +279,53 @@ void TransactionService::Evse::loop() {
         // stop tx?
 
         TransactionEventTriggerReason triggerReason = TransactionEventTriggerReason::UNDEFINED;
-        Ocpp201::Transaction::StopReason stopReason = Ocpp201::Transaction::StopReason::UNDEFINED;
+        Ocpp201::Transaction::StoppedReason stoppedReason = Ocpp201::Transaction::StoppedReason::UNDEFINED;
 
         if (transaction && !transaction->active) {
             // tx ended via endTransaction
             txStopCondition = true;
             triggerReason = transaction->stopTrigger;
-            stopReason = transaction->stopReason;
+            stoppedReason = transaction->stoppedReason;
         } else if ((txService.isTxStopPoint(TxStartStopPoint::EVConnected) ||
                     txService.isTxStopPoint(TxStartStopPoint::PowerPathClosed)) &&
                     connectorPluggedInput && !connectorPluggedInput() &&
                     (txService.stopTxOnEVSideDisconnectBool->getBool() || !transaction || !transaction->started)) {
             txStopCondition = true;
             triggerReason = TransactionEventTriggerReason::EVCommunicationLost;
-            stopReason = Ocpp201::Transaction::StopReason::EVDisconnected;
+            stoppedReason = Ocpp201::Transaction::StoppedReason::EVDisconnected;
         } else if ((txService.isTxStopPoint(TxStartStopPoint::Authorized) ||
                     txService.isTxStopPoint(TxStartStopPoint::PowerPathClosed)) &&
                     (!transaction || !transaction->isAuthorizationActive)) {
             // user revoked authorization (or EV or any "local" entity)
             txStopCondition = true;
             triggerReason = TransactionEventTriggerReason::StopAuthorized;
-            stopReason = Ocpp201::Transaction::StopReason::Local;
+            stoppedReason = Ocpp201::Transaction::StoppedReason::Local;
         } else if (txService.isTxStopPoint(TxStartStopPoint::EnergyTransfer) &&
                     evReadyInput && !evReadyInput()) {
             txStopCondition = true;
             triggerReason = TransactionEventTriggerReason::ChargingStateChanged;
-            stopReason = Ocpp201::Transaction::StopReason::StoppedByEV;
+            stoppedReason = Ocpp201::Transaction::StoppedReason::StoppedByEV;
         } else if (txService.isTxStopPoint(TxStartStopPoint::EnergyTransfer) &&
                     (evReadyInput || evseReadyInput) && // at least one of the two defined
                     !(evReadyInput && evReadyInput()) &&
                     !(evseReadyInput && evseReadyInput())) {
             txStopCondition = true;
             triggerReason = TransactionEventTriggerReason::ChargingStateChanged;
-            stopReason = Ocpp201::Transaction::StopReason::Other;
+            stoppedReason = Ocpp201::Transaction::StoppedReason::Other;
         } else if (txService.isTxStopPoint(TxStartStopPoint::Authorized) &&
                     transaction && transaction->isDeauthorized &&
                     txService.stopTxOnInvalidIdBool->getBool()) {
             // OCPP server rejected authorization
             txStopCondition = true;
             triggerReason = TransactionEventTriggerReason::Deauthorized;
-            stopReason = Ocpp201::Transaction::StopReason::DeAuthorized;
+            stoppedReason = Ocpp201::Transaction::StoppedReason::DeAuthorized;
         }
 
         if (txStopCondition &&
                 transaction && transaction->started && transaction->active) {
 
             MO_DBG_INFO("Session mngt: TxStopPoint reached");
-            transaction->active = false;
-            transaction->stopTrigger = triggerReason;
-            transaction->stopReason = stopReason;
+            endTransaction(stoppedReason, triggerReason);
         }
 
         if (transaction &&
@@ -172,14 +333,14 @@ void TransactionService::Evse::loop() {
                 (!stopTxReadyInput || stopTxReadyInput())) {
             // yes, stop running tx
 
-            txEvent = std::allocate_shared<TransactionEventData>(makeAllocator<TransactionEventData>(getMemoryTag()), transaction, transaction->seqNoCounter++);
+            txEvent = txStore.createTransactionEvent(*transaction);
             if (!txEvent) {
                 // OOM
                 return;
             }
 
             transaction->stopTrigger = triggerReason;
-            transaction->stopReason = stopReason;
+            transaction->stoppedReason = stoppedReason;
 
             txEvent->eventType = TransactionEventData::Type::Ended;
             txEvent->triggerReason = triggerReason;
@@ -229,7 +390,7 @@ void TransactionService::Evse::loop() {
             // start tx
 
             if (!transaction) {
-                transaction = allocateTransaction();
+                beginTransaction();
                 if (!transaction) {
                     // OOM
                     return;
@@ -239,7 +400,7 @@ void TransactionService::Evse::loop() {
                 }
             }
 
-            txEvent = std::allocate_shared<TransactionEventData>(makeAllocator<TransactionEventData>(getMemoryTag()), transaction, transaction->seqNoCounter++);
+            txEvent = txStore.createTransactionEvent(*transaction);
             if (!txEvent) {
                 // OOM
                 return;
@@ -334,7 +495,7 @@ void TransactionService::Evse::loop() {
         if (txUpdateCondition && !txEvent && transaction->started && !transaction->stopped) {
             // yes, updated
 
-            txEvent = std::allocate_shared<TransactionEventData>(makeAllocator<TransactionEventData>(getMemoryTag()), transaction, transaction->seqNoCounter++);
+            txEvent = txStore.createTransactionEvent(*transaction);
             if (!txEvent) {
                 // OOM
                 return;
@@ -395,15 +556,35 @@ void TransactionService::Evse::loop() {
     }
 
     if (txEvent) {
-        auto txEventRequest = makeRequest(new Ocpp201::TransactionEvent(context.getModel(), txEvent));
-        txEventRequest->setTimeout(0);
-        context.initiateRequest(std::move(txEventRequest));
-
         if (txEvent->eventType == TransactionEventData::Type::Started) {
             transaction->started = true;
         } else if (txEvent->eventType == TransactionEventData::Type::Ended) {
             transaction->stopped = true;
         }
+    }
+
+    if (txEvent) {
+        txEvent->opNr = context.getRequestQueue().getNextOpNr();
+        MO_DBG_DEBUG("enqueueing new txEvent at opNr %u", txEvent->opNr);
+    }
+
+    if (txEvent) {
+        txStore.commit(txEvent.get());
+    }
+
+    //try to pass ownership to front txEvent immediatley
+    if (txEvent && !txEventFront &&
+            transaction->txNr == txNrFront &&
+            !transaction->seqNos.empty() && transaction->seqNos.front() == txEvent->seqNo) {
+
+        //txFront set up?
+        if (!txFront) {
+            txFront = transaction.get();
+        }
+
+        //keep txEvent loaded (otherwise ReqEmitter would load it again from flash)
+        MO_DBG_DEBUG("new txEvent is front element");
+        txEventFront = std::move(txEvent);
     }
 }
 
@@ -428,7 +609,7 @@ bool TransactionService::Evse::beginAuthorization(IdToken idToken, bool validate
     }
 
     if (!transaction) {
-        transaction = allocateTransaction();
+        beginTransaction();
         if (!transaction) {
             MO_DBG_ERR("could not allocate Tx");
             return false;
@@ -442,8 +623,6 @@ bool TransactionService::Evse::beginAuthorization(IdToken idToken, bool validate
     transaction->idToken = idToken;
     transaction->beginTimestamp = context.getModel().getClock().now();
 
-    auto tx = transaction;
-
     if (validateIdToken) {
         auto authorize = makeRequest(new Authorize(context.getModel(), idToken));
         if (!authorize) {
@@ -452,27 +631,45 @@ bool TransactionService::Evse::beginAuthorization(IdToken idToken, bool validate
             return false;
         }
 
-        authorize->setOnReceiveConfListener([this, tx] (JsonObject response) {
+        char txId [sizeof(transaction->transactionId)]; //capture txId to check if transaction reference is still the same
+        snprintf(txId, sizeof(txId), "%s", transaction->transactionId);
+
+        authorize->setOnReceiveConfListener([this, txId] (JsonObject response) {
+            auto tx = getTransaction();
+            if (!tx || strcmp(tx->transactionId, txId)) {
+                MO_DBG_INFO("dangling Authorize -- discard");
+                return;
+            }
+
             if (strcmp(response["idTokenInfo"]["status"] | "_Undefined", "Accepted")) {
                 MO_DBG_DEBUG("Authorize rejected (%s), abort tx process", tx->idToken.get());
                 tx->isDeauthorized = true;
+                txStore.commit(tx);
                 return;
             }
 
             MO_DBG_DEBUG("Authorized tx with validation (%s)", tx->idToken.get());
             tx->isAuthorized = true;
             tx->notifyIdToken = true;
+            txStore.commit(tx);
         });
-        authorize->setOnAbortListener([this, tx] () {
+        authorize->setOnAbortListener([this, txId] () {
+            auto tx = getTransaction();
+            if (!tx || strcmp(tx->transactionId, txId)) {
+                MO_DBG_INFO("dangling Authorize -- discard");
+                return;
+            }
+
             MO_DBG_DEBUG("Authorize timeout (%s)", tx->idToken.get());
             tx->isDeauthorized = true;
+            txStore.commit(tx);
         });
         authorize->setTimeout(20 * 1000);
         context.initiateRequest(std::move(authorize));
     } else {
-        MO_DBG_DEBUG("Authorized tx directly (%s)", tx->idToken.get());
-        tx->isAuthorized = true;
-        tx->notifyIdToken = true;
+        MO_DBG_DEBUG("Authorized tx directly (%s)", transaction->idToken.get());
+        transaction->isAuthorized = true;
+        transaction->notifyIdToken = true;
     }
 
     return true;
@@ -498,8 +695,6 @@ bool TransactionService::Evse::endAuthorization(IdToken idToken, bool validateId
     } else {
         // use a different idToken for stopping the tx
 
-        auto tx = transaction;
-
         auto authorize = makeRequest(new Authorize(context.getModel(), idToken));
         if (!authorize) {
             // OOM
@@ -507,7 +702,16 @@ bool TransactionService::Evse::endAuthorization(IdToken idToken, bool validateId
             return false;
         }
 
-        authorize->setOnReceiveConfListener([tx, idToken, this] (JsonObject response) {
+        char txId [sizeof(transaction->transactionId)]; //capture txId to check if transaction reference is still the same
+        snprintf(txId, sizeof(txId), "%s", transaction->transactionId);
+
+        authorize->setOnReceiveConfListener([this, txId, idToken] (JsonObject response) {
+            auto tx = getTransaction();
+            if (!tx || strcmp(tx->transactionId, txId)) {
+                MO_DBG_INFO("dangling Authorize -- discard");
+                return;
+            }
+
             if (strcmp(response["idTokenInfo"]["status"] | "_Undefined", "Accepted")) {
                 MO_DBG_DEBUG("Authorize rejected (%s), don't stop tx", idToken.get());
                 return;
@@ -519,15 +723,14 @@ bool TransactionService::Evse::endAuthorization(IdToken idToken, bool validateId
             if (!tx->stopIdToken) {
                 // OOM
                 if (tx->active) {
-                    tx->active = false;
-                    tx->stopTrigger = TransactionEventTriggerReason::AbnormalCondition;
-                    tx->stopReason = Ocpp201::Transaction::StopReason::Other;
+                    abortTransaction();
                 }
                 return;
             }
 
             tx->isAuthorizationActive = false;
             tx->notifyStopIdToken = true;
+            txStore.commit(tx);
         });
         authorize->setTimeout(20 * 1000);
         context.initiateRequest(std::move(authorize));
@@ -535,24 +738,11 @@ bool TransactionService::Evse::endAuthorization(IdToken idToken, bool validateId
 
     return true;
 }
-bool TransactionService::Evse::abortTransaction(Ocpp201::Transaction::StopReason stopReason, TransactionEventTriggerReason stopTrigger) {
-
-    if (!transaction || !transaction->active) {
-        //transaction already ended / not active anymore
-        return false;
-    }
-
-    MO_DBG_DEBUG("Abort session started by idTag %s",
-                            transaction->idToken.get());
-
-    transaction->active = false;
-    transaction->stopTrigger = stopTrigger;
-    transaction->stopReason = stopReason;
-
-    return true;
+bool TransactionService::Evse::abortTransaction(Ocpp201::Transaction::StoppedReason stoppedReason, TransactionEventTriggerReason stopTrigger) {
+    return endTransaction(stoppedReason, stopTrigger);
 }
-std::shared_ptr<MicroOcpp::Ocpp201::Transaction>& TransactionService::Evse::getTransaction() {
-    return transaction;
+MicroOcpp::Ocpp201::Transaction *TransactionService::Evse::getTransaction() {
+    return transaction.get();
 }
 
 bool TransactionService::Evse::ocppPermitsCharge() {
@@ -561,6 +751,142 @@ bool TransactionService::Evse::ocppPermitsCharge() {
            transaction->isAuthorizationActive &&
            transaction->isAuthorized &&
            !transaction->isDeauthorized;
+}
+
+unsigned int TransactionService::Evse::getFrontRequestOpNr() {
+
+    if (txEventFront) {
+        return txEventFront->opNr;
+    }
+
+    /*
+     * Advance front transaction?
+     */
+
+    unsigned int txSize = (txNrEnd + MAX_TX_CNT - txNrFront) % MAX_TX_CNT;
+
+    if (txFront && txSize == 0) {
+        //catch edge case where txBack has been rolled back and txFront was equal to txBack
+        MO_DBG_DEBUG("collect front transaction %u-%u after tx rollback", evseId, txFront->txNr);
+        MO_DBG_VERBOSE("txNrBegin=%u, txNrFront=%u, txNrEnd=%u", txNrBegin, txNrFront, txNrEnd);
+        txEventFront = nullptr;
+        txFrontCache = nullptr;
+        txFront = nullptr;
+    }
+
+    for (unsigned int i = 0; i < txSize; i++) {
+
+        if (!txFront) {
+            if (transaction && transaction->txNr == txNrFront) {
+                txFront = transaction.get();
+            } else {
+                txFrontCache = txStore.loadTransaction(txNrFront);
+                txFront = txFrontCache.get();
+            }
+
+            if (txFront) {
+                MO_DBG_DEBUG("load front transaction %u-%u", evseId, txFront->txNr);
+                (void)0;
+            }
+        }
+
+        if (!txFront || (txFront && ((!txFront->active && !txFront->started) || (txFront->stopped && txFront->seqNos.empty()) || txFront->silent))) {
+            //advance front
+            MO_DBG_DEBUG("collect front transaction %u-%u", evseId, txNrFront);
+            txEventFront = nullptr;
+            txFrontCache = nullptr;
+            txFront = nullptr;
+            txNrFront = (txNrFront + 1) % MAX_TX_CNT;
+            MO_DBG_VERBOSE("txNrBegin=%u, txNrFront=%u, txNrEnd=%u", txNrBegin, txNrFront, txNrEnd);
+        } else {
+            //front is accurate. Done here
+            break;
+        }
+    }
+
+    if (txFront && !txFront->seqNos.empty()) {
+        MO_DBG_DEBUG("load front txEvent %u-%u-%u from flash", evseId, txFront->txNr, txFront->seqNos.front());
+        txEventFront = txStore.loadTransactionEvent(*txFront, txFront->seqNos.front());
+    }
+
+    if (txEventFront) {
+        return txEventFront->opNr;
+    }
+
+    return NoOperation;
+}
+
+std::unique_ptr<Request> TransactionService::Evse::fetchFrontRequest() {
+
+    if (!txEventFront) {
+        return nullptr;
+    }
+
+    if (txFront && txFront->silent) {
+        return nullptr;
+    }
+
+    if (txEventFront->seqNo == 0 &&
+            txEventFront->timestamp < MIN_TIME &&
+            txEventFront->bootNr != context.getModel().getBootNr()) {
+        //time not set, cannot be restored anymore -> invalid tx
+        MO_DBG_ERR("cannot recover tx from previous power cycle");
+
+        txFront->silent = true;
+        txFront->active = false;
+        txStore.commit(txFront);
+
+        //clean txEvents early
+        auto seqNos = txFront->seqNos;
+        for (size_t i = 0; i < seqNos.size(); i++) {
+            txStore.remove(*txFront, seqNos[i]);
+        }
+        //last remove should keep tx201 file with only tx record and without txEvent
+
+        //next getFrontRequestOpNr() call will collect txFront
+        return nullptr;
+    }
+
+    if ((int)txEventFront->attemptNr >= txService.messageAttemptsTransactionEventInt->getInt()) {
+        MO_DBG_WARN("exceeded TransactionMessageAttempts. Discard txEvent");
+
+        txStore.remove(*txFront, txEventFront->seqNo);
+        txEventFront = nullptr;
+        return nullptr;
+    }
+
+    Timestamp nextAttempt = txEventFront->attemptTime +
+                            txEventFront->attemptNr * std::max(0, txService.messageAttemptIntervalTransactionEventInt->getInt());
+
+    if (nextAttempt > context.getModel().getClock().now()) {
+        return nullptr;
+    }
+
+    if (txEventFrontIsRequested) {
+        //ensure that only one TransactionEvent request is being executed at the same time
+        return nullptr;
+    }
+
+    txEventFront->attemptNr++;
+    txEventFront->attemptTime = context.getModel().getClock().now();
+    txStore.commit(txEventFront.get());
+
+    auto txEventRequest = makeRequest(new TransactionEvent(context.getModel(), txEventFront.get()));
+    txEventRequest->setOnReceiveConfListener([this] (JsonObject) {
+        MO_DBG_DEBUG("completed front txEvent");
+        txStore.remove(*txFront, txEventFront->seqNo);
+        txEventFront = nullptr;
+        txEventFrontIsRequested = false;
+    });
+    txEventRequest->setOnAbortListener([this] () {
+        MO_DBG_DEBUG("unsuccessful front txEvent");
+        txEventFrontIsRequested = false;
+    });
+    txEventRequest->setTimeout(std::min(20, std::max(5, txService.messageAttemptIntervalTransactionEventInt->getInt())) * 1000);
+
+    txEventFrontIsRequested = true;
+
+    return txEventRequest;
 }
 
 bool TransactionService::isTxStartPoint(TxStartStopPoint check) {
@@ -643,10 +969,10 @@ bool validateUnsignedInt(int val, void*) {
 
 using namespace MicroOcpp;
 
-TransactionService::TransactionService(Context& context) :
+TransactionService::TransactionService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem, unsigned int numEvseIds) :
         MemoryManaged("v201.Transactions.TransactionService"),
         context(context),
-        evses(makeVector<Evse>(getMemoryTag())),
+        txStore(filesystem, numEvseIds),
         txStartPointParsed(makeVector<TxStartStopPoint>(getMemoryTag())),
         txStopPointParsed(makeVector<TxStartStopPoint>(getMemoryTag())) {
     auto varService = context.getModel().getVariableService();
@@ -658,6 +984,9 @@ TransactionService::TransactionService(Context& context) :
     evConnectionTimeOutInt = varService->declareVariable<int>("TxCtrlr", "EVConnectionTimeOut", 30);
     sampledDataTxUpdatedInterval = varService->declareVariable<int>("SampledDataCtrlr", "TxUpdatedInterval", 0);
     sampledDataTxEndedInterval = varService->declareVariable<int>("SampledDataCtrlr", "TxEndedInterval", 0);
+    messageAttemptsTransactionEventInt = varService->declareVariable<int>("OCPPCommCtrlr", "MessageAttempts", 3);
+    messageAttemptIntervalTransactionEventInt = varService->declareVariable<int>("OCPPCommCtrlr", "MessageAttemptInterval", 60);
+    silentOfflineTransactionsBool = varService->declareVariable<bool>("CustomizationCtrlr", "SilentOfflineTransactions", false);
 
     varService->declareVariable<bool>("AuthCtrlr", "AuthorizeRemoteStart", false, Variable::Mutability::ReadOnly, false);
 
@@ -666,21 +995,25 @@ TransactionService::TransactionService(Context& context) :
     varService->registerValidator<int>("SampledDataCtrlr", "TxUpdatedInterval", validateUnsignedInt);
     varService->registerValidator<int>("SampledDataCtrlr", "TxEndedInterval", validateUnsignedInt);
 
-    evses.reserve(MO_NUM_EVSEID);
-
-    for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID; evseId++) {
-        evses.emplace_back(context, *this, evseId);
+    for (unsigned int evseId = 0; evseId < std::min(numEvseIds, (unsigned int)MO_NUM_EVSEID); evseId++) {
+        if (!txStore.getEvse(evseId)) {
+            MO_DBG_ERR("initialization error");
+            break;
+        }
+        evses[evseId] = new Evse(context, *this, *txStore.getEvse(evseId), evseId);
     }
 
     //make sure EVSE 0 will only trigger transactions if TxStartPoint is Authorized
-    evses[0].connectorPluggedInput = [] () {return false;};
-    evses[0].evReadyInput = [] () {return false;};
-    evses[0].evseReadyInput = [] () {return false;};
+    if (evses[0]) {
+        evses[0]->connectorPluggedInput = [] () {return false;};
+        evses[0]->evReadyInput = [] () {return false;};
+        evses[0]->evseReadyInput = [] () {return false;};
+    }
 }
 
 void TransactionService::loop() {
-    for (Evse& evse : evses) {
-        evse.loop();
+    for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID && evses[evseId]; evseId++) {
+        evses[evseId]->loop();
     }
 
     if (txStartPointString->getWriteCount() != trackTxStartPoint) {
@@ -692,15 +1025,16 @@ void TransactionService::loop() {
     }
 
     // assign tx on evseId 0 to an EVSE
-    if (auto& tx0 = evses[0].getTransaction()) {
+    if (evses[0]->transaction) {
         //pending tx on evseId 0
-        if (tx0->active) {
-            for (unsigned int evseId = 1; evseId < MO_NUM_EVSEID; evseId++) {
-                if (!evses[evseId].getTransaction() && 
-                        (!evses[evseId].connectorPluggedInput || evses[evseId].connectorPluggedInput())) {
+        if (evses[0]->transaction->active) {
+            for (unsigned int evseId = 1; evseId < MO_NUM_EVSEID && evses[evseId]; evseId++) {
+                if (!evses[evseId]->getTransaction() && 
+                        (!evses[evseId]->connectorPluggedInput || evses[evseId]->connectorPluggedInput())) {
                     MO_DBG_INFO("assign tx to evse %u", evseId);
-                    tx0->notifyEvseId = true;
-                    evses[evseId].transaction = std::move(tx0);
+                    evses[0]->transaction->notifyEvseId = true;
+                    evses[0]->transaction->evseId = evseId;
+                    evses[evseId]->transaction = std::move(evses[0]->transaction);
                 }
             }
         }
@@ -708,12 +1042,10 @@ void TransactionService::loop() {
 }
 
 TransactionService::Evse *TransactionService::getEvse(unsigned int evseId) {
-    if (evseId < evses.size()) {
-        return &evses[evseId];
-    } else {
-        MO_DBG_ERR("invalid arg");
+    if (evseId >= MO_NUM_EVSEID) {
         return nullptr;
     }
+    return evses[evseId];
 }
 
 #endif // MO_ENABLE_V201

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -14,27 +14,35 @@
 #if MO_ENABLE_V201
 
 #include <MicroOcpp/Model/Transactions/Transaction.h>
+#include <MicroOcpp/Model/Transactions/TransactionStore.h>
 #include <MicroOcpp/Model/Metering/MeterValuesV201.h>
+#include <MicroOcpp/Core/RequestQueue.h>
 #include <MicroOcpp/Core/Memory.h>
 
 #include <memory>
 #include <functional>
 
+#ifndef MO_TXRECORD_SIZE_V201
+#define MO_TXRECORD_SIZE_V201 4 //maximum number of tx to hold on flash storage
+#endif
+
 namespace MicroOcpp {
 
 class Context;
+class FilesystemAdapter;
 class Variable;
 
 class TransactionService : public MemoryManaged {
 public:
 
-    class Evse : public MemoryManaged {
+    class Evse : public RequestEmitter, public MemoryManaged {
     private:
         Context& context;
         TransactionService& txService;
+        Ocpp201::TransactionStoreEvse& txStore;
         const unsigned int evseId;
         unsigned int txNrCounter = 0;
-        std::shared_ptr<Ocpp201::Transaction> transaction;
+        std::unique_ptr<Ocpp201::Transaction> transaction;
         Ocpp201::TransactionEventData::ChargingState trackChargingState = Ocpp201::TransactionEventData::ChargingState::UNDEFINED;
 
         std::function<bool()> connectorPluggedInput;
@@ -44,10 +52,20 @@ public:
         std::function<bool()> startTxReadyInput;
         std::function<bool()> stopTxReadyInput;
 
-        std::unique_ptr<Ocpp201::Transaction> allocateTransaction();
+        bool beginTransaction();
+        bool endTransaction(Ocpp201::Transaction::StoppedReason stoppedReason, Ocpp201::TransactionEventTriggerReason stopTrigger);
+
+        unsigned int txNrBegin = 0; //oldest (historical) transaction on flash. Has no function, but is useful for error diagnosis
+        unsigned int txNrFront = 0; //oldest transaction which is still queued to be sent to the server
+        unsigned int txNrEnd = 0; //one position behind newest transaction
+
+        Ocpp201::Transaction *txFront = nullptr;
+        std::unique_ptr<Ocpp201::Transaction> txFrontCache; //helper owner for txFront. Empty if txFront == transaction.get()
+        std::unique_ptr<Ocpp201::TransactionEventData> txEventFront;
+        bool txEventFrontIsRequested = false;
 
     public:
-        Evse(Context& context, TransactionService& txService, unsigned int evseId);
+        Evse(Context& context, TransactionService& txService, Ocpp201::TransactionStoreEvse& txStore, unsigned int evseId);
 
         void loop();
 
@@ -56,14 +74,17 @@ public:
         void setEvseReadyInput(std::function<bool()> connectorEnergized);
 
         bool beginAuthorization(IdToken idToken, bool validateIdToken = true); // authorize by swipe RFID
-        bool endAuthorization(IdToken idToken = IdToken(), bool validateIdToken = true); // stop authorization by swipe RFID
+        bool endAuthorization(IdToken idToken = IdToken(), bool validateIdToken = false); // stop authorization by swipe RFID
 
         // stop transaction, but neither upon user request nor OCPP server request (e.g. after PowerLoss)
-        bool abortTransaction(Ocpp201::Transaction::StopReason stopReason = Ocpp201::Transaction::StopReason::Other, Ocpp201::TransactionEventTriggerReason stopTrigger = Ocpp201::TransactionEventTriggerReason::AbnormalCondition);
+        bool abortTransaction(Ocpp201::Transaction::StoppedReason stoppedReason = Ocpp201::Transaction::StoppedReason::Other, Ocpp201::TransactionEventTriggerReason stopTrigger = Ocpp201::TransactionEventTriggerReason::AbnormalCondition);
 
-        std::shared_ptr<Ocpp201::Transaction>& getTransaction();
+        Ocpp201::Transaction *getTransaction();
 
         bool ocppPermitsCharge();
+
+        unsigned int getFrontRequestOpNr() override;
+        std::unique_ptr<Request> fetchFrontRequest() override;
 
         friend TransactionService;
     };
@@ -80,7 +101,8 @@ public:
 
 private:
     Context& context;
-    Vector<Evse> evses;
+    Ocpp201::TransactionStore txStore;
+    Evse *evses [MO_NUM_EVSEID] = {nullptr};
 
     Variable *txStartPointString = nullptr;
     Variable *txStopPointString = nullptr;
@@ -89,6 +111,9 @@ private:
     Variable *evConnectionTimeOutInt = nullptr;
     Variable *sampledDataTxUpdatedInterval = nullptr;
     Variable *sampledDataTxEndedInterval = nullptr;
+    Variable *messageAttemptsTransactionEventInt = nullptr;
+    Variable *messageAttemptIntervalTransactionEventInt = nullptr;
+    Variable *silentOfflineTransactionsBool = nullptr;
     uint16_t trackTxStartPoint = -1;
     uint16_t trackTxStopPoint = -1;
     Vector<TxStartStopPoint> txStartPointParsed;
@@ -96,7 +121,7 @@ private:
     bool isTxStartPoint(TxStartStopPoint check);
     bool isTxStopPoint(TxStartStopPoint check);
 public:
-    TransactionService(Context& context);
+    TransactionService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem, unsigned int numEvseIds);
 
     void loop();
 

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -122,6 +122,7 @@ private:
     bool isTxStopPoint(TxStartStopPoint check);
 public:
     TransactionService(Context& context, std::shared_ptr<FilesystemAdapter> filesystem, unsigned int numEvseIds);
+    ~TransactionService();
 
     void loop();
 

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -68,8 +68,6 @@ public:
         friend TransactionService;
     };
 
-private:
-
     // TxStartStopPoint (2.6.4.1)
     enum class TxStartStopPoint : uint8_t {
         ParkingBayOccupancy,
@@ -80,6 +78,7 @@ private:
         EnergyTransfer
     };
 
+private:
     Context& context;
     Vector<Evse> evses;
 
@@ -96,15 +95,14 @@ private:
     Vector<TxStartStopPoint> txStopPointParsed;
     bool isTxStartPoint(TxStartStopPoint check);
     bool isTxStopPoint(TxStartStopPoint check);
-
-    bool parseTxStartStopPoint(const char *src, Vector<TxStartStopPoint>& dst);
-
 public:
     TransactionService(Context& context);
 
     void loop();
 
     Evse *getEvse(unsigned int evseId);
+
+    bool parseTxStartStopPoint(const char *src, Vector<TxStartStopPoint>& dst);
 };
 
 } // namespace MicroOcpp

--- a/src/MicroOcpp/Model/Transactions/TransactionService.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionService.h
@@ -66,6 +66,7 @@ public:
 
     public:
         Evse(Context& context, TransactionService& txService, Ocpp201::TransactionStoreEvse& txStore, unsigned int evseId);
+        virtual ~Evse();
 
         void loop();
 

--- a/src/MicroOcpp/Model/Transactions/TransactionStore.cpp
+++ b/src/MicroOcpp/Model/Transactions/TransactionStore.cpp
@@ -57,7 +57,7 @@ std::shared_ptr<Transaction> ConnectorTransactionStore::getTransaction(unsigned 
     }
 
     char fn [MO_MAX_PATH_SIZE] = {'\0'};
-    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.jsn", connectorId, txNr);
+    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.json", connectorId, txNr);
     if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
         MO_DBG_ERR("fn error: %i", ret);
         return nullptr;
@@ -130,7 +130,7 @@ bool ConnectorTransactionStore::commit(Transaction *transaction) {
     }
 
     char fn [MO_MAX_PATH_SIZE] = {'\0'};
-    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.jsn", connectorId, transaction->getTxNr());
+    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.json", connectorId, transaction->getTxNr());
     if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
         MO_DBG_ERR("fn error: %i", ret);
         return false;
@@ -159,7 +159,7 @@ bool ConnectorTransactionStore::remove(unsigned int txNr) {
     }
 
     char fn [MO_MAX_PATH_SIZE] = {'\0'};
-    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.jsn", connectorId, txNr);
+    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx" "-%u-%u.json", connectorId, txNr);
     if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
         MO_DBG_ERR("fn error: %i", ret);
         return false;
@@ -221,3 +221,889 @@ bool TransactionStore::remove(unsigned int connectorId, unsigned int txNr) {
     }
     return connectors[connectorId]->remove(txNr);
 }
+
+#if MO_ENABLE_V201
+
+#include <algorithm>
+
+namespace MicroOcpp {
+namespace Ocpp201 {
+
+bool TransactionStoreEvse::serializeTransaction(Transaction& tx, JsonObject txJson) {
+
+    if (tx.trackEvConnected) {
+        txJson["trackEvConnected"] = tx.trackEvConnected;
+    }
+
+    if (tx.trackAuthorized) {
+        txJson["trackAuthorized"] = tx.trackAuthorized;
+    }
+
+    if (tx.trackDataSigned) {
+        txJson["trackDataSigned"] = tx.trackDataSigned;
+    }
+
+    if (tx.trackPowerPathClosed) {
+        txJson["trackPowerPathClosed"] = tx.trackPowerPathClosed;
+    }
+
+    if (tx.trackEnergyTransfer) {
+        txJson["trackEnergyTransfer"] = tx.trackEnergyTransfer;
+    }
+
+    if (tx.active) {
+        txJson["active"] = true;
+    }
+    if (tx.started) {
+        txJson["started"] = true;
+    }
+    if (tx.stopped) {
+        txJson["stopped"] = true;
+    }
+
+    if (tx.isAuthorizationActive) {
+        txJson["isAuthorizationActive"] = true;
+    }
+    if (tx.isAuthorized) {
+        txJson["isAuthorized"] = true;
+    }
+    if (tx.isDeauthorized) {
+        txJson["isDeauthorized"] = true;
+    }
+
+    if (tx.idToken.get()) {
+        txJson["idToken"]["idToken"] = tx.idToken.get();
+        txJson["idToken"]["type"] = tx.idToken.getTypeCstr();
+    }
+
+    if (tx.beginTimestamp > MIN_TIME) {
+        char timeStr [JSONDATE_LENGTH + 1] = {'\0'};
+        tx.beginTimestamp.toJsonString(timeStr, JSONDATE_LENGTH + 1);
+        txJson["beginTimestamp"] = timeStr;
+    }
+
+    if (tx.remoteStartId >= 0) {
+        txJson["remoteStartId"] = tx.remoteStartId;
+    }
+
+    if (tx.evConnectionTimeoutListen) {
+        txJson["evConnectionTimeoutListen"] = true;
+    }
+
+    if (serializeTransactionStoppedReason(tx.stoppedReason)) { // optional
+        txJson["stoppedReason"] = serializeTransactionStoppedReason(tx.stoppedReason);
+    }
+
+    if (serializeTransactionEventTriggerReason(tx.stopTrigger)) {
+        txJson["stopTrigger"] = serializeTransactionEventTriggerReason(tx.stopTrigger);
+    }
+
+    if (tx.stopIdToken) {
+        JsonObject stopIdToken = txJson.createNestedObject("stopIdToken");
+        stopIdToken["idToken"] = tx.stopIdToken->get();
+        stopIdToken["type"] = tx.stopIdToken->getTypeCstr();
+    }
+
+    //sampledDataTxEnded not supported yet
+
+    if (tx.silent) {
+        txJson["silent"] = true;
+    }
+
+    txJson["txId"] = (const char*)tx.transactionId; //force zero-copy
+
+    return true;
+}
+
+bool TransactionStoreEvse::deserializeTransaction(Transaction& tx, JsonObject txJson) {
+
+    if (txJson.containsKey("trackEvConnected") && !txJson["trackEvConnected"].is<bool>()) {
+        return false;
+    }
+    tx.trackEvConnected = txJson["trackEvConnected"] | false;
+
+    if (txJson.containsKey("trackAuthorized") && !txJson["trackAuthorized"].is<bool>()) {
+        return false;
+    }
+    tx.trackAuthorized = txJson["trackAuthorized"] | false;
+
+    if (txJson.containsKey("trackDataSigned") && !txJson["trackDataSigned"].is<bool>()) {
+        return false;
+    }
+    tx.trackDataSigned = txJson["trackDataSigned"] | false;
+
+    if (txJson.containsKey("trackPowerPathClosed") && !txJson["trackPowerPathClosed"].is<bool>()) {
+        return false;
+    }
+    tx.trackPowerPathClosed = txJson["trackPowerPathClosed"] | false;
+
+    if (txJson.containsKey("trackEnergyTransfer") && !txJson["trackEnergyTransfer"].is<bool>()) {
+        return false;
+    }
+    tx.trackEnergyTransfer = txJson["trackEnergyTransfer"] | false;
+
+    if (txJson.containsKey("active") && !txJson["active"].is<bool>()) {
+        return false;
+    }
+    tx.active = txJson["active"] | false;
+    if (txJson.containsKey("started") && !txJson["started"].is<bool>()) {
+        return false;
+    }
+    tx.started = txJson["started"] | false;
+
+    if (txJson.containsKey("stopped") && !txJson["stopped"].is<bool>()) {
+        return false;
+    }
+    tx.stopped = txJson["stopped"] | false;
+
+    if (txJson.containsKey("isAuthorizationActive") && !txJson["isAuthorizationActive"].is<bool>()) {
+        return false;
+    }
+    tx.isAuthorizationActive = txJson["isAuthorizationActive"] | false;
+    if (txJson.containsKey("isAuthorized") && !txJson["isAuthorized"].is<bool>()) {
+        return false;
+    }
+    tx.isAuthorized = txJson["isAuthorized"] | false;
+
+    if (txJson.containsKey("isDeauthorized") && !txJson["isDeauthorized"].is<bool>()) {
+        return false;
+    }
+    tx.isDeauthorized = txJson["isDeauthorized"] | false;
+
+    if (txJson.containsKey("idToken")) {
+        IdToken idToken;
+        if (!idToken.parseCstr(
+                    txJson["idToken"]["idToken"] | (const char*)nullptr, 
+                    txJson["idToken"]["type"]    | (const char*)nullptr)) {
+            return false;
+        }
+        tx.idToken = idToken;
+    }
+
+    if (txJson.containsKey("beginTimestamp")) {
+        if (!tx.beginTimestamp.setTime(txJson["beginTimestamp"] | "_Undefined")) {
+            return false;
+        }
+    }
+
+    if (txJson.containsKey("remoteStartId")) {
+        int remoteStartIdIn = txJson["remoteStartId"] | -1;
+        if (remoteStartIdIn < 0) {
+            return false;
+        }
+        tx.remoteStartId = remoteStartIdIn;
+    }
+
+    if (txJson.containsKey("evConnectionTimeoutListen") && !txJson["evConnectionTimeoutListen"].is<bool>()) {
+        return false;
+    }
+    tx.evConnectionTimeoutListen = txJson["evConnectionTimeoutListen"] | false;
+
+    Transaction::StoppedReason stoppedReason;
+    if (!deserializeTransactionStoppedReason(txJson["stoppedReason"] | (const char*)nullptr, stoppedReason)) {
+        return false;
+    }
+    tx.stoppedReason = stoppedReason;
+
+    TransactionEventTriggerReason stopTrigger;
+    if (!deserializeTransactionEventTriggerReason(txJson["stopTrigger"] | (const char*)nullptr, stopTrigger)) {
+        return false;
+    }
+    tx.stopTrigger = stopTrigger;
+
+    if (txJson.containsKey("stopIdToken")) {
+        auto stopIdToken = std::unique_ptr<IdToken>(new IdToken());
+        if (!stopIdToken) {
+            MO_DBG_ERR("OOM");
+            return false;
+        }
+        if (!stopIdToken->parseCstr(
+                    txJson["stopIdToken"]["idToken"] | (const char*)nullptr, 
+                    txJson["stopIdToken"]["type"]    | (const char*)nullptr)) {
+            return false;
+        }
+        tx.stopIdToken = std::move(stopIdToken);
+    }
+
+    //sampledDataTxEnded not supported yet
+
+    if (auto txId = txJson["txId"] | (const char*)nullptr) {
+        auto ret = snprintf(tx.transactionId, sizeof(tx.transactionId), "%s", txId);
+        if (ret < 0 || (size_t)ret >= sizeof(tx.transactionId)) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    if (txJson.containsKey("silent") && !txJson["silent"].is<bool>()) {
+        return false;
+    }
+    tx.silent = txJson["silent"] | false;
+
+    return true;
+}
+
+bool TransactionStoreEvse::serializeTransactionEvent(TransactionEventData& txEvent, JsonObject txEventJson) {
+    
+    if (txEvent.eventType != TransactionEventData::Type::Updated) {
+        txEventJson["eventType"] = serializeTransactionEventType(txEvent.eventType);
+    }
+
+    if (txEvent.timestamp > MIN_TIME) {
+        char timeStr [JSONDATE_LENGTH + 1] = {'\0'};
+        txEvent.timestamp.toJsonString(timeStr, JSONDATE_LENGTH + 1);
+        txEventJson["timestamp"] = timeStr;
+    }
+
+    txEventJson["bootNr"] = txEvent.bootNr;
+
+    if (serializeTransactionEventTriggerReason(txEvent.triggerReason)) {
+        txEventJson["triggerReason"] = serializeTransactionEventTriggerReason(txEvent.triggerReason);
+    }
+    
+    if (txEvent.offline) {
+        txEventJson["offline"] = true;
+    }
+
+    if (txEvent.numberOfPhasesUsed >= 0) {
+        txEventJson["numberOfPhasesUsed"] = txEvent.numberOfPhasesUsed;
+    }
+
+    if (txEvent.cableMaxCurrent >= 0) {
+        txEventJson["cableMaxCurrent"] = txEvent.cableMaxCurrent;
+    }
+
+    if (txEvent.reservationId >= 0) {
+        txEventJson["reservationId"] = txEvent.reservationId;
+    }
+
+    if (txEvent.remoteStartId >= 0) {
+        txEventJson["remoteStartId"] = txEvent.remoteStartId;
+    }
+
+    if (serializeTransactionEventChargingState(txEvent.chargingState)) { // optional
+        txEventJson["chargingState"] = serializeTransactionEventChargingState(txEvent.chargingState);
+    }
+
+    if (txEvent.idToken) {
+        JsonObject idToken = txEventJson.createNestedObject("idToken");
+        idToken["idToken"] = txEvent.idToken->get();
+        idToken["type"] = txEvent.idToken->getTypeCstr();
+    }
+
+    if (txEvent.evse.id >= 0) {
+        JsonObject evse = txEventJson.createNestedObject("evse");
+        evse["id"] = txEvent.evse.id;
+        if (txEvent.evse.connectorId >= 0) {
+            evse["connectorId"] = txEvent.evse.connectorId;
+        }
+    }
+
+    //meterValue not supported yet
+
+    txEventJson["opNr"] = txEvent.opNr;
+    txEventJson["attemptNr"] = txEvent.attemptNr;
+    
+    if (txEvent.attemptTime > MIN_TIME) {
+        char timeStr [JSONDATE_LENGTH + 1] = {'\0'};
+        txEvent.attemptTime.toJsonString(timeStr, JSONDATE_LENGTH + 1);
+        txEventJson["attemptTime"] = timeStr;
+    }
+
+    return true;
+}
+
+bool TransactionStoreEvse::deserializeTransactionEvent(TransactionEventData& txEvent, JsonObject txEventJson) {
+
+    TransactionEventData::Type eventType;
+    if (!deserializeTransactionEventType(txEventJson["eventType"] | "_Undefined", eventType)) {
+        return false;
+    }
+    txEvent.eventType = eventType;
+
+    if (txEventJson.containsKey("timestamp")) {
+        if (!txEvent.timestamp.setTime(txEventJson["timestamp"] | "_Undefined")) {
+            return false;
+        }
+    }
+
+    int bootNrIn = txEventJson["bootNr"] | -1;
+    if (bootNrIn >= 0 && bootNrIn <= std::numeric_limits<uint16_t>::max()) {
+        txEvent.bootNr = (uint16_t)bootNrIn;
+    } else {
+        return false;
+    }
+
+    TransactionEventTriggerReason triggerReason;
+    if (!deserializeTransactionEventTriggerReason(txEventJson["triggerReason"] | "_Undefined", triggerReason)) {
+        return false;
+    }
+    txEvent.triggerReason = triggerReason;
+    
+    if (txEventJson.containsKey("offline") && !txEventJson["offline"].is<bool>()) {
+        return false;
+    }
+    txEvent.offline = txEventJson["offline"] | false;
+
+    if (txEventJson.containsKey("numberOfPhasesUsed")) {
+        int numberOfPhasesUsedIn = txEventJson["numberOfPhasesUsed"] | -1;
+        if (numberOfPhasesUsedIn < 0) {
+            return false;
+        }
+        txEvent.numberOfPhasesUsed = numberOfPhasesUsedIn;
+    }
+
+    if (txEventJson.containsKey("cableMaxCurrent")) {
+        int cableMaxCurrentIn = txEventJson["cableMaxCurrent"] | -1;
+        if (cableMaxCurrentIn < 0) {
+            return false;
+        }
+        txEvent.cableMaxCurrent = cableMaxCurrentIn;
+    }
+
+    if (txEventJson.containsKey("reservationId")) {
+        int reservationIdIn = txEventJson["reservationId"] | -1;
+        if (reservationIdIn < 0) {
+            return false;
+        }
+        txEvent.reservationId = reservationIdIn;
+    }
+
+    if (txEventJson.containsKey("remoteStartId")) {
+        int remoteStartIdIn = txEventJson["remoteStartId"] | -1;
+        if (remoteStartIdIn < 0) {
+            return false;
+        }
+        txEvent.remoteStartId = remoteStartIdIn;
+    }
+
+    TransactionEventData::ChargingState chargingState;
+    if (!deserializeTransactionEventChargingState(txEventJson["chargingState"] | (const char*)nullptr, chargingState)) {
+        return false;
+    }
+    txEvent.chargingState = chargingState;
+
+    if (txEventJson.containsKey("idToken")) {
+        auto idToken = std::unique_ptr<IdToken>(new IdToken());
+        if (!idToken) {
+            MO_DBG_ERR("OOM");
+            return false;
+        }
+        if (!idToken->parseCstr(
+                    txEventJson["idToken"]["idToken"] | (const char*)nullptr, 
+                    txEventJson["idToken"]["type"]    | (const char*)nullptr)) {
+            return false;
+        }
+        txEvent.idToken = std::move(idToken);
+    }
+
+    if (txEventJson.containsKey("evse")) {
+        int evseId = txEventJson["evse"]["id"] | -1;
+        if (evseId < 0) {
+            return false;
+        }
+        if (txEventJson["evse"].containsKey("connectorId")) {
+            int connectorId = txEventJson["evse"]["connectorId"] | -1;
+            if (connectorId < 0) {
+                return false;
+            }
+            txEvent.evse = EvseId(evseId, connectorId);
+        } else {
+            txEvent.evse = EvseId(evseId);
+        }
+    }
+
+    //meterValue not supported yet
+
+    int opNrIn = txEventJson["opNr"] | -1;
+    if (opNrIn >= 0) {
+        txEvent.opNr = (unsigned int)opNrIn;
+    } else {
+        return false;
+    }
+
+    int attemptNrIn = txEventJson["attemptNr"] | -1;
+    if (attemptNrIn >= 0) {
+        txEvent.attemptNr = (unsigned int)attemptNrIn;
+    } else {
+        return false;
+    }
+
+    if (txEventJson.containsKey("attemptTime")) {
+        if (!txEvent.attemptTime.setTime(txEventJson["attemptTime"] | "_Undefined")) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+TransactionStoreEvse::TransactionStoreEvse(TransactionStore& txStore, unsigned int evseId, std::shared_ptr<FilesystemAdapter> filesystem) :
+        MemoryManaged("v201.Transactions.TransactionStore"),
+        txStore(txStore),
+        evseId(evseId),
+        filesystem(filesystem) {
+
+}
+
+bool TransactionStoreEvse::discoverStoredTx(unsigned int& txNrBeginOut, unsigned int& txNrEndOut) {
+
+    if (!filesystem) {
+        MO_DBG_DEBUG("no FS adapter");
+        return true;
+    }
+
+    char fnPrefix [MO_MAX_PATH_SIZE];
+    snprintf(fnPrefix, sizeof(fnPrefix), "tx201-%u-", evseId);
+    size_t fnPrefixLen = strlen(fnPrefix);
+
+    unsigned int txNrPivot = std::numeric_limits<unsigned int>::max();
+    unsigned int txNrBegin = 0, txNrEnd = 0;
+
+    auto ret = filesystem->ftw_root([fnPrefix, fnPrefixLen, &txNrPivot, &txNrBegin, &txNrEnd] (const char *fn) {
+        if (!strncmp(fn, fnPrefix, fnPrefixLen)) {
+            unsigned int parsedTxNr = 0;
+            for (size_t i = fnPrefixLen; fn[i] >= '0' && fn[i] <= '9'; i++) {
+                parsedTxNr *= 10;
+                parsedTxNr += fn[i] - '0';
+            }
+
+            if (txNrPivot == std::numeric_limits<unsigned int>::max()) {
+                txNrPivot = parsedTxNr;
+                txNrBegin = parsedTxNr;
+                txNrEnd = (parsedTxNr + 1) % MAX_TX_CNT;
+                return 0;
+            }
+
+            if ((parsedTxNr + MAX_TX_CNT - txNrPivot) % MAX_TX_CNT < MAX_TX_CNT / 2) {
+                //parsedTxNr is after pivot point
+                if ((parsedTxNr + 1 + MAX_TX_CNT - txNrPivot) % MAX_TX_CNT > (txNrEnd + MAX_TX_CNT - txNrPivot) % MAX_TX_CNT) {
+                    txNrEnd = (parsedTxNr + 1) % MAX_TX_CNT;
+                }
+            } else if ((txNrPivot + MAX_TX_CNT - parsedTxNr) % MAX_TX_CNT < MAX_TX_CNT / 2) {
+                //parsedTxNr is before pivot point
+                if ((txNrPivot + MAX_TX_CNT - parsedTxNr) % MAX_TX_CNT > (txNrPivot + MAX_TX_CNT - txNrBegin) % MAX_TX_CNT) {
+                    txNrBegin = parsedTxNr;
+                }
+            }
+
+            MO_DBG_DEBUG("found %s%u.json - Internal range from %u to %u (exclusive)", fnPrefix, parsedTxNr, txNrBegin, txNrEnd);
+        }
+        return 0;
+    });
+
+    if (ret == 0) {
+        txNrBeginOut = txNrBegin;
+        txNrEndOut = txNrEnd;
+        return true;
+    } else {
+        MO_DBG_ERR("fs error");
+        return false;
+    }
+}
+
+std::unique_ptr<Transaction> TransactionStoreEvse::loadTransaction(unsigned int txNr) {
+
+    if (!filesystem) {
+        MO_DBG_DEBUG("no FS adapter");
+        return nullptr;
+    }
+
+    char fnPrefix [MO_MAX_PATH_SIZE];
+    auto ret= snprintf(fnPrefix, sizeof(fnPrefix), "tx201-%u-%u-", evseId, txNr);
+    if (ret < 0 || (size_t)ret >= sizeof(fnPrefix)) {
+        MO_DBG_ERR("fn error");
+        return nullptr;
+    }
+    size_t fnPrefixLen = strlen(fnPrefix);
+
+    Vector<unsigned int> seqNos = makeVector<unsigned int>(getMemoryTag());
+
+    filesystem->ftw_root([fnPrefix, fnPrefixLen, &seqNos] (const char *fn) {
+        if (!strncmp(fn, fnPrefix, fnPrefixLen)) {
+            unsigned int parsedSeqNo = 0;
+            for (size_t i = fnPrefixLen; fn[i] >= '0' && fn[i] <= '9'; i++) {
+                parsedSeqNo *= 10;
+                parsedSeqNo += fn[i] - '0';
+            }
+
+            seqNos.push_back(parsedSeqNo);
+        }
+        return 0;
+    });
+
+    if (seqNos.empty()) {
+        MO_DBG_DEBUG("no tx at tx201-%u-%u", evseId, txNr);
+        return nullptr;
+    }
+
+    std::sort(seqNos.begin(), seqNos.end());
+
+    char fn [MO_MAX_PATH_SIZE] = {'\0'};
+    ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx201" "-%u-%u-%u.json", evseId, txNr, seqNos.back());
+    if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
+        MO_DBG_ERR("fn error: %i", ret);
+        return nullptr;
+    }
+
+    size_t msize;
+    if (filesystem->stat(fn, &msize) != 0) {
+        MO_DBG_ERR("tx201-%u-%u memory corruption", evseId, txNr);
+        return nullptr;
+    }
+
+    auto doc = FilesystemUtils::loadJson(filesystem, fn, getMemoryTag());
+
+    if (!doc) {
+        MO_DBG_ERR("memory corruption");
+        return nullptr;
+    }
+
+    auto transaction = std::unique_ptr<Transaction>(new Transaction());
+    if (!transaction) {
+        MO_DBG_ERR("OOM");
+        return nullptr;
+    }
+
+    transaction->evseId = evseId;
+    transaction->txNr = txNr;
+    transaction->seqNos = std::move(seqNos);
+
+    JsonObject txJson = (*doc)["tx"];
+
+    if (!deserializeTransaction(*transaction, txJson)) {
+        MO_DBG_ERR("deserialization error");
+        return nullptr;
+    }
+
+    //determine seqNoEnd and trim seqNos record
+    if (doc->containsKey("txEvent")) {
+        //last tx201 file contains txEvent -> txNoEnd is one place after tx201 file and seqNos is accurate
+        transaction->seqNoEnd = transaction->seqNos.back() + 1;
+    } else {
+        //last tx201 file contains only tx status information, but no txEvent -> remove from seqNos record and set seqNoEnd to this
+        transaction->seqNoEnd = transaction->seqNos.back();
+        transaction->seqNos.pop_back();
+    }
+
+    MO_DBG_DEBUG("loaded tx %u-%u, seqNos.size()=%zu", evseId, txNr, transaction->seqNos.size());
+
+    return transaction;
+}
+
+std::unique_ptr<Ocpp201::Transaction> TransactionStoreEvse::createTransaction(unsigned int txNr, const char *txId) {
+
+    //clean data which could still be here from a rolled-back transaction
+    if (!remove(txNr)) {
+        MO_DBG_ERR("txNr not clean");
+        return nullptr;
+    }
+
+    auto transaction = std::unique_ptr<Transaction>(new Transaction());
+    if (!transaction) {
+        MO_DBG_ERR("OOM");
+        return nullptr;
+    }
+
+    transaction->evseId = evseId;
+    transaction->txNr = txNr;
+
+    auto ret = snprintf(transaction->transactionId, sizeof(transaction->transactionId), "%s", txId);
+    if (ret < 0 || (size_t)ret >= sizeof(transaction->transactionId)) {
+        MO_DBG_ERR("invalid arg");
+        return nullptr;
+    }
+
+    if (!commit(transaction.get())) {
+        MO_DBG_ERR("FS error");
+        return nullptr;
+    }
+
+    return transaction;
+}
+
+std::unique_ptr<TransactionEventData> TransactionStoreEvse::createTransactionEvent(Transaction& tx) {
+
+    auto txEvent = std::unique_ptr<TransactionEventData>(new TransactionEventData(&tx, tx.seqNoEnd));
+    if (!txEvent) {
+        MO_DBG_ERR("OOM");
+        return nullptr;
+    }
+
+    //success
+    return txEvent;
+}
+
+std::unique_ptr<TransactionEventData> TransactionStoreEvse::loadTransactionEvent(Transaction& tx, unsigned int seqNo) {
+
+    if (!filesystem) {
+        MO_DBG_DEBUG("no FS adapter");
+        return nullptr;
+    }
+
+    bool found = false;
+    for (size_t i = 0; i < tx.seqNos.size(); i++) {
+        if (tx.seqNos[i] == seqNo) {
+            found = true;
+        }
+    }
+    if (!found) {
+        MO_DBG_DEBUG("%u-%u-%u does not exist", evseId, tx.txNr, seqNo);
+        return nullptr;
+    }
+
+    char fn [MO_MAX_PATH_SIZE] = {'\0'};
+    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx201" "-%u-%u-%u.json", evseId, tx.txNr, seqNo);
+    if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
+        MO_DBG_ERR("fn error: %i", ret);
+        return nullptr;
+    }
+
+    size_t msize;
+    if (filesystem->stat(fn, &msize) != 0) {
+        MO_DBG_ERR("seqNos out of sync: could not find %u-%u-%u", evseId, tx.txNr, seqNo);
+        return nullptr;
+    }
+
+    auto doc = FilesystemUtils::loadJson(filesystem, fn, getMemoryTag());
+
+    if (!doc) {
+        MO_DBG_ERR("memory corruption");
+        return nullptr;
+    }
+
+    if (!doc->containsKey("txEvent")) {
+        MO_DBG_DEBUG("%u-%u-%u does not contain txEvent", evseId, tx.txNr, seqNo);
+        return nullptr;
+    }
+
+    auto txEvent = std::unique_ptr<TransactionEventData>(new TransactionEventData(&tx, seqNo));
+    if (!txEvent) {
+        MO_DBG_ERR("OOM");
+        return nullptr;
+    }
+
+    if (!deserializeTransactionEvent(*txEvent, (*doc)["txEvent"])) {
+        MO_DBG_ERR("deserialization error");
+        return nullptr;
+    }
+
+    return txEvent;
+}
+
+bool TransactionStoreEvse::commit(Transaction& tx, TransactionEventData *txEvent) {
+
+    if (!filesystem) {
+        MO_DBG_DEBUG("no FS: nothing to commit");
+        return true;
+    }
+
+    unsigned int seqNo = 0;
+
+    if (txEvent) {
+        seqNo = txEvent->seqNo;
+    } else {
+        //update tx state in new or reused tx201 file
+        seqNo = tx.seqNoEnd;
+    }
+
+    size_t seqNosNewSize = tx.seqNos.size() + 1;
+    for (size_t i = 0; i < tx.seqNos.size(); i++) {
+        if (tx.seqNos[i] == seqNo) {
+            seqNosNewSize -= 1;
+            break;
+        }
+    }
+
+    // Check if to delete intermediate offline txEvent
+    if (seqNosNewSize > MO_TXEVENTRECORD_SIZE_V201) {
+        auto deltaMin = std::numeric_limits<unsigned int>::max();
+        size_t indexMin = tx.seqNos.size();
+        for (size_t i = 2; i + 1 <= tx.seqNos.size(); i++) { //always keep first and final txEvent
+            size_t t0 = tx.seqNos.size() - i - 1;
+            size_t t1 = tx.seqNos.size() - i;
+
+            auto delta = tx.seqNos[t1] - tx.seqNos[t0];
+
+            if (delta < deltaMin) {
+                deltaMin = delta;
+                indexMin = t1;
+            }
+        }
+
+        if (indexMin < tx.seqNos.size()) {
+            MO_DBG_DEBUG("delete intermediate txEvent %u-%u-%u", evseId, tx.txNr, tx.seqNos[indexMin]);
+            remove(tx, tx.seqNos[indexMin]); //remove can call commit() again. Ensure that remove is not executed for last element
+        } else {
+            MO_DBG_ERR("internal error");
+            return false;
+        }
+    }
+
+    char fn [MO_MAX_PATH_SIZE] = {'\0'};
+    auto ret = snprintf(fn, MO_MAX_PATH_SIZE, MO_FILENAME_PREFIX "tx201" "-%u-%u-%u.json", evseId, tx.txNr, seqNo);
+    if (ret < 0 || ret >= MO_MAX_PATH_SIZE) {
+        MO_DBG_ERR("fn error: %i", ret);
+        return false;
+    }
+
+    auto txDoc = initJsonDoc("v201.Transactions.TransactionStoreEvse", 2048);
+
+    if (!serializeTransaction(tx, txDoc.createNestedObject("tx"))) {
+        MO_DBG_ERR("Serialization error");
+        return false;
+    }
+
+    if (txEvent && !serializeTransactionEvent(*txEvent, txDoc.createNestedObject("txEvent"))) {
+        MO_DBG_ERR("Serialization error");
+        return false;
+    }
+
+    if (!FilesystemUtils::storeJson(filesystem, fn, txDoc)) {
+        MO_DBG_ERR("FS error");
+        return false;
+    }
+
+    if (txEvent && seqNo == tx.seqNoEnd) {
+        tx.seqNos.push_back(seqNo);
+        tx.seqNoEnd++;
+    }
+
+    MO_DBG_DEBUG("comitted tx %u-%u-%u", evseId, tx.txNr, seqNo);
+
+    //success
+    return true;
+}
+
+bool TransactionStoreEvse::commit(Transaction *transaction) {
+    return commit(*transaction, nullptr);
+}
+
+bool TransactionStoreEvse::commit(TransactionEventData *txEvent) {
+    return commit(*txEvent->transaction, txEvent);
+}
+
+bool TransactionStoreEvse::remove(unsigned int txNr) {
+
+    if (!filesystem) {
+        MO_DBG_DEBUG("no FS: nothing to remove");
+        return true;
+    }
+
+    char fnPrefix [MO_MAX_PATH_SIZE];
+    auto ret= snprintf(fnPrefix, sizeof(fnPrefix), "tx201-%u-%u-", evseId, txNr);
+    if (ret < 0 || (size_t)ret >= sizeof(fnPrefix)) {
+        MO_DBG_ERR("fn error");
+        return false;
+    }
+    size_t fnPrefixLen = strlen(fnPrefix);
+
+    auto success = FilesystemUtils::remove_if(filesystem, [fnPrefix, fnPrefixLen] (const char *fn) {
+        return !strncmp(fn, fnPrefix, fnPrefixLen);
+    });
+
+    return success;
+}
+
+bool TransactionStoreEvse::remove(Transaction& tx, unsigned int seqNo) {
+
+    if (tx.seqNos.empty()) {
+        //nothing to do
+        return true;
+    }
+
+    if (tx.seqNos.back() == seqNo) {
+        //special case: deletion of last tx201 file could also delete information about tx. Make sure all tx-related
+        //information is commited into tx201 file at seqNoEnd, then delete file at seqNo
+
+        char fn [MO_MAX_PATH_SIZE];
+        auto ret = snprintf(fn, sizeof(fn), "%stx201-%u-%u-%u.json", MO_FILENAME_PREFIX, evseId, tx.txNr, tx.seqNoEnd);
+        if (ret < 0 || (size_t)ret >= sizeof(fn)) {
+            MO_DBG_ERR("fn error");
+            return false;
+        }
+
+        auto doc = FilesystemUtils::loadJson(filesystem, fn, getMemoryTag());
+        
+        if (!doc || !doc->containsKey("tx")) {
+            //no valid tx201 file at seqNoEnd. Commit tx into file seqNoEnd, then remove file at seqNo
+
+            if (!commit(tx, nullptr)) {
+                MO_DBG_ERR("fs error");
+                return false;
+            }
+        }
+
+        //seqNoEnd contains all tx data which should be persisted. Continue
+    }
+
+    bool found = false;
+    for (size_t i = 0; i < tx.seqNos.size(); i++) {
+        if (tx.seqNos[i] == seqNo) {
+            found = true;
+        }
+    }
+    if (!found) {
+        MO_DBG_DEBUG("%u-%u-%u does not exist", evseId, tx.txNr, seqNo);
+        return true;
+    }
+
+    bool success = true;
+
+    if (filesystem) {
+        char fn [MO_MAX_PATH_SIZE];
+        auto ret = snprintf(fn, sizeof(fn), "%stx201-%u-%u-%u.json", MO_FILENAME_PREFIX, evseId, tx.txNr, seqNo);
+        if (ret < 0 || (size_t)ret >= sizeof(fn)) {
+            MO_DBG_ERR("fn error");
+            return false;
+        }
+
+        size_t msize;
+        if (filesystem->stat(fn, &msize) == 0) {
+            success &= filesystem->remove(fn);
+        } else {
+            MO_DBG_ERR("internal error: seqNos out of sync");
+            (void)0;
+        }
+    }
+
+    if (success) {
+        auto it = tx.seqNos.begin();
+        while (it != tx.seqNos.end()) {
+            if (*it == seqNo) {
+                it = tx.seqNos.erase(it);
+            } else {
+                it++;
+            }
+        }
+    }
+
+    return success;
+}
+
+TransactionStore::TransactionStore(std::shared_ptr<FilesystemAdapter> filesystem, size_t numEvses) :
+        MemoryManaged{"v201.Transactions.TransactionStore"} {
+
+    for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID && (size_t)evseId < numEvses; evseId++) {
+        evses[evseId] = new TransactionStoreEvse(*this, evseId, filesystem);
+    }
+}
+
+TransactionStore::~TransactionStore() {
+    for (unsigned int evseId = 0; evseId < MO_NUM_EVSEID && evses[evseId]; evseId++) {
+        delete evses[evseId];
+    }
+}
+
+TransactionStoreEvse *TransactionStore::getEvse(unsigned int evseId) {
+    if (evseId >= MO_NUM_EVSEID) {
+        return nullptr;
+    }
+    return evses[evseId];
+}
+
+} //namespace Ocpp201
+} //namespace MicroOcpp
+
+#endif //MO_ENABLE_V201

--- a/src/MicroOcpp/Model/Transactions/TransactionStore.h
+++ b/src/MicroOcpp/Model/Transactions/TransactionStore.h
@@ -5,6 +5,7 @@
 #ifndef MO_TRANSACTIONSTORE_H
 #define MO_TRANSACTIONSTORE_H
 
+#include <MicroOcpp/Version.h>
 #include <MicroOcpp/Model/Transactions/Transaction.h>
 #include <MicroOcpp/Core/FilesystemAdapter.h>
 #include <MicroOcpp/Core/Memory.h>
@@ -53,5 +54,64 @@ public:
 };
 
 }
+
+#if MO_ENABLE_V201
+
+#ifndef MO_TXEVENTRECORD_SIZE_V201
+#define MO_TXEVENTRECORD_SIZE_V201 10 //maximum number of of txEvents per tx to hold on flash storage
+#endif
+
+namespace MicroOcpp {
+namespace Ocpp201 {
+
+class TransactionStore;
+
+class TransactionStoreEvse : public MemoryManaged {
+private:
+    TransactionStore& txStore;
+    const unsigned int evseId;
+
+    std::shared_ptr<FilesystemAdapter> filesystem;
+
+    bool serializeTransaction(Transaction& tx, JsonObject out);
+    bool serializeTransactionEvent(TransactionEventData& txEvent, JsonObject out);
+    bool deserializeTransaction(Transaction& tx, JsonObject in);
+    bool deserializeTransactionEvent(TransactionEventData& txEvent, JsonObject in);
+
+    bool commit(Transaction& transaction, TransactionEventData *transactionEvent);
+
+public:
+    TransactionStoreEvse(TransactionStore& txStore, unsigned int evseId, std::shared_ptr<FilesystemAdapter> filesystem);
+
+    bool discoverStoredTx(unsigned int& txNrBeginOut, unsigned int& txNrEndOut);
+
+    bool commit(Transaction *transaction);
+    bool commit(TransactionEventData *transactionEvent);
+
+    std::unique_ptr<Transaction> loadTransaction(unsigned int txNr);
+    std::unique_ptr<Transaction> createTransaction(unsigned int txNr, const char *txId);
+
+    std::unique_ptr<TransactionEventData> createTransactionEvent(Transaction& tx);
+    std::unique_ptr<TransactionEventData> loadTransactionEvent(Transaction& tx, unsigned int seqNo);
+
+    bool remove(unsigned int txNr);
+    bool remove(Transaction& tx, unsigned int seqNo);
+};
+
+class TransactionStore : public MemoryManaged {
+private:
+    TransactionStoreEvse *evses [MO_NUM_EVSEID] = {nullptr};
+public:
+    TransactionStore(std::shared_ptr<FilesystemAdapter> filesystem, size_t numEvses);
+
+    ~TransactionStore();
+
+    TransactionStoreEvse *getEvse(unsigned int evseId);
+};
+
+} //namespace Ocpp201
+} //namespace MicroOcpp
+
+#endif //MO_ENABLE_V201
 
 #endif

--- a/src/MicroOcpp/Model/Variables/Variable.cpp
+++ b/src/MicroOcpp/Model/Variables/Variable.cpp
@@ -165,13 +165,6 @@ bool Variable::isConstant() {
     return constant;
 }
 
-void Variable::detach() {
-    detached = true;
-}
-bool Variable::isDetached() {
-    return detached;
-}
-
 template <class T>
 struct VariableSingleData {
     T value = 0;

--- a/src/MicroOcpp/Model/Variables/Variable.h
+++ b/src/MicroOcpp/Model/Variables/Variable.h
@@ -177,8 +177,6 @@ private:
 
     AttributeTypeSet attributes;
 
-    bool detached = false; // MO-internal: if a conflicting declaration comes in, discard the old Variable
-
     // VariableMonitoringType (2.52)
     //std::vector<VariableMonitor> monitors; // uncomment when testing Monitors
 public:
@@ -224,9 +222,6 @@ public:
     //bool addMonitor(int id, bool transaction, float value, VariableMonitor::Type type, int severity);
     
     virtual uint16_t getWriteCount() = 0; //get write count (use this as a pre-check if the value changed)
-
-    void detach();
-    bool isDetached();
 };
 
 std::unique_ptr<Variable> makeVariable(Variable::InternalDataType dtype, Variable::AttributeTypeSet supportAttributes);

--- a/src/MicroOcpp/Model/Variables/VariableContainer.cpp
+++ b/src/MicroOcpp/Model/Variables/VariableContainer.cpp
@@ -27,20 +27,20 @@ bool VariableContainer::commit() {
     return true;
 }
 
-VariableContainerExternal::VariableContainerExternal() :
-            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerExternal"), variables(makeVector<Variable*>(getMemoryTag())) {
+VariableContainerNonOwning::VariableContainerNonOwning() :
+            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerNonOwning"), variables(makeVector<Variable*>(getMemoryTag())) {
 
 }
 
-size_t VariableContainerExternal::size() {
+size_t VariableContainerNonOwning::size() {
     return variables.size();
 }
 
-Variable *VariableContainerExternal::getVariable(size_t i) {
+Variable *VariableContainerNonOwning::getVariable(size_t i) {
     return variables[i];
 }
 
-Variable *VariableContainerExternal::getVariable(const ComponentId& component, const char *variableName) {
+Variable *VariableContainerNonOwning::getVariable(const ComponentId& component, const char *variableName) {
     for (size_t i = 0; i < variables.size(); i++) {
         auto& var = variables[i];
         if (!strcmp(var->getName(), variableName) &&
@@ -51,12 +51,12 @@ Variable *VariableContainerExternal::getVariable(const ComponentId& component, c
     return nullptr;
 }
 
-bool VariableContainerExternal::add(Variable *variable) {
+bool VariableContainerNonOwning::add(Variable *variable) {
     variables.push_back(variable);
     return true;
 }
 
-bool VariableContainerInternal::checkWriteCountUpdated() {
+bool VariableContainerOwning::checkWriteCountUpdated() {
 
     decltype(trackWriteCount) writeCount = 0;
 
@@ -71,25 +71,25 @@ bool VariableContainerInternal::checkWriteCountUpdated() {
     return updated;
 }
 
-VariableContainerInternal::VariableContainerInternal() :
-            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerInternal"), variables(makeVector<std::unique_ptr<Variable>>(getMemoryTag())) {
+VariableContainerOwning::VariableContainerOwning() :
+            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerOwning"), variables(makeVector<std::unique_ptr<Variable>>(getMemoryTag())) {
 
 }
 
-VariableContainerInternal::~VariableContainerInternal() {
+VariableContainerOwning::~VariableContainerOwning() {
     MO_FREE(filename);
     filename = nullptr;
 }
 
-size_t VariableContainerInternal::size() {
+size_t VariableContainerOwning::size() {
     return variables.size();
 }
 
-Variable *VariableContainerInternal::getVariable(size_t i) {
+Variable *VariableContainerOwning::getVariable(size_t i) {
     return variables[i].get();
 }
 
-Variable *VariableContainerInternal::getVariable(const ComponentId& component, const char *variableName) {
+Variable *VariableContainerOwning::getVariable(const ComponentId& component, const char *variableName) {
     for (size_t i = 0; i < variables.size(); i++) {
         auto& var = variables[i];
         if (!strcmp(var->getName(), variableName) &&
@@ -100,12 +100,12 @@ Variable *VariableContainerInternal::getVariable(const ComponentId& component, c
     return nullptr;
 }
 
-bool VariableContainerInternal::add(std::unique_ptr<Variable> variable) {
+bool VariableContainerOwning::add(std::unique_ptr<Variable> variable) {
     variables.push_back(std::move(variable));
     return true;
 }
 
-bool VariableContainerInternal::enablePersistency(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename) {
+bool VariableContainerOwning::enablePersistency(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename) {
     this->filesystem = filesystem;
 
     MO_FREE(this->filename);
@@ -123,7 +123,7 @@ bool VariableContainerInternal::enablePersistency(std::shared_ptr<FilesystemAdap
     return true;
 }
 
-bool VariableContainerInternal::load() {
+bool VariableContainerOwning::load() {
     if (loaded) {
         return true;
     }
@@ -200,7 +200,7 @@ bool VariableContainerInternal::load() {
     return true;
 }
 
-bool VariableContainerInternal::commit() {
+bool VariableContainerOwning::commit() {
     if (!filesystem || !filename) {
         //persistency disabled - nothing to do
         return true;

--- a/src/MicroOcpp/Model/Variables/VariableContainer.cpp
+++ b/src/MicroOcpp/Model/Variables/VariableContainer.cpp
@@ -278,9 +278,6 @@ bool VariableContainerOwning::commit() {
                 if (variable.hasAttribute(Variable::AttributeType::MaxSet)) stored["valMaxSet"] = variable.getString(Variable::AttributeType::MaxSet);
                 break;
         }
-
-        char buf [1000];
-        serializeJson(doc, buf, 1000);
     }
 
 

--- a/src/MicroOcpp/Model/Variables/VariableContainer.cpp
+++ b/src/MicroOcpp/Model/Variables/VariableContainer.cpp
@@ -11,6 +11,7 @@
 #if MO_ENABLE_V201
 
 #include <MicroOcpp/Model/Variables/VariableContainer.h>
+#include <MicroOcpp/Core/FilesystemUtils.h>
 
 #include <string.h>
 
@@ -22,52 +23,276 @@ VariableContainer::~VariableContainer() {
 
 }
 
-VariableContainerVolatile::VariableContainerVolatile(const char *filename, bool accessible) :
-        VariableContainer(filename, accessible), MemoryManaged("v201.Variables.VariableContainerVolatile.", filename), variables(makeVector<std::unique_ptr<Variable>>(getMemoryTag())) {
-
-}
-
-VariableContainerVolatile::~VariableContainerVolatile() {
-
-}
-
-bool VariableContainerVolatile::load() {
+bool VariableContainer::commit() {
     return true;
 }
 
-bool VariableContainerVolatile::save() {
-    return true;
+VariableContainerExternal::VariableContainerExternal() :
+            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerExternal"), variables(makeVector<Variable*>(getMemoryTag())) {
+
 }
 
-std::unique_ptr<Variable> VariableContainerVolatile::createVariable(Variable::InternalDataType dtype, Variable::AttributeTypeSet attributes) {
-    return makeVariable(dtype, attributes);
-}
-
-bool VariableContainerVolatile::add(std::unique_ptr<Variable> variable) {
-    variables.push_back(std::move(variable));
-    return true;
-}
-
-size_t VariableContainerVolatile::size() const {
+size_t VariableContainerExternal::size() {
     return variables.size();
 }
 
-Variable *VariableContainerVolatile::getVariable(size_t i) const {
-    return variables[i].get();
+Variable *VariableContainerExternal::getVariable(size_t i) {
+    return variables[i];
 }
 
-Variable *VariableContainerVolatile::getVariable(const ComponentId& component, const char *variableName) const {
-    for (auto it = variables.begin(); it != variables.end(); it++) {
-        if (!strcmp((*it)->getName(), variableName) &&
-                (*it)->getComponentId().equals(component)) {
-            return it->get();
+Variable *VariableContainerExternal::getVariable(const ComponentId& component, const char *variableName) {
+    for (size_t i = 0; i < variables.size(); i++) {
+        auto& var = variables[i];
+        if (!strcmp(var->getName(), variableName) &&
+                var->getComponentId().equals(component)) {
+            return var;
         }
     }
     return nullptr;
 }
 
-std::unique_ptr<VariableContainerVolatile> MicroOcpp::makeVariableContainerVolatile(const char *filename, bool accessible) {
-    return std::unique_ptr<VariableContainerVolatile>(new VariableContainerVolatile(filename, accessible));
+bool VariableContainerExternal::add(Variable *variable) {
+    variables.push_back(variable);
+    return true;
+}
+
+bool VariableContainerInternal::checkWriteCountUpdated() {
+
+    decltype(trackWriteCount) writeCount = 0;
+
+    for (size_t i = 0; i < variables.size(); i++) {
+        writeCount += variables[i]->getWriteCount();
+    }
+
+    bool updated = writeCount != trackWriteCount;
+
+    trackWriteCount = writeCount;
+
+    return updated;
+}
+
+VariableContainerInternal::VariableContainerInternal() :
+            VariableContainer(), MemoryManaged("v201.Variables.VariableContainerInternal"), variables(makeVector<std::unique_ptr<Variable>>(getMemoryTag())) {
+
+}
+
+VariableContainerInternal::~VariableContainerInternal() {
+    MO_FREE(filename);
+    filename = nullptr;
+}
+
+size_t VariableContainerInternal::size() {
+    return variables.size();
+}
+
+Variable *VariableContainerInternal::getVariable(size_t i) {
+    return variables[i].get();
+}
+
+Variable *VariableContainerInternal::getVariable(const ComponentId& component, const char *variableName) {
+    for (size_t i = 0; i < variables.size(); i++) {
+        auto& var = variables[i];
+        if (!strcmp(var->getName(), variableName) &&
+                var->getComponentId().equals(component)) {
+            return var.get();
+        }
+    }
+    return nullptr;
+}
+
+bool VariableContainerInternal::add(std::unique_ptr<Variable> variable) {
+    variables.push_back(std::move(variable));
+    return true;
+}
+
+bool VariableContainerInternal::enablePersistency(std::shared_ptr<FilesystemAdapter> filesystem, const char *filename) {
+    this->filesystem = filesystem;
+
+    MO_FREE(this->filename);
+    this->filename = nullptr;
+
+    size_t fnsize = strlen(filename) + 1;
+
+    this->filename = static_cast<char*>(MO_MALLOC(getMemoryTag(), fnsize));
+    if (!this->filename) {
+        MO_DBG_ERR("OOM");
+        return false;
+    }
+
+    snprintf(this->filename, fnsize, "%s", filename);
+    return true;
+}
+
+bool VariableContainerInternal::load() {
+    if (loaded) {
+        return true;
+    }
+
+    if (!filesystem || !filename) {
+        return true; //persistency disabled - nothing to do
+    }
+
+    size_t file_size = 0;
+    if (filesystem->stat(filename, &file_size) != 0 // file does not exist
+            || file_size == 0) {                         // file exists, but empty
+        MO_DBG_DEBUG("Populate FS: create variables file");
+        return commit();
+    }
+
+    auto doc = FilesystemUtils::loadJson(filesystem, filename, getMemoryTag());
+    if (!doc) {
+        MO_DBG_ERR("failed to load %s", filename);
+        return false;
+    }
+    
+    JsonArray variablesJson = (*doc)["variables"];
+
+    for (JsonObject stored : variablesJson) {
+
+        const char *component = stored["component"] | (const char*)nullptr;
+        int evseId = stored["evseId"] | -1;
+        const char *name = stored["name"] | (const char*)nullptr;
+
+        if (!component || !name) {
+            MO_DBG_ERR("corrupt entry: %s", filename);
+            continue;
+        }
+
+        auto variablePtr = getVariable(ComponentId(component, EvseId(evseId)), name);
+        if (!variablePtr) {
+            MO_DBG_ERR("loaded variable does not exist: %s, %s, %s", filename, component, name);
+            continue;
+        }
+
+        auto& variable = *variablePtr;
+
+        switch (variable.getInternalDataType()) {
+            case Variable::InternalDataType::Int:
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) variable.setInt(stored["valActual"] | 0, Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) variable.setInt(stored["valTarget"] | 0, Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) variable.setInt(stored["valMinSet"] | 0, Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) variable.setInt(stored["valMaxSet"] | 0, Variable::AttributeType::MaxSet);
+                break;
+            case Variable::InternalDataType::Bool:
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) variable.setBool(stored["valActual"] | false, Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) variable.setBool(stored["valTarget"] | false, Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) variable.setBool(stored["valMinSet"] | false, Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) variable.setBool(stored["valMaxSet"] | false, Variable::AttributeType::MaxSet);
+                break;
+            case Variable::InternalDataType::String:
+                bool success = true;
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) success &= variable.setString(stored["valActual"] | "", Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) success &= variable.setString(stored["valTarget"] | "", Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) success &= variable.setString(stored["valMinSet"] | "", Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) success &= variable.setString(stored["valMaxSet"] | "", Variable::AttributeType::MaxSet);
+                if (!success) {
+                    MO_DBG_ERR("value error: %s, %s, %s", filename, component, name);
+                    continue;
+                }
+                break;
+        }
+    }
+
+    checkWriteCountUpdated(); // update trackWriteCount after load is completed
+
+    MO_DBG_DEBUG("Initialization finished");
+    loaded = true;
+    return true;
+}
+
+bool VariableContainerInternal::commit() {
+    if (!filesystem || !filename) {
+        //persistency disabled - nothing to do
+        return true;
+    }
+
+    if (!checkWriteCountUpdated()) {
+        return true; //nothing to be done
+    }
+
+    size_t jsonCapacity = JSON_OBJECT_SIZE(1) + JSON_ARRAY_SIZE(0);
+    size_t variableCapacity = 0;
+    for (size_t i = 0; i < variables.size(); i++) {
+        auto& variable = *variables[i];
+
+        if (!variable.isPersistent()) {
+            continue;
+        }
+
+        size_t addedJsonCapacity = JSON_ARRAY_SIZE(variableCapacity + 1) - JSON_ARRAY_SIZE(variableCapacity);
+
+        size_t storedEntities = 2; //component name, variable name will always be stored
+        storedEntities += variable.getComponentId().evse.id >= 0 ?                 1 : 0;
+        storedEntities += variable.hasAttribute(Variable::AttributeType::Actual) ? 1 : 0;
+        storedEntities += variable.hasAttribute(Variable::AttributeType::Target) ? 1 : 0;
+        storedEntities += variable.hasAttribute(Variable::AttributeType::MinSet) ? 1 : 0;
+        storedEntities += variable.hasAttribute(Variable::AttributeType::MaxSet) ? 1 : 0;
+
+        addedJsonCapacity += JSON_OBJECT_SIZE(storedEntities);
+
+        if (jsonCapacity + addedJsonCapacity <= MO_MAX_JSON_CAPACITY) {
+            jsonCapacity += addedJsonCapacity;
+            variableCapacity++;
+        } else {
+            MO_DBG_ERR("configs JSON exceeds maximum capacity (%s, %zu entries). Crop configs file (by FCFS)", filename, variables.size());
+            break;
+        }
+    }
+
+    auto doc = initJsonDoc(getMemoryTag(), jsonCapacity);
+
+    JsonArray variablesJson = doc.createNestedArray("variables");
+
+    for (size_t i = 0; i < variableCapacity; i++) {
+        auto& variable = *variables[i];
+
+        if (!variable.isPersistent()) {
+            continue;
+        }
+
+        auto stored = variablesJson.createNestedObject();
+
+        stored["component"] = variable.getComponentId().name;
+        if (variable.getComponentId().evse.id >= 0) {
+            stored["evseId"] = variable.getComponentId().evse.id;
+        }
+        stored["name"] = variable.getName();
+        
+        switch (variable.getInternalDataType()) {
+            case Variable::InternalDataType::Int:
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) stored["valActual"] = variable.getInt(Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) stored["valTarget"] = variable.getInt(Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) stored["valMinSet"] = variable.getInt(Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) stored["valMaxSet"] = variable.getInt(Variable::AttributeType::MaxSet);
+                break;
+            case Variable::InternalDataType::Bool:
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) stored["valActual"] = variable.getBool(Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) stored["valTarget"] = variable.getBool(Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) stored["valMinSet"] = variable.getBool(Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) stored["valMaxSet"] = variable.getBool(Variable::AttributeType::MaxSet);
+                break;
+            case Variable::InternalDataType::String:
+                if (variable.hasAttribute(Variable::AttributeType::Actual)) stored["valActual"] = variable.getString(Variable::AttributeType::Actual);
+                if (variable.hasAttribute(Variable::AttributeType::Target)) stored["valTarget"] = variable.getString(Variable::AttributeType::Target);
+                if (variable.hasAttribute(Variable::AttributeType::MinSet)) stored["valMinSet"] = variable.getString(Variable::AttributeType::MinSet);
+                if (variable.hasAttribute(Variable::AttributeType::MaxSet)) stored["valMaxSet"] = variable.getString(Variable::AttributeType::MaxSet);
+                break;
+        }
+
+        char buf [1000];
+        serializeJson(doc, buf, 1000);
+    }
+
+
+    bool success = FilesystemUtils::storeJson(filesystem, filename, doc);
+
+    if (success) {
+        MO_DBG_DEBUG("Saving variables finished");
+    } else {
+        MO_DBG_ERR("could not save variables file: %s", filename);
+    }
+
+    return success;
 }
 
 #endif // MO_ENABLE_V201

--- a/src/MicroOcpp/Model/Variables/VariableContainer.h
+++ b/src/MicroOcpp/Model/Variables/VariableContainer.h
@@ -31,11 +31,11 @@ public:
     virtual bool commit();
 };
 
-class VariableContainerExternal : public VariableContainer, public MemoryManaged {
+class VariableContainerNonOwning : public VariableContainer, public MemoryManaged {
 private:
     Vector<Variable*> variables;
 public:
-    VariableContainerExternal();
+    VariableContainerNonOwning();
 
     size_t size() override;
     Variable *getVariable(size_t i) override;
@@ -44,7 +44,7 @@ public:
     bool add(Variable *variable);
 };
 
-class VariableContainerInternal : public VariableContainer, public MemoryManaged {
+class VariableContainerOwning : public VariableContainer, public MemoryManaged {
 private:
     Vector<std::unique_ptr<Variable>> variables;
     std::shared_ptr<FilesystemAdapter> filesystem;
@@ -56,8 +56,8 @@ private:
     bool loaded = false;
 
 public:
-    VariableContainerInternal();
-    ~VariableContainerInternal();
+    VariableContainerOwning();
+    ~VariableContainerOwning();
 
     size_t size() override;
     Variable *getVariable(size_t i) override;

--- a/src/MicroOcpp/Model/Variables/VariableService.cpp
+++ b/src/MicroOcpp/Model/Variables/VariableService.cpp
@@ -59,7 +59,7 @@ VariableValidator<const char*> *VariableService::getValidatorString(const Compon
     return getVariableValidator<const char*>(validatorString, component, name);
 }
 
-VariableContainerInternal& VariableService::getContainerInternalByVariable(const ComponentId& component, const char *name) {
+VariableContainerOwning& VariableService::getContainerInternalByVariable(const ComponentId& component, const char *name) {
     unsigned int hash = 0;
     for (size_t i = 0; i < strlen(component.name); i++) {
         hash += (unsigned int)component.name[i];

--- a/src/MicroOcpp/Model/Variables/VariableService.h
+++ b/src/MicroOcpp/Model/Variables/VariableService.h
@@ -53,9 +53,9 @@ private:
     Context& context;
     std::shared_ptr<FilesystemAdapter> filesystem;
     Vector<VariableContainer*> containers;
-    VariableContainerExternal containerExternal;
-    VariableContainerInternal containersInternal [MO_VARIABLESTORE_BUCKETS];
-    VariableContainerInternal& getContainerInternalByVariable(const ComponentId& component, const char *name);
+    VariableContainerNonOwning containerExternal;
+    VariableContainerOwning containersInternal [MO_VARIABLESTORE_BUCKETS];
+    VariableContainerOwning& getContainerInternalByVariable(const ComponentId& component, const char *name);
 
     Vector<VariableValidator<int>> validatorInt;
     Vector<VariableValidator<bool>> validatorBool;

--- a/src/MicroOcpp/Operations/RequestStartTransaction.cpp
+++ b/src/MicroOcpp/Operations/RequestStartTransaction.cpp
@@ -43,7 +43,7 @@ void RequestStartTransaction::processReq(JsonObject payload) {
         return;
     }
 
-    status = rcService.requestStartTransaction(evseId, remoteStartId, idToken, transaction);
+    status = rcService.requestStartTransaction(evseId, remoteStartId, idToken, transactionId, sizeof(transactionId));
 }
 
 std::unique_ptr<JsonDoc> RequestStartTransaction::createConf(){

--- a/src/MicroOcpp/Operations/RequestStartTransaction.h
+++ b/src/MicroOcpp/Operations/RequestStartTransaction.h
@@ -26,6 +26,7 @@ private:
 
     RequestStartStopStatus status;
     std::shared_ptr<Ocpp201::Transaction> transaction;
+    char transactionId [MO_TXID_LEN_MAX + 1] = {'\0'};
 
     const char *errorCode = nullptr;
 public:

--- a/src/MicroOcpp/Operations/TransactionEvent.h
+++ b/src/MicroOcpp/Operations/TransactionEvent.h
@@ -22,12 +22,12 @@ class TransactionEventData;
 class TransactionEvent : public Operation, public MemoryManaged {
 private:
     Model& model;
-    std::shared_ptr<TransactionEventData> txEvent;
+    TransactionEventData *txEvent;
 
     const char *errorCode = nullptr;
 public:
 
-    TransactionEvent(Model& model, std::shared_ptr<TransactionEventData> txEvent);
+    TransactionEvent(Model& model, TransactionEventData *txEvent);
 
     const char* getOperationType() override;
 

--- a/tests/LocalAuthList.cpp
+++ b/tests/LocalAuthList.cpp
@@ -265,8 +265,6 @@ TEST_CASE( "LocalAuth" ) {
 
         REQUIRE( connector->getStatus() == ChargePointStatus_Available );
 
-        unsigned long t_before = mocpp_tick_ms();
-
         beginTransaction("unknownIdTag");
         loop();
 

--- a/tests/Reset.cpp
+++ b/tests/Reset.cpp
@@ -50,6 +50,17 @@ TEST_CASE( "Reset" ) {
                 return doc;
             });});
 
+    getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [] () {
+        return new Ocpp16::CustomOperation("TransactionEvent",
+            [] (JsonObject) {}, //ignore req
+            [] () {
+                //create conf
+                auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                auto payload = doc->to<JsonObject>();
+                payload["idTokenInfo"]["status"] = "Accepted";
+                return doc;
+            });});
+
     // Register Reset handlers
     bool checkNotified [MO_NUM_EVSEID] = {false};
     bool checkExecuted [MO_NUM_EVSEID] = {false};

--- a/tests/Transactions.cpp
+++ b/tests/Transactions.cpp
@@ -333,7 +333,79 @@ TEST_CASE( "Transactions" ) {
 
         REQUIRE( checkReceivedStarted );
         REQUIRE( checkReceivedEnded );
+    }
 
+    SECTION("TxEvents queue size limit") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        bool checkReceivedStarted = false, checkReceivedEnded = false;
+        size_t checkSeqNosSize = 0;
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&checkReceivedStarted, &checkReceivedEnded, &checkSeqNosSize] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&checkReceivedStarted, &checkReceivedEnded, &checkSeqNosSize] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    if (!strcmp(eventType, "Started")) {
+                        checkReceivedStarted = true;
+                    } else if (!strcmp(eventType, "Ended")) {
+                        checkReceivedEnded = true;
+                    }
+                    checkSeqNosSize++;
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+    
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(false);
+
+        context->getModel().getTransactionService()->getEvse(1)->beginAuthorization("mIdToken", false);
+
+        loop();
+
+        auto tx = context->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+
+        for (size_t i = 0; i < MO_TXEVENTRECORD_SIZE_V201 * 2; i++) {
+            setEvReadyInput([] () {return false;});
+            loop();
+            setEvReadyInput([] () {return true;});
+            loop();
+            setEvReadyInput([] () {return false;});
+            loop();
+        }
+
+        REQUIRE( tx->seqNos.size() == MO_TXEVENTRECORD_SIZE_V201 );
+
+        for (auto seqNo : tx->seqNos) {
+            MO_DBG_DEBUG("stored seqNo %u", seqNo);
+        }
+
+        for (size_t i = 1; i < tx->seqNos.size(); i++) {
+            auto delta = tx->seqNos[i] - tx->seqNos[i-1];
+            REQUIRE(delta <= 2 * tx->seqNos.back() / MO_TXEVENTRECORD_SIZE_V201 );
+        }
+
+        context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+
+        loop();
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(true);
+        loop();
+
+        REQUIRE( checkReceivedStarted );
+        REQUIRE( checkReceivedEnded );
+        REQUIRE( checkSeqNosSize == MO_TXEVENTRECORD_SIZE_V201 );
     }
 
     SECTION("Tx queue") {
@@ -411,6 +483,251 @@ TEST_CASE( "Transactions" ) {
         context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
         loop();
         REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+    }
+
+    SECTION("Power loss during running transaction") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        REQUIRE( getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        const char *idTag = "example123";
+
+        getOcppContext()->getModel().getTransactionService()->getEvse(1)->beginAuthorization(idTag, false);
+        loop();
+
+        auto tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+        REQUIRE( tx->started );
+
+        auto txNr = tx->txNr;
+        std::string txId = tx->transactionId;
+
+        //power cut
+        mocpp_deinitialize();
+
+        //power restored
+        mocpp_initialize(loopback,
+            ChargerCredentials(),
+            makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail),
+            false,
+            ProtocolVersion(2,0,1));
+        mocpp_set_timer(custom_timer_cb);
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        bool checkProcessed = false;
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&checkProcessed, txId] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&checkProcessed, txId] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    REQUIRE( strcmp(eventType, "Started") );
+                    if (!strcmp(eventType, "Ended")) {
+                        checkProcessed = true;
+                    }
+                    REQUIRE( !txId.compare(request["transactionInfo"]["transactionId"] | "_Undefined") );
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+        
+        loop(); //let MO spin up and reconnect
+
+        tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+        REQUIRE( tx->started );
+        REQUIRE( !tx->stopped );
+        REQUIRE( tx->txNr == txNr );
+        REQUIRE( !txId.compare(tx->transactionId) );
+        REQUIRE( !strcmp(tx->idToken.get(), idTag) );
+
+        getOcppContext()->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+        loop();
+
+        tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx == nullptr );
+        REQUIRE( checkProcessed ); //txEvent was sent
+    }
+
+    SECTION("Power loss with enqueued txEvents") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        REQUIRE( getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(false);
+
+        const char *idTag = "example123";
+
+        getOcppContext()->getModel().getTransactionService()->getEvse(1)->beginAuthorization(idTag, false);
+        loop();
+
+        auto tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+        REQUIRE( tx->started );
+
+        auto txNr = tx->txNr;
+        std::string txId = tx->transactionId;
+
+        setEvReadyInput([] () {return false;});
+        loop();
+        setEvReadyInput([] () {return true;});
+        loop();
+        setEvReadyInput([] () {return false;});
+        loop();
+
+        size_t seqNosSize = tx->seqNos.size();
+        size_t checkSeqNosSize = 0;
+
+        //power cut
+        mocpp_deinitialize();
+
+        //power restored
+        mocpp_initialize(loopback,
+            ChargerCredentials(),
+            makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail),
+            false,
+            ProtocolVersion(2,0,1));
+        mocpp_set_timer(custom_timer_cb);
+
+        loopback.setConnected(true);
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        bool checkReceivedStarted = false, checkReceivedEnded = false;
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&checkReceivedStarted, &checkReceivedEnded, txId, &checkSeqNosSize] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&checkReceivedStarted, &checkReceivedEnded, txId, &checkSeqNosSize] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    if (!strcmp(eventType, "Started")) {
+                        checkReceivedStarted = true;
+                    } else if (!strcmp(eventType, "Ended")) {
+                        checkReceivedEnded = true;
+                    }
+                    REQUIRE( !txId.compare(request["transactionInfo"]["transactionId"] | "_Undefined") );
+                    checkSeqNosSize++;
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+        
+        loop(); //let MO spin up and reconnect
+
+        REQUIRE( checkReceivedStarted );
+        REQUIRE( (seqNosSize == checkSeqNosSize || seqNosSize + 1 == checkSeqNosSize) );
+
+        tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+        REQUIRE( tx->started );
+        REQUIRE( !tx->stopped );
+        REQUIRE( tx->txNr == txNr );
+        REQUIRE( !txId.compare(tx->transactionId) );
+        REQUIRE( !strcmp(tx->idToken.get(), idTag) );
+
+        getOcppContext()->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+        loop();
+
+        tx = getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx == nullptr );
+        REQUIRE( checkReceivedEnded ); //txEvent was sent
+    }
+
+    SECTION("Power loss with enqueued transactions") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        std::map<std::string,std::tuple<bool,bool>> txEventRequests;
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(false);
+
+        for (size_t i = 0; i < MO_TXRECORD_SIZE_V201; i++) {
+
+            char idTokenBuf [MO_IDTOKEN_LEN_MAX + 1];
+            snprintf(idTokenBuf, sizeof(idTokenBuf), "mIdToken-%zu", i);
+
+            REQUIRE( context->getModel().getTransactionService()->getEvse(1)->beginAuthorization(idTokenBuf, false) );
+
+            loop();
+
+            auto tx = context->getModel().getTransactionService()->getEvse(1)->getTransaction();
+
+            REQUIRE( tx != nullptr );
+            REQUIRE( tx->started );
+            txEventRequests[tx->transactionId] = {false, false};
+
+            context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+
+            loop();
+
+            REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+        }
+
+        //power cut
+        mocpp_deinitialize();
+
+        //power restored
+        mocpp_initialize(loopback,
+            ChargerCredentials(),
+            makeDefaultFilesystemAdapter(FilesystemOpt::Use_Mount_FormatOnFail),
+            false,
+            ProtocolVersion(2,0,1));
+        mocpp_set_timer(custom_timer_cb);
+
+        loopback.setConnected(true);
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&txEventRequests] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&txEventRequests] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    if (!strcmp(eventType, "Started")) {
+                        std::get<0>(txEventRequests[request["transactionInfo"]["transactionId"] | "_Undefined"]) = true;
+                    } else if (!strcmp(eventType, "Ended")) {
+                        std::get<1>(txEventRequests[request["transactionInfo"]["transactionId"] | "_Undefined"]) = true;
+                    }
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+
+        loopback.setConnected(true);
+        loop();
+
+        for (const auto& txReq : txEventRequests) {
+            MO_DBG_DEBUG("check txId %s", txReq.first.c_str());
+            REQUIRE( std::get<0>(txReq.second) );
+            REQUIRE( std::get<1>(txReq.second) );
+        }
+
+        REQUIRE( txEventRequests.size() == MO_TXRECORD_SIZE_V201 );
+
+        REQUIRE( getOcppContext()->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
     }
 
     mocpp_deinitialize();

--- a/tests/Transactions.cpp
+++ b/tests/Transactions.cpp
@@ -48,6 +48,17 @@ TEST_CASE( "Transactions" ) {
                 payload["idTokenInfo"]["status"] = "Accepted";
                 return doc;
             });});
+    
+    getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [] () {
+        return new Ocpp16::CustomOperation("TransactionEvent",
+            [] (JsonObject) {}, //ignore req
+            [] () {
+                //create conf
+                auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                auto payload = doc->to<JsonObject>();
+                payload["idTokenInfo"]["status"] = "Accepted";
+                return doc;
+            });});
 
     loop();
 
@@ -128,6 +139,10 @@ TEST_CASE( "Transactions" ) {
         MO_DBG_INFO("Memory requirements UC C01-04:");
 
         MO_MEM_PRINT_STATS();
+
+        context->getModel().getTransactionService()->getEvse(1)->abortTransaction();
+        loop();
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
     }
 
     SECTION("UC E01 - S5 / E06") {
@@ -164,17 +179,13 @@ TEST_CASE( "Transactions" ) {
 
         MO_MEM_PRINT_STATS();
 
-        auto trackTx = context->getModel().getTransactionService()->getEvse(1)->getTransaction();
-
         MO_MEM_RESET();
 
         setConnectorPluggedInput([] () {return false;});
         loop();
 
         REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
-        REQUIRE( trackTx->stopped );
         REQUIRE( getChargePointStatus() == ChargePointStatus_Available );
-        trackTx.reset();
 
         MO_DBG_INFO("Memory requirements UC E06:");
         MO_MEM_PRINT_STATS();
@@ -206,10 +217,10 @@ TEST_CASE( "Transactions" ) {
         getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("PowerPathClosed");
         getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("PowerPathClosed");
 
-        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "SampledDataTxStartedMeasurands", "")->setString("Energy.Active.Import.Register");
-        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "SampledDataTxUpdatedMeasurands", "")->setString("Power.Active.Import");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "TxStartedMeasurands", "")->setString("Energy.Active.Import.Register");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "TxUpdatedMeasurands", "")->setString("Power.Active.Import");
         getOcppContext()->getModel().getVariableService()->declareVariable<int>("SampledDataCtrlr", "TxUpdatedInterval", 0)->setInt(60);
-        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "SampledDataTxEndedMeasurands", "")->setString("Current.Import");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("SampledDataCtrlr", "TxEndedMeasurands", "")->setString("Current.Import");
         getOcppContext()->getModel().getVariableService()->declareVariable<int>("SampledDataCtrlr", "TxEndededInterval", 0)->setInt(100);
 
         setConnectorPluggedInput([] () {return false;});
@@ -264,6 +275,142 @@ TEST_CASE( "Transactions" ) {
         MO_DBG_INFO("Memory requirements UC E01 - S5:");
 
         MO_MEM_PRINT_STATS();
+
+        context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+        loop();
+
+        REQUIRE( (tStart > MIN_TIME) );
+        //REQUIRE( (tUpdated > MIN_TIME) );
+        REQUIRE( (tEnded > MIN_TIME) );
+
+    }
+
+    SECTION("TxEvents queue") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        bool checkReceivedStarted = false, checkReceivedEnded = false;
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&checkReceivedStarted, &checkReceivedEnded] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&checkReceivedStarted, &checkReceivedEnded] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    if (!strcmp(eventType, "Started")) {
+                        checkReceivedStarted = true;
+                    } else if (!strcmp(eventType, "Ended")) {
+                        checkReceivedEnded = true;
+                    }
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(false);
+
+        context->getModel().getTransactionService()->getEvse(1)->beginAuthorization("mIdToken", false);
+
+        loop();
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() != nullptr );
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction()->started );
+
+        context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+
+        loop();
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(true);
+        loop();
+
+        REQUIRE( checkReceivedStarted );
+        REQUIRE( checkReceivedEnded );
+
+    }
+
+    SECTION("Tx queue") {
+
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStartPoint", "")->setString("Authorized");
+        getOcppContext()->getModel().getVariableService()->declareVariable<const char*>("TxCtrlr", "TxStopPoint", "")->setString("Authorized");
+
+        std::map<std::string,std::tuple<bool,bool>> txEventRequests;
+
+        getOcppContext()->getOperationRegistry().registerOperation("TransactionEvent", [&txEventRequests] () {
+            return new Ocpp16::CustomOperation("TransactionEvent",
+                [&txEventRequests] (JsonObject request) {
+                    //process req
+                    const char *eventType = request["eventType"] | (const char*)nullptr;
+                    if (!strcmp(eventType, "Started")) {
+                        std::get<0>(txEventRequests[request["transactionInfo"]["transactionId"] | "_Undefined"]) = true;
+                    } else if (!strcmp(eventType, "Ended")) {
+                        std::get<1>(txEventRequests[request["transactionInfo"]["transactionId"] | "_Undefined"]) = true;
+                    }
+                },
+                [] () {
+                    //create conf
+                    auto doc = makeJsonDoc("UnitTests", 2 * JSON_OBJECT_SIZE(1));
+                    auto payload = doc->to<JsonObject>();
+                    payload["idTokenInfo"]["status"] = "Accepted";
+                    return doc;
+                });});
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(false);
+
+        for (size_t i = 0; i < MO_TXRECORD_SIZE_V201; i++) {
+
+            char idTokenBuf [MO_IDTOKEN_LEN_MAX + 1];
+            snprintf(idTokenBuf, sizeof(idTokenBuf), "mIdToken-%zu", i);
+
+            REQUIRE( context->getModel().getTransactionService()->getEvse(1)->beginAuthorization(idTokenBuf, false) );
+
+            loop();
+
+            auto tx = context->getModel().getTransactionService()->getEvse(1)->getTransaction();
+
+            REQUIRE( tx != nullptr );
+            REQUIRE( tx->started );
+            txEventRequests[tx->transactionId] = {false, false};
+
+            context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+
+            loop();
+
+            REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+        }
+
+        REQUIRE( !context->getModel().getTransactionService()->getEvse(1)->beginAuthorization("mIdToken", false) );
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
+
+        loopback.setConnected(true);
+        loop();
+
+        for (const auto& txReq : txEventRequests) {
+            MO_DBG_DEBUG("check txId %s", txReq.first.c_str());
+            REQUIRE( std::get<0>(txReq.second) );
+            REQUIRE( std::get<1>(txReq.second) );
+        }
+
+        REQUIRE( txEventRequests.size() == MO_TXRECORD_SIZE_V201 );
+
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->beginAuthorization("mIdToken", false) );
+        loop();
+        auto tx = context->getModel().getTransactionService()->getEvse(1)->getTransaction();
+        REQUIRE( tx != nullptr );
+        REQUIRE( tx->started );
+
+        context->getModel().getTransactionService()->getEvse(1)->endAuthorization();
+        loop();
+        REQUIRE( context->getModel().getTransactionService()->getEvse(1)->getTransaction() == nullptr );
     }
 
     mocpp_deinitialize();

--- a/tests/Variables.cpp
+++ b/tests/Variables.cpp
@@ -34,7 +34,7 @@ TEST_CASE( "Variable" ) {
     FilesystemUtils::remove_if(filesystem, [] (const char*) {return true;});
 
     SECTION("Basic container operations"){
-        auto container = std::unique_ptr<VariableContainerInternal>(new VariableContainerInternal());
+        auto container = std::unique_ptr<VariableContainerOwning>(new VariableContainerOwning());
 
         //check emptyness
         REQUIRE( container->size() == 0 );
@@ -74,7 +74,7 @@ TEST_CASE( "Variable" ) {
 
     SECTION("Persistency on filesystem") {
 
-        auto container = std::unique_ptr<VariableContainerInternal>(new VariableContainerInternal());
+        auto container = std::unique_ptr<VariableContainerOwning>(new VariableContainerOwning());
         container->enablePersistency(filesystem, MO_FILENAME_PREFIX "persistent1.jsn");
 
         //trivial load call
@@ -94,7 +94,7 @@ TEST_CASE( "Variable" ) {
         container.reset(); //destroy
 
         //...load again
-        auto container2 = std::unique_ptr<VariableContainerInternal>(new VariableContainerInternal());
+        auto container2 = std::unique_ptr<VariableContainerOwning>(new VariableContainerOwning());
         container2->enablePersistency(filesystem, MO_FILENAME_PREFIX "persistent1.jsn");
         REQUIRE( container2->size() == 0 );
 

--- a/tests/benchmarks/scripts/measure_heap.py
+++ b/tests/benchmarks/scripts/measure_heap.py
@@ -181,7 +181,7 @@ def setup_simulator():
     print('   - upload credentials')
     sftp = client.open_sftp()
     sftp.putfo(io.StringIO(os.environ['MO_SIM_CONFIG']),     os.path.join('MicroOcppSimulator', 'mo_store', 'simulator.jsn'))
-    sftp.putfo(io.StringIO(os.environ['MO_SIM_OCPP_SERVER']),os.path.join('MicroOcppSimulator', 'mo_store', 'ws-conn.jsn'))
+    sftp.putfo(io.StringIO(os.environ['MO_SIM_OCPP_SERVER']),os.path.join('MicroOcppSimulator', 'mo_store', 'ws-conn-v201.jsn'))
     sftp.putfo(io.StringIO(os.environ['MO_SIM_API_CERT']),   os.path.join('MicroOcppSimulator', 'mo_store', 'api_cert.pem'))
     sftp.putfo(io.StringIO(os.environ['MO_SIM_API_KEY']),    os.path.join('MicroOcppSimulator', 'mo_store', 'api_key.pem'))
     sftp.putfo(io.StringIO(os.environ['MO_SIM_API_CONFIG']), os.path.join('MicroOcppSimulator', 'mo_store', 'api.jsn'))


### PR DESCRIPTION
This PR makes Variables and Transactions persistent over reboots. Furthermore, Transactions implement the TransactionMessageAttempts(-Interval) behavior now.