### PR TITLE
Minor OCPP 1.6 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Timing issues for OCTT test cases ([#383](https://github.com/matth-x/MicroOcpp/pull/383))
+- Misleading Reset failure dbg msg ([#388](https://github.com/matth-x/MicroOcpp/pull/388))
 
 ## [1.2.0] - 2024-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Timing issues for OCTT test cases ([#383](https://github.com/matth-x/MicroOcpp/pull/383))
 - Misleading Reset failure dbg msg ([#388](https://github.com/matth-x/MicroOcpp/pull/388))
+- Reject negative ints in ChangeConfig ([#388](https://github.com/matth-x/MicroOcpp/pull/388))
 
 ## [1.2.0] - 2024-11-03
 

--- a/src/MicroOcpp/Core/Configuration.cpp
+++ b/src/MicroOcpp/Core/Configuration.cpp
@@ -246,4 +246,13 @@ bool configuration_clean_unused() {
     return configuration_save();
 }
 
+bool VALIDATE_UNSIGNED_INT(const char *value) {
+    for(size_t i = 0; value[i] != '\0'; i++) {
+        if (value[i] < '0' || value[i] > '9') {
+            return false;
+        }
+    }
+    return true;
+}
+
 } //end namespace MicroOcpp

--- a/src/MicroOcpp/Core/Configuration.h
+++ b/src/MicroOcpp/Core/Configuration.h
@@ -38,5 +38,8 @@ bool configuration_save();
 
 bool configuration_clean_unused(); //remove configs which haven't been accessed
 
+//default implementation for common validator
+bool VALIDATE_UNSIGNED_INT(const char*);
+
 } //end namespace MicroOcpp
 #endif

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -49,7 +49,9 @@ Connector::Connector(Context& context, std::shared_ptr<FilesystemAdapter> filesy
 #endif //MO_ENABLE_CONNECTOR_LOCK
 
     connectionTimeOutInt = declareConfiguration<int>("ConnectionTimeOut", 30);
+    registerConfigurationValidator("ConnectionTimeOut", VALIDATE_UNSIGNED_INT);
     minimumStatusDurationInt = declareConfiguration<int>("MinimumStatusDuration", 0);
+    registerConfigurationValidator("MinimumStatusDuration", VALIDATE_UNSIGNED_INT);
     stopTransactionOnInvalidIdBool = declareConfiguration<bool>("StopTransactionOnInvalidId", true);
     stopTransactionOnEVSideDisconnectBool = declareConfiguration<bool>("StopTransactionOnEVSideDisconnect", true);
     localPreAuthorizeBool = declareConfiguration<bool>("LocalPreAuthorize", false);
@@ -61,6 +63,7 @@ Connector::Connector(Context& context, std::shared_ptr<FilesystemAdapter> filesy
 
     //how long the EVSE tries the Authorize request before it enters offline mode
     authorizationTimeoutInt = MicroOcpp::declareConfiguration<int>(MO_CONFIG_EXT_PREFIX "AuthorizationTimeout", 20);
+    registerConfigurationValidator(MO_CONFIG_EXT_PREFIX "AuthorizationTimeout", VALIDATE_UNSIGNED_INT);
 
     //FreeVend mode
     freeVendActiveBool = declareConfiguration<bool>(MO_CONFIG_EXT_PREFIX "FreeVendActive", false);
@@ -69,7 +72,9 @@ Connector::Connector(Context& context, std::shared_ptr<FilesystemAdapter> filesy
     txStartOnPowerPathClosedBool = declareConfiguration<bool>(MO_CONFIG_EXT_PREFIX "TxStartOnPowerPathClosed", false);
 
     transactionMessageAttemptsInt = declareConfiguration<int>("TransactionMessageAttempts", 3);
+    registerConfigurationValidator("TransactionMessageAttempts", VALIDATE_UNSIGNED_INT);
     transactionMessageRetryIntervalInt = declareConfiguration<int>("TransactionMessageRetryInterval", 60);
+    registerConfigurationValidator("TransactionMessageRetryInterval", VALIDATE_UNSIGNED_INT);
 
     if (!availabilityBool) {
         MO_DBG_ERR("Cannot declare availabilityBool");

--- a/src/MicroOcpp/Model/Heartbeat/HeartbeatService.cpp
+++ b/src/MicroOcpp/Model/Heartbeat/HeartbeatService.cpp
@@ -13,6 +13,7 @@ using namespace MicroOcpp;
 
 HeartbeatService::HeartbeatService(Context& context) : MemoryManaged("v16.Heartbeat.HeartbeatService"), context(context) {
     heartbeatIntervalInt = declareConfiguration<int>("HeartbeatInterval", 86400);
+    registerConfigurationValidator("HeartbeatInterval", VALIDATE_UNSIGNED_INT);
     lastHeartbeat = mocpp_tick_ms();
 
     //Register message handler for TriggerMessage operation

--- a/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringConnector.cpp
@@ -28,6 +28,7 @@ MeteringConnector::MeteringConnector(Context& context, int connectorId, MeterSto
     auto meterValuesSampledDataString = declareConfiguration<const char*>("MeterValuesSampledData", "");
     declareConfiguration<int>("MeterValuesSampledDataMaxLength", 8, CONFIGURATION_VOLATILE, true);
     meterValueSampleIntervalInt = declareConfiguration<int>("MeterValueSampleInterval", 60);
+    registerConfigurationValidator("MeterValueSampleInterval", VALIDATE_UNSIGNED_INT);
 
     auto stopTxnSampledDataString = declareConfiguration<const char*>("StopTxnSampledData", "");
     declareConfiguration<int>("StopTxnSampledDataMaxLength", 8, CONFIGURATION_VOLATILE, true);
@@ -35,6 +36,7 @@ MeteringConnector::MeteringConnector(Context& context, int connectorId, MeterSto
     auto meterValuesAlignedDataString = declareConfiguration<const char*>("MeterValuesAlignedData", "");
     declareConfiguration<int>("MeterValuesAlignedDataMaxLength", 8, CONFIGURATION_VOLATILE, true);
     clockAlignedDataIntervalInt  = declareConfiguration<int>("ClockAlignedDataInterval", 0);
+    registerConfigurationValidator("ClockAlignedDataInterval", VALIDATE_UNSIGNED_INT);
 
     auto stopTxnAlignedDataString = declareConfiguration<const char*>("StopTxnAlignedData", "");
 

--- a/src/MicroOcpp/Model/Metering/MeteringService.cpp
+++ b/src/MicroOcpp/Model/Metering/MeteringService.cpp
@@ -57,22 +57,12 @@ MeteringService::MeteringService(Context& context, int numConn, std::shared_ptr<
         return isValid;
     };
 
-    std::function<bool(const char*)> validateUnsignedIntString = [] (const char *value) {
-        for(size_t i = 0; value[i] != '\0'; i++)
-        {
-            if (value[i] < '0' || value[i] > '9') {
-                return false;
-            }
-        }
-        return true;
-    };
-
     registerConfigurationValidator("MeterValuesSampledData", validateSelectString);
     registerConfigurationValidator("StopTxnSampledData", validateSelectString);
     registerConfigurationValidator("MeterValuesAlignedData", validateSelectString);
     registerConfigurationValidator("StopTxnAlignedData", validateSelectString);
-    registerConfigurationValidator("MeterValueSampleInterval", validateUnsignedIntString);
-    registerConfigurationValidator("ClockAlignedDataInterval", validateUnsignedIntString);
+    registerConfigurationValidator("MeterValueSampleInterval", VALIDATE_UNSIGNED_INT);
+    registerConfigurationValidator("ClockAlignedDataInterval", VALIDATE_UNSIGNED_INT);
 
     /*
      * Register further message handlers to support echo mode: when this library

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -50,9 +50,10 @@ void ResetService::loop() {
             MO_DBG_ERR("No Reset function set! Abort");
             outstandingResetRetries = 0;
         }
-        MO_DBG_ERR("Reset device failure. %s", outstandingResetRetries == 0 ? "Abort" : "Retry");
 
         if (outstandingResetRetries <= 0) {
+
+            MO_DBG_ERR("Reset device failure. Abort");
 
             ChargePointStatus cpStatus = ChargePointStatus_UNDEFINED;
             if (context.getModel().getNumConnectors() > 0) {

--- a/src/MicroOcpp/Model/Reset/ResetService.cpp
+++ b/src/MicroOcpp/Model/Reset/ResetService.cpp
@@ -29,6 +29,7 @@ ResetService::ResetService(Context& context)
       : MemoryManaged("v16.Reset.ResetService"), context(context) {
 
     resetRetriesInt = declareConfiguration<int>("ResetRetries", 2);
+    registerConfigurationValidator("ResetRetries", VALIDATE_UNSIGNED_INT);
 
     context.getOperationRegistry().registerOperation("Reset", [&context] () {
         return new Ocpp16::Reset(context.getModel());});


### PR DESCRIPTION
Fix a misleading debug OCPP message related to the Reset operation and reject negative integer values in ChangeConfiguration.