### PR TITLE
Improvements for custom platform integrations

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -158,7 +158,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: google/bloaty
-        ref: 379d5305670c00c36a57e608079fd253f13bde63
+        ref: e1155149d54bb09b81e86f0e4e5cb7fbd2a318eb
         path: tools/bloaty
         submodules: recursive
     - name: Install bloaty

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       run: ./build/mo_unit_tests --abort
     - name: Create coverage report
       run: |
-        lcov --directory . --capture --output-file coverage.info
+        lcov --directory . --capture --output-file coverage.info --ignore-errors mismatch
         lcov --remove coverage.info '/usr/*' '*/tests/*' '*/ArduinoJson.h' --output-file coverage.info
         lcov --list coverage.info
     - name: Upload coverage reports to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@
 - Change `MicroOcpp::TxNotification` into C-style enum, replace `OCPP_TxNotication` ([#386](https://github.com/matth-x/MicroOcpp/pull/386))
 - Improved UUID generation ([#383](https://github.com/matth-x/MicroOcpp/pull/383))
 - `beginTransaction()` returns bool for better v2.0.1 interop ([#386](https://github.com/matth-x/MicroOcpp/pull/386))
+- Configurations C-API updates ([#400](https://github.com/matth-x/MicroOcpp/pull/400))
+- Platform integrations C-API upates ([#400](https://github.com/matth-x/MicroOcpp/pull/400))
 
 ### Added
 
 - `getTransactionV201()` exposes v201 Tx in API ([#386](https://github.com/matth-x/MicroOcpp/pull/386))
 - v201 support in Transaction.h C-API ([#386](https://github.com/matth-x/MicroOcpp/pull/386))
+- Write-only Configurations ([#400](https://github.com/matth-x/MicroOcpp/pull/400))
 
 ### Fixed
 
 - Timing issues for OCTT test cases ([#383](https://github.com/matth-x/MicroOcpp/pull/383))
 - Misleading Reset failure dbg msg ([#388](https://github.com/matth-x/MicroOcpp/pull/388))
 - Reject negative ints in ChangeConfig ([#388](https://github.com/matth-x/MicroOcpp/pull/388))
+- Revised SCons integration ([#400](https://github.com/matth-x/MicroOcpp/pull/400))
 
 ## [1.2.0] - 2024-11-03
 

--- a/SConscript.py
+++ b/SConscript.py
@@ -7,7 +7,7 @@
 #       Use this file as a starting point for writing your own SCons integration. And as always, any
 #       contributions are highly welcome!
 
-Import("env", "ARDUINOJSON_DIR")
+Import("env")
 
 import os, pathlib
 
@@ -17,16 +17,15 @@ def getAllDirs(root_dir):
         dir_list.append(Dir(root))
     return dir_list
 
-SOURCE_DIR = Dir(".").srcnode()
+SOURCE_DIR = Dir(".").srcnode().Dir("src")
 
-source_dirs = getAllDirs(SOURCE_DIR.Dir("src"))
-source_dirs += getAllDirs(ARDUINOJSON_DIR.Dir("src"))
+source_dirs = getAllDirs(SOURCE_DIR)
 
 source_files = []
 
 for folder in source_dirs:
+    source_files += folder.glob("*.c")
     source_files += folder.glob("*.cpp")
-    env["CPPPATH"].append(folder)
 
 compiled_objects = []
 for source_file in source_files:
@@ -44,7 +43,7 @@ libmicroocpp = env.StaticLibrary(
 
 exports = {
     'library': libmicroocpp,
-    'CPPPATH': source_dirs.copy()
+    'CPPPATH': SOURCE_DIR
 }
 
 Return("exports")

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.cpp
@@ -75,11 +75,27 @@ bool Configuration::isRebootRequired() {
 }
 
 void Configuration::setReadOnly() {
-    readOnly = true;
+    if (mutability == Mutability::ReadWrite) {
+        mutability = Mutability::ReadOnly;
+    } else {
+        mutability = Mutability::None;
+    }
 }
 
 bool Configuration::isReadOnly() {
-    return readOnly;
+    return mutability == Mutability::ReadOnly;
+}
+
+bool Configuration::isReadable() {
+    return mutability == Mutability::ReadWrite || mutability == Mutability::ReadOnly;
+}
+
+void Configuration::setWriteOnly() {
+    if (mutability == Mutability::ReadWrite) {
+        mutability = Mutability::WriteOnly;
+    } else {
+        mutability = Mutability::None;
+    }
 }
 
 /*

--- a/src/MicroOcpp/Core/ConfigurationKeyValue.h
+++ b/src/MicroOcpp/Core/ConfigurationKeyValue.h
@@ -36,7 +36,15 @@ protected:
     revision_t value_revision = 0; //write access counter; used to check if this config has been changed
 private:
     bool rebootRequired = false;
-    bool readOnly = false;
+
+    enum class Mutability : uint8_t {
+        ReadWrite,
+        ReadOnly,
+        WriteOnly,
+        None
+    };
+    Mutability mutability = Mutability::ReadWrite;
+
 public:
     virtual ~Configuration();
 
@@ -60,6 +68,9 @@ public:
 
     void setReadOnly();
     bool isReadOnly();
+    bool isReadable();
+
+    void setWriteOnly();
 };
 
 /*

--- a/src/MicroOcpp/Core/Configuration_c.h
+++ b/src/MicroOcpp/Core/Configuration_c.h
@@ -42,8 +42,21 @@ typedef struct ocpp_configuration {
 
     uint16_t (*get_write_count) (void *user_data); // Return number of changes of the value. MO uses this to detect if the firmware has updated the config
 
+    bool read_only;
+    bool write_only;
+    bool reboot_required;
+
     void *mo_data; // Reserved for MO
 } ocpp_configuration;
+
+void ocpp_setRebootRequired(ocpp_configuration *config);
+bool ocpp_isRebootRequired(ocpp_configuration *config);
+
+void ocpp_setReadOnly(ocpp_configuration *config);
+bool ocpp_isReadOnly(ocpp_configuration *config);
+bool ocpp_isReadable(ocpp_configuration *config);
+
+void ocpp_setWriteOnly(ocpp_configuration *config);
 
 typedef struct ocpp_configuration_container {
     void *user_data; //set this at your choice. MO passes it back to the functions below

--- a/src/MicroOcpp/Model/Transactions/Transaction.cpp
+++ b/src/MicroOcpp/Model/Transactions/Transaction.cpp
@@ -444,6 +444,16 @@ const char *ocpp_tx_getIdTag(OCPP_Transaction *tx) {
     return reinterpret_cast<MicroOcpp::Transaction*>(tx)->getIdTag();
 }
 
+const char *ocpp_tx_getParentIdTag(OCPP_Transaction *tx) {
+    #if MO_ENABLE_V201
+    if (g_ocpp_tx_compat_v201) {
+        MO_DBG_ERR("only supported in v16");
+        return nullptr;
+    }
+    #endif //MO_ENABLE_V201
+    return reinterpret_cast<MicroOcpp::Transaction*>(tx)->getParentIdTag();
+}
+
 bool ocpp_tx_getBeginTimestamp(OCPP_Transaction *tx, char *buf, size_t len) {
     #if MO_ENABLE_V201
     if (g_ocpp_tx_compat_v201) {

--- a/src/MicroOcpp/Model/Transactions/Transaction.h
+++ b/src/MicroOcpp/Model/Transactions/Transaction.h
@@ -14,7 +14,7 @@ extern "C" {
 
 //TxNotification - event from MO to the main firmware to notify it about transaction state changes
 typedef enum {
-    UNDEFINED,
+    TxNotification_UNDEFINED,
 
     //Authorization events
     TxNotification_Authorized, //success
@@ -472,6 +472,8 @@ bool ocpp_tx_isAborted(OCPP_Transaction *tx);
 bool ocpp_tx_isCompleted(OCPP_Transaction *tx);
 
 const char *ocpp_tx_getIdTag(OCPP_Transaction *tx);
+
+const char *ocpp_tx_getParentIdTag(OCPP_Transaction *tx);
 
 bool ocpp_tx_getBeginTimestamp(OCPP_Transaction *tx, char *buf, size_t len);
 

--- a/src/MicroOcpp/Operations/GetConfiguration.cpp
+++ b/src/MicroOcpp/Operations/GetConfiguration.cpp
@@ -40,6 +40,9 @@ std::unique_ptr<JsonDoc> GetConfiguration::createConf(){
                     MO_DBG_ERR("invalid config");
                     continue;
                 }
+                if (!container->getConfiguration(i)->isReadable()) {
+                    continue;
+                }
                 configurations.push_back(container->getConfiguration(i));
             }
         }
@@ -53,7 +56,7 @@ std::unique_ptr<JsonDoc> GetConfiguration::createConf(){
                 }
             }
 
-            if (res) {
+            if (res && res->isReadable()) {
                 configurations.push_back(res);
             } else {
                 unknownKeys.push_back(key.c_str());

--- a/src/MicroOcpp/Platform.h
+++ b/src/MicroOcpp/Platform.h
@@ -16,6 +16,12 @@
 #define MO_PLATFORM MO_PLATFORM_ARDUINO
 #endif
 
+#ifdef __cplusplus
+#define MO_EXTERN_C extern "C"
+#else
+#define MO_EXTERN_C
+#endif
+
 #if MO_PLATFORM == MO_PLATFORM_NONE
 #ifndef MO_CUSTOM_CONSOLE
 #define MO_CUSTOM_CONSOLE
@@ -32,18 +38,10 @@
 #define MO_CUSTOM_CONSOLE_MAXMSGSIZE 256
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 extern char _mo_console_msg_buf [MO_CUSTOM_CONSOLE_MAXMSGSIZE]; //define msg_buf in data section to save memory (see https://github.com/matth-x/MicroOcpp/pull/304)
-void _mo_console_out(const char *msg);
+MO_EXTERN_C void _mo_console_out(const char *msg);
 
-void mocpp_set_console_out(void (*console_out)(const char *msg));
-
-#ifdef __cplusplus
-}
-#endif
+MO_EXTERN_C void mocpp_set_console_out(void (*console_out)(const char *msg));
 
 #define MO_CONSOLE_PRINTF(X, ...) \
             do { \
@@ -79,9 +77,9 @@ void mocpp_set_console_out(void (*console_out)(const char *msg));
 #endif
 
 #ifdef MO_CUSTOM_TIMER
-extern "C" void mocpp_set_timer(unsigned long (*get_ms)());
+MO_EXTERN_C void mocpp_set_timer(unsigned long (*get_ms)());
 
-extern "C" unsigned long mocpp_tick_ms_custom();
+MO_EXTERN_C unsigned long mocpp_tick_ms_custom();
 #define mocpp_tick_ms mocpp_tick_ms_custom
 #else
 
@@ -89,20 +87,20 @@ extern "C" unsigned long mocpp_tick_ms_custom();
 #include <Arduino.h>
 #define mocpp_tick_ms millis
 #elif MO_PLATFORM == MO_PLATFORM_ESPIDF
-extern "C" unsigned long mocpp_tick_ms_espidf();
+MO_EXTERN_C unsigned long mocpp_tick_ms_espidf();
 #define mocpp_tick_ms mocpp_tick_ms_espidf
 #elif MO_PLATFORM == MO_PLATFORM_UNIX
-extern "C" unsigned long mocpp_tick_ms_unix();
+MO_EXTERN_C unsigned long mocpp_tick_ms_unix();
 #define mocpp_tick_ms mocpp_tick_ms_unix
 #endif
 #endif
 
 #ifdef MO_CUSTOM_RNG
-void mocpp_set_rng(uint32_t (*rng)());
-uint32_t mocpp_rng_custom();
+MO_EXTERN_C void mocpp_set_rng(uint32_t (*rng)());
+MO_EXTERN_C uint32_t mocpp_rng_custom();
 #define mocpp_rng mocpp_rng_custom
 #else
-uint32_t mocpp_time_based_prng(void);
+MO_EXTERN_C uint32_t mocpp_time_based_prng(void);
 #define mocpp_rng mocpp_time_based_prng
 #endif
 

--- a/tests/Api.cpp
+++ b/tests/Api.cpp
@@ -13,6 +13,8 @@
 #include <catch2/catch.hpp>
 #include "./helpers/testHelper.h"
 
+#include <array>
+
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
 #define SCPROFILE "[2,\"testmsg\",\"SetChargingProfile\",{\"connectorId\":0,\"csChargingProfiles\":{\"chargingProfileId\":0,\"stackLevel\":0,\"chargingProfilePurpose\":\"ChargePointMaxProfile\",\"chargingProfileKind\":\"Absolute\",\"chargingSchedule\":{\"duration\":1000000,\"startSchedule\":\"2023-01-01T00:00:00.000Z\",\"chargingRateUnit\":\"W\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":16,\"numberPhases\":3}]}}}]"
 

--- a/tests/ChargingSessions.cpp
+++ b/tests/ChargingSessions.cpp
@@ -16,6 +16,8 @@
 #include <catch2/catch.hpp>
 #include "./helpers/testHelper.h"
 
+#include <array>
+
 #define BASE_TIME "2023-01-01T00:00:00.000Z"
 
 using namespace MicroOcpp;


### PR DESCRIPTION
Simplify some aspects of custom platform integrations:

* Extend C-API
  * Revise Configurations C-API
  * Add parentIdTag getter in Transactions C-API
  * Move Console Cb and Rng Cb to Platform.h
  * Simplify the usage of custom FilesystemAdapters
  * Add `ocpp_addMeterValueInputIntTx` to support reading Tx start and stop values
* Revise SCons support
* Built-in support for write-only Configurations