### PR TITLE
Add ESP_LOG support in platform

### DIFF
--- a/src/MicroOcpp/Platform.h
+++ b/src/MicroOcpp/Platform.h
@@ -69,7 +69,11 @@ MO_EXTERN_C void mocpp_set_console_out(void (*console_out)(const char *msg));
 #endif
 
 #define MO_CONSOLE_PRINTF(X, ...) MO_USE_SERIAL.printf_P(PSTR(X), ##__VA_ARGS__)
-#elif MO_PLATFORM == MO_PLATFORM_ESPIDF || MO_PLATFORM == MO_PLATFORM_UNIX
+#elif MO_PLATFORM == MO_PLATFORM_ESPIDF
+#include "esp_log.h"
+
+#define MO_CONSOLE_PRINTF(X, ...) ESP_LOGI("MicroOcpp", X, ##__VA_ARGS__)
+#elif MO_PLATFORM == MO_PLATFORM_UNIX
 #include <stdio.h>
 
 #define MO_CONSOLE_PRINTF(X, ...) printf(X, ##__VA_ARGS__)


### PR DESCRIPTION
Update the platform logging to use the `ESP_LOGx` macros when `MO_PLATFORM` is set to `MO_PLATFORM_ESPIDF`.

This allows log messages from the library to be managed properly alongside other application logs when using functions from the [ESP-IDF logging library](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html) like `esp_log_level_set()` to supress logs or `esp_log_set_vprintf()` to route them to a different destination.