### PR TITLE
fix(c-api): add missing standard library header includes

### DIFF
--- a/src/MicroOcpp/Core/ConfigurationOptions.h
+++ b/src/MicroOcpp/Core/ConfigurationOptions.h
@@ -5,6 +5,8 @@
 #ifndef MO_CONFIGURATIONOPTIONS_H
 #define MO_CONFIGURATIONOPTIONS_H
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/src/MicroOcpp/Core/Configuration_c.h
+++ b/src/MicroOcpp/Core/Configuration_c.h
@@ -5,6 +5,7 @@
 #ifndef MO_CONFIGURATION_C_H
 #define MO_CONFIGURATION_C_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/MicroOcpp/Model/Certificates/Certificate.h
+++ b/src/MicroOcpp/Model/Certificates/Certificate.h
@@ -9,7 +9,9 @@
 
 #if MO_ENABLE_CERT_MGMT
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.h
+++ b/src/MicroOcpp/Model/Certificates/CertificateMbedTLS.h
@@ -9,6 +9,10 @@
  * Built-in implementation of the Certificate interface for MbedTLS
  */
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <MicroOcpp/Version.h>
 #include <MicroOcpp/Platform.h>
 

--- a/src/MicroOcpp/Model/Certificates/Certificate_c.h
+++ b/src/MicroOcpp/Model/Certificates/Certificate_c.h
@@ -9,7 +9,9 @@
 
 #if MO_ENABLE_CERT_MGMT
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <MicroOcpp/Model/Certificates/Certificate.h>
 

--- a/src/MicroOcpp/Model/Transactions/Transaction.h
+++ b/src/MicroOcpp/Model/Transactions/Transaction.h
@@ -5,6 +5,10 @@
 #ifndef TRANSACTION_H
 #define TRANSACTION_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <MicroOcpp/Version.h>
 
 /* General Tx defs */

--- a/src/MicroOcpp_c.h
+++ b/src/MicroOcpp_c.h
@@ -5,7 +5,9 @@
 #ifndef MO_MICROOCPP_C_H
 #define MO_MICROOCPP_C_H
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <MicroOcpp/Core/ConfigurationOptions.h>
 #include <MicroOcpp/Model/ConnectorBase/ChargePointStatus.h>


### PR DESCRIPTION
Fixes #448

### Summary
Adds `<stdbool.h>`, `<stdint.h>`, and `<stddef.h>` includes to C-API headers to ensure standard type definitions (bool, uint, size_t) are self-contained and eliminate include order dependencies.