### PR TITLE
TC_068_CS / Stop transaction logic simplication

### DIFF
--- a/examples/ESP/main.cpp
+++ b/examples/ESP/main.cpp
@@ -103,35 +103,14 @@ void loop() {
     if (/* RFID chip detected? */ false) {
         String idTag = "0123456789ABCD"; //e.g. idTag = RFID.readIdTag();
 
-        if (!getTransaction()) {
-            //no transaction running or preparing. Begin a new transaction
-            Serial.printf("[main] Begin Transaction with idTag %s\n", idTag.c_str());
-
-            /*
-             * Begin Transaction. The OCPP lib will prepare transaction by checking the Authorization
-             * and listen to the ConnectorPlugged Input. When the Authorization succeeds and an EV
-             * is plugged, the OCPP lib will send the StartTransaction
-             */
-            auto ret = beginTransaction(idTag.c_str());
-
-            if (ret) {
-                Serial.println(F("[main] Transaction initiated. OCPP lib will send a StartTransaction when" \
-                                 "ConnectorPlugged Input becomes true and if the Authorization succeeds"));
-            } else {
-                Serial.println(F("[main] No transaction initiated"));
-            }
-
-        } else {
-            //Transaction already initiated. Check if to stop current Tx by RFID card
-            if (idTag.equals(getTransactionIdTag())) {
-                //card matches -> user can stop Tx
-                Serial.println(F("[main] End transaction by RFID card"));
-
-                endTransaction(idTag.c_str());
-            } else {
-                Serial.println(F("[main] Cannot end transaction by RFID card (different card?)"));
-            }
-        }
+        /*
+         * Begin Transaction. The OCPP lib will prepare transaction by checking the Authorization
+         * and listen to the ConnectorPlugged Input. When the Authorization succeeds and an EV
+         * is plugged, the OCPP lib will send the StartTransaction
+         * 
+         * If transaction already exists, stop by RFID card (if idTag or parentIdTag match)
+         */
+        authorize(idTag.c_str());
     }
 
     //... see MicroOcpp.h for more possibilities

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -547,7 +547,7 @@ bool endTransaction(const char *idTag, const char *reason, unsigned int connecto
                         }
                         return;
                     }
-                    if (idTagInfo.containsKey("parentIdTag") && !strcmp(idTagInfo["parenIdTag"], tx->getParentIdTag()))
+                    if (idTagInfo.containsKey("parentIdTag") && !strcmp(idTagInfo["parentIdTag"], tx->getParentIdTag()))
                     {
                         endTransaction_authorized(idTag_capture.c_str(), reason_capture.empty() ? (const char*)nullptr : reason_capture.c_str(), connectorId);
                     }

--- a/src/MicroOcpp.cpp
+++ b/src/MicroOcpp.cpp
@@ -1397,6 +1397,18 @@ void authorize(const char *idTag, OnReceiveConfListener onConf, OnAbortListener 
         MO_DBG_ERR("idTag format violation. Expect c-style string with at most %u characters", IDTAG_LEN_MAX);
         return;
     }
+
+    //check for active transactions
+    for (unsigned int cId = 1; cId < context->getModel().getNumConnectors(); cId++) {
+        if (isTransactionActive(cId)) {
+            //this will check both parentIdTag and idTag
+            if (endTransaction(idTag, "Local", cId)) {
+                MO_DBG_INFO("ended active transaction on connector %d for idTag '%s'", cId, idTag);
+                return;
+            }
+        }
+    }
+
     auto authorize = makeRequest(
         new Authorize(context->getModel(), idTag));
     if (onConf)


### PR DESCRIPTION
@matth-x what do you think about this? We found this removed a lot of lines of code from our main loop.

If you like the idea, I can add a test-case for it in unit tests.

Still, this test case fails for some reason I can't understand:

```
[19:20:35.456] [info]  ========================= Starting Testcase Preparation ==========================
[19:20:35.456] [info]  Entering state Charging
[19:20:35.458] [REQUEST]
[19:20:35.458] [msg-out]  [2, "17e3f195-3870-4cd9-808c-378bc34d687f", "GetConfiguration", {"key":["AuthorizeRemoteTxRequests"]}]
[19:20:35.459] [info]  Waiting for response message of type GetConfigurationResponse
[19:20:35.608] [RESPONSE]
[19:20:35.608] [msg-in]  [3,"17e3f195-3870-4cd9-808c-378bc34d687f",{"configurationKey":[{"key":"AuthorizeRemoteTxRequests","readonly":false,"value":"false"}]}]
[19:20:35.618] [info]  Received response message of the expected type.
[19:20:35.619] [REQUEST]
[19:20:35.619] [msg-out]  [2, "7a1624a0-44d3-4e5b-bc3c-f66d8767f42d", "RemoteStartTransaction", {"connectorId":1,"idTag":"042E3BDA6B6B80"}]
[19:20:35.619] [info]  Waiting for response message of type RemoteStartTransactionResponse
[19:20:35.831] [RESPONSE]
[19:20:35.831] [msg-in]  [3,"7a1624a0-44d3-4e5b-bc3c-f66d8767f42d",{"status":"Accepted"}]
[19:20:35.838] [info]  Received response message of the expected type.
[19:20:35.839] [info]  Waiting for request message of type StatusNotificationRequest
[19:20:35.926] [REQUEST]
[19:20:35.926] [msg-in]  [2,"03f67a97-1281-4f89-0a10-9197812771b8","StartTransaction",{"connectorId":1,"idTag":"042E3BDA6B6B80","meterStart":164,"timestamp":"2025-11-28T19:20:35Z"}]
[19:20:35.947] [RESPONSE]
[19:20:35.947] [msg-out]  [3, "03f67a97-1281-4f89-0a10-9197812771b8", {"idTagInfo":{"status":"Accepted"},"transactionId":1764356684}]
[19:20:35.948] [info]  Received unexpected request message: StartTransactionRequest (Waiting for StatusNotificationRequest; )
[19:20:35.949] [info]  The value of 'Reset CS after testcase' is false
[19:20:35.949] [info]  ============================ Starting Final Cleanup ==============================
[19:20:36.122] [verdict]  INCONC
[19:20:36.122] [info]  The test case has ended.
[19:20:36.123] [stopped_testcase]  

2025-11-28 19:22:40.626
msg-in
[
  2,
  "0d7ce563-5334-aae6-b2e0-f5d44d3c247c",
  "StatusNotification",
  {
    "connectorId": 1,
    "errorCode": "NoError",
    "status": "SuspendedEV",
    "timestamp": "2025-11-28T19:22:39Z"
  }
]
2025-11-28 19:22:40.631
msg-out
[
  3,
  "0d7ce563-5334-aae6-b2e0-f5d44d3c247c",
  {}
]
2025-11-28 19:22:42.246
msg-in
[
  2,
  "0838895f-a165-5e53-5247-8c557306eaa7",
  "StatusNotification",
  {
    "connectorId": 1,
    "errorCode": "NoError",
    "status": "Charging",
    "timestamp": "2025-11-28T19:22:41Z"
  }
]
2025-11-28 19:22:42.250
msg-out

[
  3,
  "0838895f-a165-5e53-5247-8c557306eaa7",
  {}
]
```

so the charger sends the `StatusNotification`, but after `StartTransactionRequest`, isn't this expected?

<img width="1020" height="1383" alt="Screenshot 2025-11-28 at 21 29 08" src="https://github.com/user-attachments/assets/18b5c0f7-cf0c-4fa6-b1db-3c934ac819d1" />