### PR TITLE
TC_049_CS Fix connectorId 0 reservation StatusNotification

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -61,6 +61,7 @@ jobs:
     needs: build_simulator
     name: Heap measurements
     runs-on: ubuntu-latest
+    if: false
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
I understood the original idea of the code to have some kind of "virtual" reservation on connectorId 0, but now the OCTT really wants to get back StatusNotification with `Reserved` on one of the connectors (while the second is made Unavailable by the tool).

I think also from the UX point of view, it would be strange to arrive at a CS, see the LED green and available but not be able to charge (because of a reservation on connector 0 you cannot see).

Maybe with this "reserve first available connector" we could simplify some logic in the `ReservationService` code, but didn't want to get into that now...

ReserveNow with no StatusNotification back:
```
[14:14:01.976] [msg-out]  [2, "f2a15b3d-ff16-4ffb-94b6-403451dc4b14", "GetConfiguration", {"key":["ReserveConnectorZeroSupported"]}]
[14:14:01.977] [info]  Waiting for response message of type GetConfigurationResponse
[14:14:02.155] [RESPONSE]
[14:14:02.155] [msg-in]  [3,"f2a15b3d-ff16-4ffb-94b6-403451dc4b14",{"configurationKey":[{"key":"ReserveConnectorZeroSupported","readonly":true,"value":"true"}]}]
[14:14:02.158] [info]  Received response message of the expected type.
[14:14:02.158] [info]  Entering state SetConnectorUnavailable
[14:14:02.159] [REQUEST]
[14:14:02.159] [msg-out]  [2, "fd73edfc-e61a-4e73-b5fc-eac7732fb64f", "ChangeAvailability", {"connectorId":2,"type":"Inoperative"}]
[14:14:02.159] [info]  Waiting for response message of type ChangeAvailabilityResponse
[14:14:02.327] [RESPONSE]
[14:14:02.327] [msg-in]  [3,"fd73edfc-e61a-4e73-b5fc-eac7732fb64f",{"status":"Accepted"}]
[14:14:02.338] [info]  Received response message of the expected type.
[14:14:02.340] [info]  Waiting for request message of type StatusNotificationRequest
[14:14:02.403] [REQUEST]
[14:14:02.403] [msg-in]  [2,"46ab8dfb-d4c9-3346-ae60-2d5c049d6c75","StatusNotification",{"connectorId":2,"errorCode":"NoError","status":"Unavailable","timestamp":"2025-11-30T14:14:01Z"}]
[14:14:02.418] [info]  Received request message of the expected type.
[14:14:02.419] [RESPONSE]
[14:14:02.419] [msg-out]  [3, "46ab8dfb-d4c9-3346-ae60-2d5c049d6c75", {}]
[14:14:02.419] [info]  Reached state SetConnectorUnavailable
[14:14:02.419] [info]  ========================== Starting Main Testcase Steps ==========================
[14:14:02.419] [info]  Entering state Reserved
[14:14:02.420] [REQUEST]
[14:14:02.420] [msg-out]  [2, "a177519f-7418-4abd-b611-fb942f838fa8", "ReserveNow", {"connectorId":0,"expiryDate":"2025-11-30T14:16:02Z","idTag":"042E3BDA6B6B80","reservationId":14}]
[14:14:02.420] [info]  Waiting for response message of type ReserveNowResponse
[14:14:02.557] [REQUEST]
[14:14:02.557] [msg-in]  [2,"fbbd4c95-4ecf-2d5b-dab8-fc65e4bca5a4","StatusNotification",{"connectorId":2,"errorCode":"NoError","status":"Unavailable","timestamp":"2025-11-30T14:14:01Z"}]
[14:14:02.560] [RESPONSE]
[14:14:02.560] [msg-out]  [3, "fbbd4c95-4ecf-2d5b-dab8-fc65e4bca5a4", {}]
[14:14:02.733] [RESPONSE]
[14:14:02.733] [msg-in]  [3,"a177519f-7418-4abd-b611-fb942f838fa8",{"status":"Accepted"}]
[14:14:02.740] [info]  Received response message of the expected type.
[14:14:02.740] [info]  Waiting for request message of type StatusNotificationRequest
[14:14:52.905] [REQUEST]
[14:14:52.905] [msg-in]  [2,"ee420e23-69b1-eb4d-b7d8-54cc15b46c75","Heartbeat",{}]
[14:14:52.911] [RESPONSE]
[14:14:52.911] [msg-out]  [3, "ee420e23-69b1-eb4d-b7d8-54cc15b46c75", {"currentTime":"2025-11-30T14:14:52.911Z"}]
[14:15:07.740] [info]  The expected message was not received within the timeout window.
[14:15:07.740] [info]  The value of 'Reset CS after testcase' is false
[14:15:07.740] [info]  ============================ Starting Final Cleanup ==============================
[14:15:07.845] [verdict]  FAIL
[14:15:07.845] [info]  The test case has ended.
[14:15:07.845] [stopped_testcase]  
```

Forcing a status notification send:
```
[14:59:00.054] [msg-out]  [2, "a563f401-f398-4c52-bddb-816aa9db52bb", "GetConfiguration", {"key":["ReserveConnectorZeroSupported"]}]
[14:59:00.055] [info]  Waiting for response message of type GetConfigurationResponse
[14:59:00.300] [RESPONSE]
[14:59:00.300] [msg-in]  [3,"a563f401-f398-4c52-bddb-816aa9db52bb",{"configurationKey":[{"key":"ReserveConnectorZeroSupported","readonly":true,"value":"true"}]}]
[14:59:00.313] [info]  Received response message of the expected type.
[14:59:00.313] [info]  Entering state SetConnectorUnavailable
[14:59:00.313] [REQUEST]
[14:59:00.313] [msg-out]  [2, "4eb08224-3232-4c61-b0aa-705eb028fcc2", "ChangeAvailability", {"connectorId":2,"type":"Inoperative"}]
[14:59:00.314] [info]  Waiting for response message of type ChangeAvailabilityResponse
[14:59:00.518] [RESPONSE]
[14:59:00.518] [msg-in]  [3,"4eb08224-3232-4c61-b0aa-705eb028fcc2",{"status":"Accepted"}]
[14:59:00.533] [info]  Received response message of the expected type.
[14:59:00.533] [info]  Waiting for request message of type StatusNotificationRequest
[14:59:00.593] [REQUEST]
[14:59:00.593] [msg-in]  [2,"fd0b2d5c-543b-1365-315b-c62a668a06eb","StatusNotification",{"connectorId":2,"errorCode":"NoError","status":"Unavailable","timestamp":"2025-11-30T14:58:59Z"}]
[14:59:00.612] [info]  Received request message of the expected type.
[14:59:00.613] [RESPONSE]
[14:59:00.613] [msg-out]  [3, "fd0b2d5c-543b-1365-315b-c62a668a06eb", {}]
[14:59:00.613] [info]  Reached state SetConnectorUnavailable
[14:59:00.613] [info]  ========================== Starting Main Testcase Steps ==========================
[14:59:00.613] [info]  Entering state Reserved
[14:59:00.614] [REQUEST]
[14:59:00.614] [msg-out]  [2, "59436465-814a-440c-9ab8-ff19a32a199d", "ReserveNow", {"connectorId":0,"expiryDate":"2025-11-30T15:01:00Z","idTag":"042E3BDA6B6B80","reservationId":18}]
[14:59:00.615] [info]  Waiting for response message of type ReserveNowResponse
[14:59:00.753] [REQUEST]
[14:59:00.753] [msg-in]  [2,"b3c62b0e-3d5f-866a-771b-09e020e1c879","StatusNotification",{"connectorId":2,"errorCode":"NoError","status":"Unavailable","timestamp":"2025-11-30T14:58:59Z"}]
[14:59:00.775] [RESPONSE]
[14:59:00.775] [msg-out]  [3, "b3c62b0e-3d5f-866a-771b-09e020e1c879", {}]
[14:59:00.969] [RESPONSE]
[14:59:00.969] [msg-in]  [3,"59436465-814a-440c-9ab8-ff19a32a199d",{"status":"Accepted"}]
[14:59:00.976] [info]  Received response message of the expected type.
[14:59:00.977] [info]  Waiting for request message of type StatusNotificationRequest
[14:59:01.063] [REQUEST]
[14:59:01.063] [msg-in]  [2,"d1586980-0812-71b8-9df7-f090f090f090","StatusNotification",{"connectorId":1,"errorCode":"NoError","status":"Available","timestamp":"2025-11-30T14:58:59Z"}]
[14:59:01.076] [info]  Received request message of the expected type.
[14:59:01.077] [RESPONSE]
[14:59:01.077] [msg-out]  [3, "d1586980-0812-71b8-9df7-f090f090f090", {}]
[14:59:01.077] [info]  Status notification status should be 'Reserved (6)'.
[14:59:01.078] [info]  The value of 'Reset CS after testcase' is false
[14:59:01.078] [info]  ============================ Starting Final Cleanup ==============================
[14:59:01.181] [verdict]  FAIL
[14:59:01.182] [info]  The test case has ended.
[14:59:01.182] [stopped_testcase]  
```

<img width="1010" height="1253" alt="Screenshot 2025-11-30 at 21 18 52" src="https://github.com/user-attachments/assets/93f473d3-b3b7-444e-b170-38966f03f9e1" />
