### PR TITLE
Add std includes to C-API headers.

### DIFF
--- a/src/MicroOcpp/Core/Configuration_c.h
+++ b/src/MicroOcpp/Core/Configuration_c.h
@@ -5,6 +5,7 @@
 #ifndef MO_CONFIGURATION_C_H
 #define MO_CONFIGURATION_C_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/MicroOcpp_c.h
+++ b/src/MicroOcpp_c.h
@@ -5,6 +5,7 @@
 #ifndef MO_MICROOCPP_C_H
 #define MO_MICROOCPP_C_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include <MicroOcpp/Core/ConfigurationOptions.h>


### PR DESCRIPTION
Ensure types declared in C-API header have the matching std includes for those types.

This removes the burden from the calling application to apply these includes before any MicroOcpp includes.