### PR TITLE
TC_037_2_CS Fix Offline Start Transaction - Invalid IdTag

### DIFF
--- a/src/MicroOcpp/Core/RequestQueue.cpp
+++ b/src/MicroOcpp/Core/RequestQueue.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<Request> VolatileRequestQueue::fetchFrontRequest() {
 bool VolatileRequestQueue::pushRequestBack(std::unique_ptr<Request> request) {
 
     // Don't queue up multiple StatusNotification messages for the same connectorId
-    #if 0 // Leads to ASAN failure when executed by Unit test suite (CustomOperation is casted to StatusNotification)
+    #ifndef CATCH_CONFIG_EXTERNAL_INTERFACES // Leads to ASAN failure when executed by Unit test suite (CustomOperation is casted to StatusNotification)
     if (strcmp(request->getOperationType(), "StatusNotification") == 0)
     {
         size_t i = 0;


### PR DESCRIPTION
When StopTransactionOnInvalidId = false, the dedup of StatusNotification messages is important, OCTT expects Charging, not Preparing + SuspendedEV + Charging.

```
[23:12:57.681] [info]  ========================== Starting Main Testcase Steps ==========================
[23:12:57.782] [info]  Disconnected from System Under Test
[23:12:57.784] [prompt]  Please authorize the transaction, with idTag: '045741FA6B6B80' on connectorId '1'.
[23:12:57.785] [info]  Ignoring event: <unbound>
[23:13:18.802] [api_dismissed]  a75e7ebd-f286-43e5-8ae3-dfbd02fb7be9
[23:13:18.802] [info]  Got 'continue' on the previous API request, continuing.
[23:13:18.802] [prompt]  Please plug in your cable on EV side.
[23:13:25.968] [api_dismissed]  96866b12-8f0a-448c-b9ee-bca4344836b2
[23:13:25.968] [info]  Got 'continue' on the previous API request, continuing.
[23:13:25.969] [prompt]  Please plug in your cable on Charging Station side on connectorId '1'.
[23:13:30.051] [api_dismissed]  66a49b0b-82b3-496a-bd18-ccc2a189b476
[23:13:30.051] [info]  Got 'continue' on the previous API request, continuing.
[23:13:30.051] [info]  Waiting for 10 seconds.
[23:13:40.051] [info]  Using Security Profile:  2
[23:13:40.062] [info]  Using keystore: meta-data/certificates/root/stores/csms_keystore.jks
[23:13:40.062] [info]  Using truststore: meta-data/certificates/root/stores/csms_truststore.jks
[23:13:40.062] [info]  Enabled cipher suite(s): TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256
[23:13:40.075] [info]  Waiting for request message of type StatusNotificationRequest
[23:13:44.680] [info]  TLS handshake succeeded with cipher suite TLS_RSA_WITH_AES_128_GCM_SHA256
[23:13:44.807] [info]  Successfully connected to System Under Test on Default port
[23:13:44.821] [info]  Waiting for request messages of type StatusNotificationRequest and StartTransactionRequest. Not all message types are mandatory, as some are optional. Please refer to the testcase document to see which ones are mandatory.
[23:13:45.171] [REQUEST]
[23:13:45.171] [msg-in]  [2,"e26ec28e-2af2-668a-7923-725e527e3346","StatusNotification",{"connectorId":1,"errorCode":"NoError","status":"Preparing","timestamp":"2025-11-30T23:13:14Z"}]
[23:13:45.184] [RESPONSE]
[23:13:45.184] [msg-out]  [3, "e26ec28e-2af2-668a-7923-725e527e3346", {}]
[23:13:45.185] [info]  StatusNotificationRequest.status should be 'SuspendedEVSE'.
[23:13:45.185] [info]  The value of 'Reset CS after testcase' is false
[23:13:45.185] [info]  ============================ Starting Final Cleanup ==============================
[23:13:45.288] [verdict]  FAIL
[23:13:45.288] [info]  The test case has ended.
[23:13:45.289] [stopped_testcase]  
```

OCTT Test-Case passes after this change & unit tests pass as well, not sure how else to make github actions happy... we don't have rtti enabled to use dynamic_cast 🙁 