### PR TITLE
TxMessageAttempts optionally ignores offline attempts

### DIFF
--- a/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.cpp
@@ -1172,6 +1172,7 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
                 return nullptr;
             }
 
+            const auto attemptNr_capture = transactionFront->getStartSync().getAttemptNr();
             transactionFront->getStartSync().advanceAttemptNr();
             transactionFront->getStartSync().setAttemptTime(model.getClock().now());
             transactionFront->commit();
@@ -1203,6 +1204,19 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
                 }
             });
 
+            #if MO_TX_ATTEMPT_TIMEOUT == 0
+            //a timeout should not increase the attemptNr. Roll back to previous attemptNr
+            startTx->setOnTimeoutListener([transactionFront_capture, attemptNr_capture] () {
+                MO_DBG_DEBUG("StartTx timeout -> roll back attemptNr and try again");
+                if (transactionFront_capture) {
+                    transactionFront_capture->getStartSync().setAttemptNr(attemptNr_capture);
+                    transactionFront_capture->commit();
+                }
+            });
+            #else
+            (void)attemptNr_capture;
+            #endif
+
             return startTx;
         }
 
@@ -1229,6 +1243,7 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
                 return nullptr;
             }
 
+            const auto attemptNr_capture = transactionFront->getStopSync().getAttemptNr();
             transactionFront->getStopSync().advanceAttemptNr();
             transactionFront->getStopSync().setAttemptTime(model.getClock().now());
             transactionFront->commit();
@@ -1263,6 +1278,19 @@ std::unique_ptr<Request> Connector::fetchFrontRequest() {
                     //next getFrontRequestOpNr() call will collect transactionFront
                 }
             });
+
+            #if MO_TX_ATTEMPT_TIMEOUT == 0
+            //a timeout should not increase the attemptNr. Roll back to previous attemptNr
+            stopTx->setOnTimeoutListener([transactionFront_capture, attemptNr_capture] () {
+                MO_DBG_DEBUG("StopTx timeout -> roll back attemptNr and try again");
+                if (transactionFront_capture) {
+                    transactionFront_capture->getStopSync().setAttemptNr(attemptNr_capture);
+                    transactionFront_capture->commit();
+                }
+            });
+            #else
+            (void)attemptNr_capture;
+            #endif
 
             return stopTx;
         }

--- a/src/MicroOcpp/Model/ConnectorBase/Connector.h
+++ b/src/MicroOcpp/Model/ConnectorBase/Connector.h
@@ -28,6 +28,10 @@
 #define MO_REPORT_NOERROR 0
 #endif
 
+#ifndef MO_TX_ATTEMPT_TIMEOUT
+#define MO_TX_ATTEMPT_TIMEOUT 1 //if the timeout of a tx-related msg should increase its attempt counter
+#endif
+
 namespace MicroOcpp {
 
 class Context;


### PR DESCRIPTION
Add build switch `MO_TX_ATTEMPT_TIMEOUT` to control if a message timeout should increment the TxMessageAttempts counter.

MO only attempts to send messages when the WebSocket is in the connected state. This is, however, no guarantee that the signal strength is sufficient so that the messages actually arrive at the server and in consequence, the attempt fails. During long periods with bad signal strength, the connection could frequently switch between the connected and unconnected states without ever allowing OCPP operations to pass through. MO would effectively drop the offline tx queue then, even though there is nothing wrong with these messages themselves.

The new option `MO_TX_ATTEMPT_TIMEOUT` allows to control what happens if tx-related messages time out. In the default setting, `MO_TX_ATTEMPT_TIMEOUT=1`, a timed-out message increments the attempt counter (current behavior). `MO_TX_ATTEMPT_TIMEOUT=0` defines that time-outs should leave the attempt counter like before (optional, new behavior).