### PR TITLE
TC_045_2_CS Fix Get Diagnostics - Upload Failed

### DIFF
--- a/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
+++ b/src/MicroOcpp/Model/Diagnostics/DiagnosticsService.h
@@ -29,7 +29,7 @@ private:
     Context& context;
     
     String location;
-    unsigned int retries = 0;
+    int retries = -1;
     unsigned int retryInterval = 0;
     Timestamp startTime;
     Timestamp stopTime;
@@ -68,7 +68,7 @@ public:
     //timestamps before year 2021 will be treated as "undefined"
     //returns empty std::string if onUpload is missing or upload cannot be scheduled for another reason
     //returns fileName of diagnostics file to be uploaded if upload has been scheduled
-    String requestDiagnosticsUpload(const char *location, unsigned int retries = 1, unsigned int retryInterval = 0, Timestamp startTime = Timestamp(), Timestamp stopTime = Timestamp());
+    String requestDiagnosticsUpload(const char *location, int retries = 1, unsigned int retryInterval = 0, Timestamp startTime = Timestamp(), Timestamp stopTime = Timestamp());
 
     Ocpp16::DiagnosticsStatus getDiagnosticsStatus();
 


### PR DESCRIPTION
Closes #397

This test-case has changed in the meantime, so retries is 0 in OCTT, which in the current implementation means "not even trying once".

```
2025-11-30 22:27:23.945
RESPONSE
2025-11-30 22:27:23.945
msg-in
[
  3,
  "bf15dd11-5a87-4c24-a8ca-e07b3d7ad77d",
  {
    "fileName": "AstreeaDiagnostics_SNASTR2568_2025-11-30T22:27:23Z.log"
  }
]
2025-11-30 22:27:23.957
info
Received response message of the expected type.
2025-11-30 22:27:23.957
info
Waiting for request message of type DiagnosticsStatusNotificationRequest
2025-11-30 22:27:28.993
REQUEST
2025-11-30 22:27:28.993
msg-in
[
  2,
  "4bee420e-22e0-f5d3-5a4f-0b2d5b5dab8d",
  "DiagnosticsStatusNotification",
  {
    "status": "UploadFailed"
  }
]
2025-11-30 22:27:29.009
info
Received request message of the expected type.
2025-11-30 22:27:29.010
RESPONSE
2025-11-30 22:27:29.010
msg-out
[
  3,
  "4bee420e-22e0-f5d3-5a4f-0b2d5b5dab8d",
  {}
]
2025-11-30 22:27:29.014
info
DiagnosticsStatusNotificationRequest.status should be 'Uploading'.
2025-11-30 22:27:29.014
info
The value of 'Reset CS after testcase' is false
2025-11-30 22:27:29.014
info
============================ Starting Final Cleanup ==============================
2025-11-30 22:27:29.116
FAIL
FAIL
2025-11-30 22:27:29.117
info
The test case has ended.
```